### PR TITLE
docs: add testing resources to llms indexes

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -21,6 +21,7 @@ The Agents SDK delivers a focused set of Python primitives—agents, tools, guar
 - [Streaming](https://openai.github.io/openai-agents-python/streaming/): Shows how to subscribe to incremental events, stream tool progress, and render partial model outputs in real time.
 - [REPL](https://openai.github.io/openai-agents-python/repl/): Interactive runner for exploring agent behavior, step-by-step execution, and debugging tool calls.
 - [Visualization](https://openai.github.io/openai-agents-python/visualization/): Demonstrates embeddable visualizations for session timelines, message flows, and tool interactions.
+- [Testing](https://openai.github.io/openai-agents-python/testing/): Build deterministic, provider-neutral tests for Agent, Sandbox, Realtime, and Voice workflows.
 
 ## Coordination, Safety, and Tooling
 - [Handoffs](https://openai.github.io/openai-agents-python/handoffs/): Implements delegation between agents, argument passing, completion handling, and error recovery across agent boundaries.
@@ -47,6 +48,7 @@ The Agents SDK delivers a focused set of Python primitives—agents, tools, guar
 - [memory interfaces](https://openai.github.io/openai-agents-python/ref/memory/): Session memory primitives, storage adapters, and utilities for retrieving historical context.
 - [repl utilities](https://openai.github.io/openai-agents-python/ref/repl/): Programmatic access to the interactive REPL loop and inspection helpers.
 - [tool base classes](https://openai.github.io/openai-agents-python/ref/tool/): Tool registration, invocation, and structured argument parsing.
+- [testing utilities](https://openai.github.io/openai-agents-python/ref/testing/): Deterministic utilities for Agent model calls and Sandbox workflows.
 - [tool context helpers](https://openai.github.io/openai-agents-python/ref/tool_context/): Manage shared resources, dependency injection, and cleanup for tool execution.
 - [result objects](https://openai.github.io/openai-agents-python/ref/result/): Fields exposed on run results, including final content, tool call summaries, and attachments.
 - [stream events](https://openai.github.io/openai-agents-python/ref/stream_events/): Event models emitted during streaming runs and their payload schemas.
@@ -85,6 +87,7 @@ The Agents SDK delivers a focused set of Python primitives—agents, tools, guar
 - [Realtime events](https://openai.github.io/openai-agents-python/ref/realtime/events/): Event payload types delivered over realtime channels.
 - [Realtime config](https://openai.github.io/openai-agents-python/ref/realtime/config/): Configuration models for realtime transports and behaviors.
 - [Realtime model interface](https://openai.github.io/openai-agents-python/ref/realtime/model/): Interfaces for plugging in realtime-capable models.
+- [Realtime testing](https://openai.github.io/openai-agents-python/ref/realtime/testing/): Scripted model utilities for Realtime session and tool workflow tests.
 
 ## API Reference – Voice
 - [Voice pipeline API](https://openai.github.io/openai-agents-python/ref/voice/pipeline/): Programmatic control over the voice pipeline and event flow.
@@ -96,6 +99,7 @@ The Agents SDK delivers a focused set of Python primitives—agents, tools, guar
 - [Voice exceptions](https://openai.github.io/openai-agents-python/ref/voice/exceptions/): Exception types for voice pipelines and error handling guidance.
 - [Voice model adapters](https://openai.github.io/openai-agents-python/ref/voice/model/): Interfaces for voice-enabled models and synthesis engines.
 - [Voice utility helpers](https://openai.github.io/openai-agents-python/ref/voice/utils/): Audio conversion, streaming helpers, and testing utilities.
+- [Voice testing](https://openai.github.io/openai-agents-python/ref/voice/testing/): Scripted STT, TTS, transcription, and workflow test utilities.
 - [OpenAI voice provider](https://openai.github.io/openai-agents-python/ref/voice/models/openai_provider/): Adapter for OpenAI voice models.
 - [OpenAI speech-to-text provider](https://openai.github.io/openai-agents-python/ref/voice/models/openai_stt/): Integration for STT models used in the pipeline.
 - [OpenAI text-to-speech provider](https://openai.github.io/openai-agents-python/ref/voice/models/openai_tts/): Adapter for OpenAI TTS output.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -17,6 +17,7 @@ The SDK focuses on a concise set of primitives so you can orchestrate multi-agen
 - [Streaming](https://openai.github.io/openai-agents-python/streaming/): Stream intermediate tool usage and LLM responses for responsive UIs.
 - [REPL](https://openai.github.io/openai-agents-python/repl/): Use the interactive runner to prototype agents and inspect execution step by step.
 - [Context strategies](https://openai.github.io/openai-agents-python/context/): Control what past messages, attachments, and tool runs are injected into prompts.
+- [Testing](https://openai.github.io/openai-agents-python/testing/): Test Agent, Sandbox, Realtime, and Voice workflows deterministically without provider requests.
 
 ## Coordination and Safety
 - [Handoffs](https://openai.github.io/openai-agents-python/handoffs/): Delegate tasks between agents with intent classification, argument passing, and return values.
@@ -46,6 +47,7 @@ The SDK focuses on a concise set of primitives so you can orchestrate multi-agen
 - [Runs and sessions](https://openai.github.io/openai-agents-python/ref/run/): API for launching runs, streaming updates, and handling cancellations.
 - [Results objects](https://openai.github.io/openai-agents-python/ref/result/): Data structures returned from agent runs, including final output and tool calls.
 - [Tool interfaces](https://openai.github.io/openai-agents-python/ref/tool/): Create tools, parse arguments, and manage tool execution contexts.
+- [Testing APIs](https://openai.github.io/openai-agents-python/ref/testing/): Reference provider-neutral testing utilities for Agent model calls and Sandbox workflows.
 - [Tracing APIs](https://openai.github.io/openai-agents-python/ref/tracing/index/): Programmatic interfaces for creating traces, spans, and integrating custom processors.
 - [Realtime APIs](https://openai.github.io/openai-agents-python/ref/realtime/agent/): Classes for realtime agents, runners, sessions, and event payloads.
 - [Voice APIs](https://openai.github.io/openai-agents-python/ref/voice/pipeline/): Configure voice pipelines, inputs, events, and model adapters.


### PR DESCRIPTION
### Summary

- add the Testing guide to both LLM documentation indexes
- add Agent, Realtime, and Voice testing API references to the full index
- make provider-neutral testing utilities easier for LLM-based tools to discover

### Test plan

- `uv run docs/scripts/generate_ref_files.py`
- `uv run mkdocs build` (the two commands in `make build-docs`; run individually because `make.exe` is unavailable on this Windows host)
- verified that all newly indexed documentation URLs return HTTP 200
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` — no findings

### Issue number

N/A — documentation discoverability update

### Checks

- [x] I've added new tests, if relevant — not applicable; this is a docs-only change with no runtime behavior.
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` — not applicable; the repository's docs-only exception applies, so the runtime format/lint/typecheck/test stack was not run.
- [x] I've confirmed all applicable verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR