### PR TITLE
fix(visualization): preserve nodes with duplicate names

### DIFF
--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -1,9 +1,121 @@
 from __future__ import annotations
 
+from collections import Counter
+
 import graphviz  # type: ignore
 
 from agents import Agent
 from agents.handoffs import Handoff
+
+_NodeKey = tuple[str, int]
+
+
+class _GraphNodeIds:
+    """Assign stable DOT identifiers without conflating nodes that share a label."""
+
+    def __init__(
+        self,
+        agent: Agent,
+        *,
+        initially_visited_names: frozenset[str] = frozenset(),
+    ) -> None:
+        nodes: list[tuple[_NodeKey, str]] = []
+        previsited_agents: list[tuple[_NodeKey, str]] = []
+        node_keys: set[_NodeKey] = set()
+        visited_agents: set[int] = set()
+
+        def add_node(key: _NodeKey, label: str) -> None:
+            if key not in node_keys:
+                node_keys.add(key)
+                nodes.append((key, label))
+
+        def visit(current_agent: Agent) -> None:
+            agent_key = self.agent_key(current_agent)
+            if id(current_agent) in visited_agents:
+                return
+            visited_agents.add(id(current_agent))
+            if current_agent.name in initially_visited_names:
+                previsited_agents.append((agent_key, current_agent.name))
+                return
+            add_node(agent_key, current_agent.name)
+
+            for tool in current_agent.tools:
+                add_node(self.tool_key(tool), tool.name)
+            for server in current_agent.mcp_servers:
+                add_node(self.mcp_server_key(server), server.name)
+            for handoff in current_agent.handoffs:
+                if isinstance(handoff, Agent):
+                    visit(handoff)
+                    continue
+                if isinstance(handoff, Handoff):
+                    target = _handoff_target_agent(handoff)
+                    if target is not None:
+                        visit(target)
+                    else:
+                        add_node(self.handoff_key(handoff), handoff.agent_name)
+
+        visit(agent)
+
+        escaped_labels = [(key, label, _escape_label(label)) for key, label in nodes]
+        escaped_previsited_agents = [
+            (key, label, _escape_label(label)) for key, label in previsited_agents
+        ]
+        label_counts = Counter(escaped_label for _, _, escaped_label in escaped_labels)
+        raw_labels = {
+            escaped_label for _, _, escaped_label in [*escaped_previsited_agents, *escaped_labels]
+        }
+        used_ids = {"__start__", "__end__"}
+        self._ids: dict[_NodeKey, str] = {}
+        generated_id = 0
+
+        def generate_id(key: _NodeKey) -> str:
+            nonlocal generated_id
+            while True:
+                node_id = f"__agents_graph_{key[0]}_{generated_id}__"
+                generated_id += 1
+                if node_id not in raw_labels and node_id not in used_ids:
+                    return node_id
+
+        for key, label, escaped_label in escaped_previsited_agents:
+            node_id = label if escaped_label not in used_ids else generate_id(key)
+            used_ids.add(_escape_label(node_id))
+            self._ids[key] = node_id
+
+        for key, label, escaped_label in escaped_labels:
+            if label_counts[escaped_label] == 1 and escaped_label not in used_ids:
+                node_id = label
+            else:
+                node_id = generate_id(key)
+            used_ids.add(_escape_label(node_id))
+            self._ids[key] = node_id
+
+    @staticmethod
+    def agent_key(agent: Agent) -> _NodeKey:
+        return ("agent", id(agent))
+
+    @staticmethod
+    def tool_key(tool: object) -> _NodeKey:
+        return ("tool", id(tool))
+
+    @staticmethod
+    def mcp_server_key(server: object) -> _NodeKey:
+        return ("mcp", id(server))
+
+    @staticmethod
+    def handoff_key(handoff: object) -> _NodeKey:
+        return ("handoff", id(handoff))
+
+    def agent(self, agent: Agent) -> str:
+        return self._ids[self.agent_key(agent)]
+
+    def tool(self, tool: object) -> str:
+        return self._ids[self.tool_key(tool)]
+
+    def mcp_server(self, server: object) -> str:
+        return self._ids[self.mcp_server_key(server)]
+
+    def handoff(self, handoff: object) -> str:
+        return self._ids[self.handoff_key(handoff)]
 
 
 def _escape_label(name: str) -> str:
@@ -49,8 +161,9 @@ def get_main_graph(agent: Agent) -> str:
         edge [penwidth=1.5];
     """
     ]
-    parts.append(get_all_nodes(agent))
-    parts.append(get_all_edges(agent))
+    node_ids = _GraphNodeIds(agent)
+    parts.append(_get_all_nodes(agent, node_ids=node_ids))
+    parts.append(_get_all_edges(agent, node_ids=node_ids))
     parts.append("}")
     return "".join(parts)
 
@@ -67,11 +180,34 @@ def get_all_nodes(
     Returns:
         str: The DOT format string representing the nodes.
     """
-    if visited is None:
-        visited = set()
-    if agent.name in visited:
+    visited_names = visited if visited is not None else set()
+    initially_visited_names = frozenset(visited_names)
+    return _get_all_nodes(
+        agent,
+        parent=parent,
+        visited_names=visited_names,
+        initially_visited_names=initially_visited_names,
+        node_ids=_GraphNodeIds(agent, initially_visited_names=initially_visited_names),
+    )
+
+
+def _get_all_nodes(
+    agent: Agent,
+    *,
+    node_ids: _GraphNodeIds,
+    parent: Agent | None = None,
+    visited_names: set[str] | None = None,
+    initially_visited_names: frozenset[str] = frozenset(),
+    visited_agents: set[int] | None = None,
+) -> str:
+    if visited_names is None:
+        visited_names = set()
+    if visited_agents is None:
+        visited_agents = set()
+    if id(agent) in visited_agents or agent.name in initially_visited_names:
         return ""
-    visited.add(agent.name)
+    visited_agents.add(id(agent))
+    visited_names.add(agent.name)
 
     parts = []
 
@@ -84,56 +220,80 @@ def get_all_nodes(
             "fillcolor=lightblue, width=0.5, height=0.3];"
         )
         # Ensure parent agent node is colored
+        node_id = _escape_label(node_ids.agent(agent))
         name = _escape_label(agent.name)
         parts.append(
-            f'"{name}" [label="{name}", '
+            f'"{node_id}" [label="{name}", '
             "shape=box, style=filled, "
             "fillcolor=lightyellow, width=1.5, height=0.8];"
         )
 
     for tool in agent.tools:
+        node_id = _escape_label(node_ids.tool(tool))
         name = _escape_label(tool.name)
         parts.append(
-            f'"{name}" [label="{name}", '
+            f'"{node_id}" [label="{name}", '
             "shape=ellipse, style=filled, "
             "fillcolor=lightgreen, width=0.5, height=0.3];"
         )
 
     for mcp_server in agent.mcp_servers:
+        node_id = _escape_label(node_ids.mcp_server(mcp_server))
         name = _escape_label(mcp_server.name)
         parts.append(
-            f'"{name}" [label="{name}", '
+            f'"{node_id}" [label="{name}", '
             "shape=box, style=filled, "
             "fillcolor=lightgrey, width=1, height=0.5];"
         )
 
     for handoff in agent.handoffs:
         if isinstance(handoff, Agent):
-            if handoff.name not in visited:
+            if id(handoff) not in visited_agents and handoff.name not in initially_visited_names:
+                node_id = _escape_label(node_ids.agent(handoff))
                 name = _escape_label(handoff.name)
                 parts.append(
-                    f'"{name}" [label="{name}", '
+                    f'"{node_id}" [label="{name}", '
                     f'shape=box, style="filled,rounded", '
                     f"fillcolor=lightyellow, width=1.5, height=0.8];"
                 )
-            parts.append(get_all_nodes(handoff, agent, visited))
+            parts.append(
+                _get_all_nodes(
+                    handoff,
+                    parent=agent,
+                    visited_names=visited_names,
+                    initially_visited_names=initially_visited_names,
+                    visited_agents=visited_agents,
+                    node_ids=node_ids,
+                )
+            )
             continue
 
         if isinstance(handoff, Handoff):
             target = _handoff_target_agent(handoff)
             if target is not None:
-                if target.name not in visited:
+                if id(target) not in visited_agents and target.name not in initially_visited_names:
+                    node_id = _escape_label(node_ids.agent(target))
                     name = _escape_label(target.name)
                     parts.append(
-                        f'"{name}" [label="{name}", '
+                        f'"{node_id}" [label="{name}", '
                         f'shape=box, style="filled,rounded", '
                         f"fillcolor=lightyellow, width=1.5, height=0.8];"
                     )
-                parts.append(get_all_nodes(target, agent, visited))
+                parts.append(
+                    _get_all_nodes(
+                        target,
+                        parent=agent,
+                        visited_names=visited_names,
+                        initially_visited_names=initially_visited_names,
+                        visited_agents=visited_agents,
+                        node_ids=node_ids,
+                    )
+                )
             else:
+                node_id = _escape_label(node_ids.handoff(handoff))
                 name = _escape_label(handoff.agent_name)
                 parts.append(
-                    f'"{name}" [label="{name}", '
+                    f'"{node_id}" [label="{name}", '
                     f'shape=box, style="filled,rounded", '
                     f"fillcolor=lightyellow, width=1.5, height=0.8];"
                 )
@@ -154,50 +314,91 @@ def get_all_edges(
     Returns:
         str: The DOT format string representing the edges.
     """
-    if visited is None:
-        visited = set()
-    if agent.name in visited:
+    visited_names = visited if visited is not None else set()
+    initially_visited_names = frozenset(visited_names)
+    return _get_all_edges(
+        agent,
+        parent=parent,
+        visited_names=visited_names,
+        initially_visited_names=initially_visited_names,
+        node_ids=_GraphNodeIds(agent, initially_visited_names=initially_visited_names),
+    )
+
+
+def _get_all_edges(
+    agent: Agent,
+    *,
+    node_ids: _GraphNodeIds,
+    parent: Agent | None = None,
+    visited_names: set[str] | None = None,
+    initially_visited_names: frozenset[str] = frozenset(),
+    visited_agents: set[int] | None = None,
+) -> str:
+    if visited_names is None:
+        visited_names = set()
+    if visited_agents is None:
+        visited_agents = set()
+    if id(agent) in visited_agents or agent.name in initially_visited_names:
         return ""
-    visited.add(agent.name)
+    visited_agents.add(id(agent))
+    visited_names.add(agent.name)
 
     parts = []
 
-    agent_name = _escape_label(agent.name)
+    agent_id = _escape_label(node_ids.agent(agent))
 
     if parent is None:
-        parts.append(f'"__start__" -> "{agent_name}";')
+        parts.append(f'"__start__" -> "{agent_id}";')
 
     for tool in agent.tools:
-        tool_name = _escape_label(tool.name)
+        tool_id = _escape_label(node_ids.tool(tool))
         parts.append(f"""
-        "{agent_name}" -> "{tool_name}" [style=dotted, penwidth=1.5];
-        "{tool_name}" -> "{agent_name}" [style=dotted, penwidth=1.5];""")
+        "{agent_id}" -> "{tool_id}" [style=dotted, penwidth=1.5];
+        "{tool_id}" -> "{agent_id}" [style=dotted, penwidth=1.5];""")
 
     for mcp_server in agent.mcp_servers:
-        server_name = _escape_label(mcp_server.name)
+        server_id = _escape_label(node_ids.mcp_server(mcp_server))
         parts.append(f"""
-        "{agent_name}" -> "{server_name}" [style=dashed, penwidth=1.5];
-        "{server_name}" -> "{agent_name}" [style=dashed, penwidth=1.5];""")
+        "{agent_id}" -> "{server_id}" [style=dashed, penwidth=1.5];
+        "{server_id}" -> "{agent_id}" [style=dashed, penwidth=1.5];""")
 
     for handoff in agent.handoffs:
         if isinstance(handoff, Agent):
             parts.append(f"""
-            "{agent_name}" -> "{_escape_label(handoff.name)}";""")
-            parts.append(get_all_edges(handoff, agent, visited))
+            "{agent_id}" -> "{_escape_label(node_ids.agent(handoff))}";""")
+            parts.append(
+                _get_all_edges(
+                    handoff,
+                    parent=agent,
+                    visited_names=visited_names,
+                    initially_visited_names=initially_visited_names,
+                    visited_agents=visited_agents,
+                    node_ids=node_ids,
+                )
+            )
             continue
 
         if isinstance(handoff, Handoff):
             target = _handoff_target_agent(handoff)
             if target is not None:
                 parts.append(f"""
-            "{agent_name}" -> "{_escape_label(target.name)}";""")
-                parts.append(get_all_edges(target, agent, visited))
+            "{agent_id}" -> "{_escape_label(node_ids.agent(target))}";""")
+                parts.append(
+                    _get_all_edges(
+                        target,
+                        parent=agent,
+                        visited_names=visited_names,
+                        initially_visited_names=initially_visited_names,
+                        visited_agents=visited_agents,
+                        node_ids=node_ids,
+                    )
+                )
             else:
                 parts.append(f"""
-            "{agent_name}" -> "{_escape_label(handoff.agent_name)}";""")
+            "{agent_id}" -> "{_escape_label(node_ids.handoff(handoff))}";""")
 
     if not agent.handoffs:
-        parts.append(f'"{agent_name}" -> "__end__";')
+        parts.append(f'"{agent_id}" -> "__end__";')
 
     return "".join(parts)
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock
+import re
+from unittest.mock import Mock, PropertyMock
 
 import graphviz  # type: ignore
 import pytest
@@ -184,6 +185,155 @@ def test_cycle_detection():
     assert nodes.count('"B" [label="B"') == 1
     assert '"A" -> "B"' in edges
     assert '"B" -> "A"' in edges
+
+
+def test_graph_keeps_different_node_types_with_the_same_name_distinct():
+    shared_tool = Mock()
+    shared_tool.name = "shared"
+    shared_handoff = Mock(spec=Handoff)
+    shared_handoff.agent_name = "shared"
+    agent = Mock(spec=Agent)
+    agent.name = "shared"
+    agent.tools = [shared_tool]
+    agent.mcp_servers = [FakeMCPServer(server_name="shared")]
+    agent.handoffs = [shared_handoff]
+
+    source = get_main_graph(agent)
+
+    node_ids = re.findall(r'"([^"]+)" \[label="shared"', source)
+    assert len(node_ids) == 4
+    assert len(set(node_ids)) == 4
+    agent_id, tool_id, server_id, handoff_id = node_ids
+    assert f'"{agent_id}" -> "{tool_id}" [style=dotted' in source
+    assert f'"{agent_id}" -> "{server_id}" [style=dashed' in source
+    assert f'"{agent_id}" -> "{handoff_id}";' in source
+    assert all(f'"{node_id}" -> "{node_id}"' not in source for node_id in node_ids)
+
+
+def test_graph_keeps_names_that_escape_to_the_same_id_distinct():
+    shared_tool = Mock()
+    shared_tool.name = "shared\r"
+    shared_handoff = Mock(spec=Handoff)
+    shared_handoff.agent_name = "shared\r\n"
+    shared_handoff._agent_ref = None
+    agent = Mock(spec=Agent)
+    agent.name = "shared\n"
+    agent.tools = [shared_tool]
+    agent.mcp_servers = []
+    agent.handoffs = [shared_handoff]
+
+    source = get_main_graph(agent)
+
+    node_ids = re.findall(r'"([^"]+)" \[label="shared\\n"', source)
+    assert len(node_ids) == 3
+    assert len(set(node_ids)) == 3
+    agent_id, tool_id, handoff_id = node_ids
+    assert f'"{agent_id}" -> "{tool_id}" [style=dotted' in source
+    assert f'"{agent_id}" -> "{handoff_id}";' in source
+    assert all(f'"{node_id}" -> "{node_id}"' not in source for node_id in node_ids)
+
+
+@pytest.mark.parametrize("use_handoff_object", [False, True])
+def test_graph_traverses_different_agents_with_the_same_name(
+    use_handoff_object: bool,
+):
+    child_tool = Mock()
+    child_tool.name = "child_tool"
+    child = Agent(name="duplicate", tools=[child_tool])
+    child_handoff = handoff(child) if use_handoff_object else child
+    parent = Agent(name="duplicate", handoffs=[child_handoff])
+
+    source = get_main_graph(parent)
+
+    agent_ids = re.findall(r'"([^"]+)" \[label="duplicate"', source)
+    assert len(agent_ids) == 2
+    assert len(set(agent_ids)) == 2
+    parent_id, child_id = agent_ids
+    assert f'"{parent_id}" -> "{child_id}";' in source
+    assert f'"{child_id}" -> "child_tool" [style=dotted' in source
+
+
+@pytest.mark.parametrize("use_handoff_object", [False, True])
+def test_get_all_nodes_honors_prepopulated_visited_names(
+    use_handoff_object: bool,
+):
+    child = Agent(name="child")
+    child_handoff = handoff(child) if use_handoff_object else child
+    parent = Agent(name="parent", handoffs=[child_handoff])
+    visited = {"child"}
+
+    nodes = get_all_nodes(parent, visited=visited)
+
+    assert '"child" [label="child"' not in nodes
+    assert visited == {"parent", "child"}
+
+
+@pytest.mark.parametrize("renderer", [get_all_nodes, get_all_edges])
+def test_graph_does_not_inspect_previsited_root(renderer):
+    agent = Mock(spec=Agent)
+    agent.name = "visited"
+    type(agent).tools = PropertyMock(
+        side_effect=AssertionError("previsited agent should not be inspected")
+    )
+
+    assert renderer(agent, visited={"visited"}) == ""
+
+
+@pytest.mark.parametrize("renderer", [get_all_nodes, get_all_edges])
+def test_previsited_subgraph_does_not_affect_included_node_ids(renderer):
+    included_tool = Mock()
+    included_tool.name = "shared"
+    skipped_tool = Mock()
+    skipped_tool.name = "shared"
+    child = Agent(name="child", tools=[skipped_tool])
+    parent = Agent(name="parent", tools=[included_tool], handoffs=[child])
+
+    source = renderer(parent, visited={"child"})
+
+    assert '"shared"' in source
+    assert "__agents_graph_tool_" not in source
+
+
+@pytest.mark.parametrize("use_handoff_object", [False, True])
+def test_previsited_agent_reserves_its_id(use_handoff_object: bool):
+    tool = Mock()
+    tool.name = "shared"
+    child = Agent(name="shared")
+    child_handoff = handoff(child) if use_handoff_object else child
+    parent = Agent(name="parent", tools=[tool], handoffs=[child_handoff])
+
+    nodes = get_all_nodes(parent, visited={"shared"})
+    edges = get_all_edges(parent, visited={"shared"})
+
+    tool_ids = re.findall(r'"([^"]+)" \[label="shared"', nodes)
+    assert len(tool_ids) == 1
+    assert tool_ids[0].startswith("__agents_graph_tool_")
+    assert f'"parent" -> "{tool_ids[0]}" [style=dotted' in edges
+    assert '"parent" -> "shared";' in edges
+
+
+def test_collision_free_escaped_ids_keep_legacy_names():
+    tool = Mock()
+    tool.name = "shared\n"
+    agent = Agent(name=r"shared\n", tools=[tool])
+
+    source = get_main_graph(agent)
+
+    assert '"shared\\\\n" [label="shared\\\\n"' in source
+    assert '"shared\\n" [label="shared\\n"' in source
+    assert "__agents_graph_" not in source
+
+
+def test_graph_reserves_start_and_end_node_ids():
+    agent = Agent(name="__start__")
+
+    source = get_main_graph(agent)
+
+    start_ids = re.findall(r'"([^"]+)" \[label="__start__"', source)
+    assert len(start_ids) == 2
+    assert len(set(start_ids)) == 2
+    assert start_ids[0] == "__start__"
+    assert f'"__start__" -> "{start_ids[1]}";' in source
 
 
 def test_names_with_quotes_and_backslashes_are_escaped(mock_agent):


### PR DESCRIPTION
### Summary

This pull request fixes graph visualization when distinct agents, tools, MCP servers, or handoffs share the same display name.

Graphviz node identifiers were previously derived directly from display names, so colliding names were merged into one node, could create self-loops, and caused same-name agents to be skipped during traversal. A per-render identity registry now assigns identifiers by entity identity, generates deterministic identifiers only for collisions and reserved virtual-node names, and preserves the existing DOT output for collision-free graphs.

The implementation also preserves traversal through live `handoff()` targets, honors caller-supplied `visited` names, and detects collisions after DOT escaping so CR, LF, and CRLF variants cannot collapse into one identifier.

Regression coverage includes cross-type name collisions, separate agents with the same name through both direct and `handoff()` branches, escaped-identifier collisions, caller-supplied visited names, and an agent whose name matches the virtual start node.

### Test plan

- `pytest -q tests/test_visualization.py` (19 passed)
- `.agents/skills/code-change-verification/scripts/run.sh` (format, lint, type checking, and full tests passed)

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
