### PR TITLE
fix(chatcmpl): raise ModelBehaviorError on truncated empty completions

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -445,11 +445,11 @@ class ChatCmplStreamHandler:
 
                 if has_passthrough_output:
                     passthrough_choices.append(choice)
-                elif choice.finish_reason == "content_filter":
-                    # A content-filtered choice ends the stream with an empty delta, so it
-                    # would otherwise be dropped here and the handler would never see the
-                    # finish_reason it needs to synthesize the refusal. Forward a
-                    # delta-stripped copy so buffering semantics are unchanged.
+                elif choice.finish_reason in {"content_filter", "length"}:
+                    # A content-filtered or truncated choice ends the stream with an empty
+                    # delta, so it would otherwise be dropped here and the handler would
+                    # never see the finish_reason it needs to synthesize the refusal.
+                    # Forward a delta-stripped copy so buffering semantics are unchanged.
                     passthrough_choices.append(choice.model_copy(update={"delta": ChoiceDelta()}))
 
             if passthrough_choices or chunk.usage is not None:
@@ -630,7 +630,10 @@ class ChatCmplStreamHandler:
         # safety block only through finish_reason == "content_filter" with an
         # empty delta and no refusal field. Track it so we can synthesize an
         # explicit refusal after the stream if nothing else was emitted.
+        # A completion truncated before any visible token (finish_reason ==
+        # "length") has the same shape and must not collapse into an empty turn.
         saw_content_filter = False
+        saw_length = False
         async for chunk in stream:
             if not state.started:
                 state.started = True
@@ -675,6 +678,8 @@ class ChatCmplStreamHandler:
 
             if choice.finish_reason == "content_filter":
                 saw_content_filter = True
+            elif choice.finish_reason == "length":
+                saw_length = True
 
             if not choice.delta:
                 continue
@@ -1117,17 +1122,18 @@ class ChatCmplStreamHandler:
                             sequence_number=sequence_number.get_and_increment(),
                         )
 
-        # Content-filter refusal with no emitted output: synthesize a refusal so
-        # the completed response carries a ResponseOutputRefusal rather than an
-        # empty turn. Only when nothing else was produced (text / refusal / tool
-        # calls) — a content_filter that still emitted content is left as-is.
+        # Content-filter refusal / zero-token truncation with no emitted output:
+        # synthesize a refusal so the completed response carries a
+        # ResponseOutputRefusal rather than an empty turn. Only when nothing else
+        # was produced (text / refusal / tool calls) — a content_filter or length
+        # that still emitted content is left as-is.
         if (
-            saw_content_filter
+            (saw_content_filter or saw_length)
             and state.text_content_index_and_output is None
             and state.refusal_content_index_and_output is None
             and not state.function_calls
         ):
-            # A content-filtered turn (e.g. Bedrock) can terminate with no
+            # A content-filtered or truncated turn (e.g. Bedrock) can terminate with no
             # emitted output. Its leading empty "" content delta is suppressed
             # above so no text part opens, so we announce a fresh assistant
             # message and place the refusal at content index 0. A reasoning item
@@ -1137,7 +1143,11 @@ class ChatCmplStreamHandler:
             # the sole content part, is at content_index 0 in both the stream and
             # response.completed regardless of any reasoning item.
             refusal_index = 0
-            refusal_message = "Response withheld by the provider's content filter."
+            refusal_message = (
+                "Response withheld by the provider's content filter."
+                if saw_content_filter
+                else "Response truncated because the provider's maximum token limit was reached."
+            )
             state.refusal_content_index_and_output = (
                 refusal_index,
                 ResponseOutputRefusal(refusal=refusal_message, type="refusal"),

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -609,6 +609,7 @@ class ChatCmplStreamHandler:
         model: str | None = None,
         strict_feature_validation: bool = False,
         preserve_raw_usage: bool = False,
+        raise_on_length_truncation: bool = False,
     ) -> AsyncIterator[TResponseStreamEvent]:
         """
         Handle a streaming chat completion response and yield response events.
@@ -620,6 +621,11 @@ class ChatCmplStreamHandler:
                 provider-specific stream processing.
             preserve_raw_usage: Whether to retain the last provider usage payload before
                 converting it to the Responses usage shape.
+            raise_on_length_truncation: Whether to raise ModelBehaviorError when the
+                stream terminates with finish_reason == "length" and no visible output.
+                This is an internal option enabled only by OpenAIChatCompletionsModel:
+                the shared handler also serves LiteLLM and AnyLLM, whose streaming
+                behavior must remain unchanged.
         """
         usage: CompletionUsage | None = None
         raw_usage: dict[str, Any] | None = None
@@ -1128,21 +1134,11 @@ class ChatCmplStreamHandler:
         # empty turn. Only when nothing else was produced (text / refusal / tool
         # calls) — a content_filter that still emitted content is left as-is.
         if (
-            (saw_content_filter or saw_length)
+            saw_content_filter
             and state.text_content_index_and_output is None
             and state.refusal_content_index_and_output is None
             and not state.function_calls
         ):
-            if saw_length:
-                # A completion truncated before any visible token (finish_reason ==
-                # "length") is a token- or reasoning-budget exhaustion, not a policy
-                # refusal. Surface it as a model behavior error rather than
-                # manufacturing a refusal that would route through model_refusal
-                # handlers.
-                raise ModelBehaviorError(
-                    "Chat Completions stream terminated with finish_reason='length' "
-                    "but produced no assistant text, tool call, or refusal."
-                )
             # A content-filtered turn (e.g. Bedrock) can terminate with no
             # emitted output. Its leading empty "" content delta is suppressed
             # above so no text part opens, so we announce a fresh assistant
@@ -1188,6 +1184,34 @@ class ChatCmplStreamHandler:
                 output_index=output_layout.assistant_message_output_index(state),
                 type="response.refusal.delta",
                 sequence_number=sequence_number.get_and_increment(),
+            )
+
+        # A completion truncated before any visible token (finish_reason ==
+        # "length") is a token- or reasoning-budget exhaustion, not a policy
+        # refusal. Surface it as a model behavior error rather than manufacturing
+        # a refusal that would route through model_refusal handlers. This is an
+        # internal behavior enabled only by OpenAIChatCompletionsModel: the
+        # shared handler also serves LiteLLM and AnyLLM, whose streaming behavior
+        # must remain unchanged.
+        if (
+            saw_length
+            and raise_on_length_truncation
+            and state.text_content_index_and_output is None
+            and state.refusal_content_index_and_output is None
+            and not state.function_calls
+        ):
+            # Preserve the request and any reported token usage on the response
+            # so the caller can attach it to the generation span before the
+            # error propagates.
+            if usage is not None:
+                response.usage = cls._build_response_usage(usage)
+            else:
+                _mark_request_completed_without_usage(response)
+            if preserve_raw_usage and raw_usage is not None:
+                _attach_raw_usage_snapshot(response, raw_usage)
+            raise ModelBehaviorError(
+                "Chat Completions stream terminated with finish_reason='length' "
+                "but produced no assistant text, tool call, or refusal."
             )
 
         cls._finalize_thinking_blocks(state)
@@ -1310,27 +1334,7 @@ class ChatCmplStreamHandler:
         final_response = response.model_copy()
         final_response.output = outputs
 
-        final_response.usage = (
-            ResponseUsage(
-                input_tokens=usage.prompt_tokens or 0,
-                output_tokens=usage.completion_tokens or 0,
-                total_tokens=usage.total_tokens or 0,
-                output_tokens_details=OutputTokensDetails(
-                    reasoning_tokens=usage.completion_tokens_details.reasoning_tokens
-                    if usage.completion_tokens_details
-                    and usage.completion_tokens_details.reasoning_tokens
-                    else 0
-                ),
-                input_tokens_details=_make_input_tokens_details(
-                    cached_tokens=usage.prompt_tokens_details.cached_tokens
-                    if usage.prompt_tokens_details and usage.prompt_tokens_details.cached_tokens
-                    else 0,
-                    cache_write_tokens=_cache_write_tokens(usage.prompt_tokens_details),
-                ),
-            )
-            if usage
-            else None
-        )
+        final_response.usage = cls._build_response_usage(usage)
         if preserve_raw_usage:
             _attach_raw_usage_snapshot(final_response, raw_usage)
         if usage is None:
@@ -1343,4 +1347,27 @@ class ChatCmplStreamHandler:
             response=final_response,
             type="response.completed",
             sequence_number=sequence_number.get_and_increment(),
+        )
+
+    @staticmethod
+    def _build_response_usage(usage: CompletionUsage | None) -> ResponseUsage | None:
+        """Convert the streamed provider usage into a Responses usage payload."""
+        if usage is None:
+            return None
+        return ResponseUsage(
+            input_tokens=usage.prompt_tokens or 0,
+            output_tokens=usage.completion_tokens or 0,
+            total_tokens=usage.total_tokens or 0,
+            output_tokens_details=OutputTokensDetails(
+                reasoning_tokens=usage.completion_tokens_details.reasoning_tokens
+                if usage.completion_tokens_details
+                and usage.completion_tokens_details.reasoning_tokens
+                else 0
+            ),
+            input_tokens_details=_make_input_tokens_details(
+                cached_tokens=usage.prompt_tokens_details.cached_tokens
+                if usage.prompt_tokens_details and usage.prompt_tokens_details.cached_tokens
+                else 0,
+                cache_write_tokens=_cache_write_tokens(usage.prompt_tokens_details),
+            ),
         )

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -448,7 +448,7 @@ class ChatCmplStreamHandler:
                 elif choice.finish_reason in {"content_filter", "length"}:
                     # A content-filtered or truncated choice ends the stream with an empty
                     # delta, so it would otherwise be dropped here and the handler would
-                    # never see the finish_reason it needs to synthesize the refusal.
+                    # never see the finish_reason it needs to act on.
                     # Forward a delta-stripped copy so buffering semantics are unchanged.
                     passthrough_choices.append(choice.model_copy(update={"delta": ChoiceDelta()}))
 
@@ -631,7 +631,8 @@ class ChatCmplStreamHandler:
         # empty delta and no refusal field. Track it so we can synthesize an
         # explicit refusal after the stream if nothing else was emitted.
         # A completion truncated before any visible token (finish_reason ==
-        # "length") has the same shape and must not collapse into an empty turn.
+        # "length") has the same shape; track it too so we can surface a model
+        # behavior error instead of collapsing into an empty turn.
         saw_content_filter = False
         saw_length = False
         async for chunk in stream:
@@ -1122,18 +1123,27 @@ class ChatCmplStreamHandler:
                             sequence_number=sequence_number.get_and_increment(),
                         )
 
-        # Content-filter refusal / zero-token truncation with no emitted output:
-        # synthesize a refusal so the completed response carries a
-        # ResponseOutputRefusal rather than an empty turn. Only when nothing else
-        # was produced (text / refusal / tool calls) — a content_filter or length
-        # that still emitted content is left as-is.
+        # Content-filter refusal with no emitted output: synthesize a refusal so
+        # the completed response carries a ResponseOutputRefusal rather than an
+        # empty turn. Only when nothing else was produced (text / refusal / tool
+        # calls) — a content_filter that still emitted content is left as-is.
         if (
             (saw_content_filter or saw_length)
             and state.text_content_index_and_output is None
             and state.refusal_content_index_and_output is None
             and not state.function_calls
         ):
-            # A content-filtered or truncated turn (e.g. Bedrock) can terminate with no
+            if saw_length:
+                # A completion truncated before any visible token (finish_reason ==
+                # "length") is a token- or reasoning-budget exhaustion, not a policy
+                # refusal. Surface it as a model behavior error rather than
+                # manufacturing a refusal that would route through model_refusal
+                # handlers.
+                raise ModelBehaviorError(
+                    "Chat Completions stream terminated with finish_reason='length' "
+                    "but produced no assistant text, tool call, or refusal."
+                )
+            # A content-filtered turn (e.g. Bedrock) can terminate with no
             # emitted output. Its leading empty "" content delta is suppressed
             # above so no text part opens, so we announce a fresh assistant
             # message and place the refusal at content index 0. A reasoning item
@@ -1143,11 +1153,7 @@ class ChatCmplStreamHandler:
             # the sole content part, is at content_index 0 in both the stream and
             # response.completed regardless of any reasoning item.
             refusal_index = 0
-            refusal_message = (
-                "Response withheld by the provider's content filter."
-                if saw_content_filter
-                else "Response truncated because the provider's maximum token limit was reached."
-            )
+            refusal_message = "Response withheld by the provider's content filter."
             state.refusal_content_index_and_output = (
                 refusal_index,
                 ResponseOutputRefusal(refusal=refusal_message, type="refusal"),

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -300,6 +300,18 @@ class OpenAIChatCompletionsModel(Model):
                 else Usage(requests=1)
             )
 
+            # Record the request and token usage on the span before the terminal
+            # branches below, so a ModelBehaviorError raised for a truncated empty
+            # completion still leaves the request and usage accounted for.
+            span_generation.span_data.usage = {
+                "requests": usage.requests,
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "total_tokens": usage.total_tokens,
+                "input_tokens_details": usage.input_tokens_details.model_dump(),
+                "output_tokens_details": usage.output_tokens_details.model_dump(),
+            }
+
             # Some providers signal a filtered non-streaming completion only through
             # finish_reason="content_filter" and an otherwise empty message. Preserve
             # that terminal signal as a refusal instead of returning an empty output.
@@ -334,14 +346,6 @@ class OpenAIChatCompletionsModel(Model):
                 span_generation.span_data.output = (
                     [message.model_dump()] if message is not None else []
                 )
-            span_generation.span_data.usage = {
-                "requests": usage.requests,
-                "input_tokens": usage.input_tokens,
-                "output_tokens": usage.output_tokens,
-                "total_tokens": usage.total_tokens,
-                "input_tokens_details": usage.input_tokens_details.model_dump(),
-                "output_tokens_details": usage.output_tokens_details.model_dump(),
-            }
 
             # Build provider_data for provider_specific_fields
             provider_data = {"model": self.model}
@@ -487,6 +491,7 @@ class OpenAIChatCompletionsModel(Model):
                     cast(AsyncStream[ChatCompletionChunk], stream_for_handler),
                     model=self.model,
                     strict_feature_validation=self._strict_feature_validation,
+                    raise_on_length_truncation=True,
                     **raw_usage_options,
                 ):
                     if chunk.type == "response.completed":
@@ -500,6 +505,12 @@ class OpenAIChatCompletionsModel(Model):
                         )
 
                     yield chunk
+            except ModelBehaviorError:
+                # The handler preserves the request and any reported token usage on the
+                # base response before raising (e.g. a token-budget-exhausted empty
+                # completion). Attach it to the span before the error surfaces.
+                self._populate_stream_generation_span(span_generation, response, tracing)
+                raise
             except asyncio.CancelledError:
                 close_stream_in_background = True
                 self._schedule_async_iterator_close(stream)

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -303,15 +303,23 @@ class OpenAIChatCompletionsModel(Model):
             # Some providers signal a filtered non-streaming completion only through
             # finish_reason="content_filter" and an otherwise empty message. Preserve
             # that terminal signal as a refusal instead of returning an empty output.
+            # A completion truncated before any visible token (finish_reason="length")
+            # has the same shape and must not collapse into an indistinguishable
+            # empty turn either.
             if (
                 message is not None
                 and first_choice is not None
-                and first_choice.finish_reason == "content_filter"
+                and first_choice.finish_reason in {"content_filter", "length"}
                 and not message.content
                 and not message.refusal
                 and not message.tool_calls
             ):
-                message.refusal = "Response withheld by the provider's content filter."
+                if first_choice.finish_reason == "content_filter":
+                    message.refusal = "Response withheld by the provider's content filter."
+                else:
+                    message.refusal = (
+                        "Response truncated because the provider's maximum token limit was reached."
+                    )
 
             if tracing.include_data():
                 span_generation.span_data.output = (

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -303,23 +303,32 @@ class OpenAIChatCompletionsModel(Model):
             # Some providers signal a filtered non-streaming completion only through
             # finish_reason="content_filter" and an otherwise empty message. Preserve
             # that terminal signal as a refusal instead of returning an empty output.
-            # A completion truncated before any visible token (finish_reason="length")
-            # has the same shape and must not collapse into an indistinguishable
-            # empty turn either.
             if (
                 message is not None
                 and first_choice is not None
-                and first_choice.finish_reason in {"content_filter", "length"}
+                and first_choice.finish_reason == "content_filter"
                 and not message.content
                 and not message.refusal
                 and not message.tool_calls
             ):
-                if first_choice.finish_reason == "content_filter":
-                    message.refusal = "Response withheld by the provider's content filter."
-                else:
-                    message.refusal = (
-                        "Response truncated because the provider's maximum token limit was reached."
-                    )
+                message.refusal = "Response withheld by the provider's content filter."
+
+            # A completion truncated before any visible token (finish_reason="length")
+            # is a token- or reasoning-budget exhaustion, not a policy refusal.
+            # Surface it as a model behavior error rather than manufacturing a
+            # refusal that would route through model_refusal handlers.
+            if (
+                message is not None
+                and first_choice is not None
+                and first_choice.finish_reason == "length"
+                and not message.content
+                and not message.refusal
+                and not message.tool_calls
+            ):
+                raise ModelBehaviorError(
+                    "Chat Completions response terminated with finish_reason='length' "
+                    "but produced no assistant text, tool call, or refusal."
+                )
 
             if tracing.include_data():
                 span_generation.span_data.output = (

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -50,7 +50,7 @@ from agents import (
     generation_span,
     trace,
 )
-from agents.exceptions import UserError
+from agents.exceptions import ModelBehaviorError, UserError
 from agents.models._retry_runtime import provider_managed_retries_disabled
 from agents.models.chatcmpl_helpers import HEADERS_OVERRIDE, ChatCmplHelpers
 from agents.models.fake_id import FAKE_RESPONSES_ID
@@ -428,30 +428,8 @@ async def test_get_response_preserves_empty_nonfiltered_output(monkeypatch) -> N
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
-async def test_get_response_surfaces_truncated_empty_turn_as_refusal(monkeypatch) -> None:
-    resp = await _get_response_for_choice(
-        monkeypatch,
-        Choice(
-            index=0,
-            finish_reason="length",
-            message=ChatCompletionMessage(role="assistant", content=None),
-        ),
-    )
-
-    assert len(resp.output) == 1
-    assert isinstance(resp.output[0], ResponseOutputMessage)
-    assert len(resp.output[0].content) == 1
-    assert isinstance(resp.output[0].content[0], ResponseOutputRefusal)
-    assert (
-        resp.output[0].content[0].refusal
-        == "Response truncated because the provider's maximum token limit was reached."
-    )
-
-
-@pytest.mark.allow_call_model_methods
-@pytest.mark.asyncio
-async def test_get_response_traces_synthesized_truncation_refusal(monkeypatch) -> None:
-    with trace(workflow_name="truncation-refusal"):
+async def test_get_response_raises_on_truncated_empty_turn(monkeypatch) -> None:
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
         await _get_response_for_choice(
             monkeypatch,
             Choice(
@@ -459,8 +437,37 @@ async def test_get_response_traces_synthesized_truncation_refusal(monkeypatch) -
                 finish_reason="length",
                 message=ChatCompletionMessage(role="assistant", content=None),
             ),
-            tracing=ModelTracing.ENABLED,
         )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_raises_on_truncated_empty_string_turn(monkeypatch) -> None:
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await _get_response_for_choice(
+            monkeypatch,
+            Choice(
+                index=0,
+                finish_reason="length",
+                message=ChatCompletionMessage(role="assistant", content=""),
+            ),
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_traces_error_on_truncated_empty_turn(monkeypatch) -> None:
+    with trace(workflow_name="truncation-error"):
+        with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+            await _get_response_for_choice(
+                monkeypatch,
+                Choice(
+                    index=0,
+                    finish_reason="length",
+                    message=ChatCompletionMessage(role="assistant", content=None),
+                ),
+                tracing=ModelTracing.ENABLED,
+            )
 
     generation_spans = [
         span for span in fetch_ordered_spans() if span.span_data.type == "generation"
@@ -468,9 +475,7 @@ async def test_get_response_traces_synthesized_truncation_refusal(monkeypatch) -
     assert len(generation_spans) == 1
     exported_span = generation_spans[0].export()
     assert exported_span is not None
-    assert exported_span["span_data"]["output"][0]["refusal"] == (
-        "Response truncated because the provider's maximum token limit was reached."
-    )
+    assert exported_span["error"] is not None
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -473,9 +473,67 @@ async def test_get_response_traces_error_on_truncated_empty_turn(monkeypatch) ->
         span for span in fetch_ordered_spans() if span.span_data.type == "generation"
     ]
     assert len(generation_spans) == 1
-    exported_span = generation_spans[0].export()
+    generation = generation_spans[0]
+    exported_span = generation.export()
     assert exported_span is not None
     assert exported_span["error"] is not None
+    # The request (and any reported tokens) must be preserved on the span even though
+    # the call raised, so the run's usage accounting does not lose the request.
+    assert generation.span_data.usage is not None
+    assert generation.span_data.usage["requests"] == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_traces_usage_on_truncated_empty_turn(monkeypatch) -> None:
+    """The token usage reported before a truncated empty completion raises must be
+    preserved on the generation span, alongside the request."""
+    chat = ChatCompletion(
+        id="resp-id",
+        created=0,
+        model="fake",
+        object="chat.completion",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="length",
+                message=ChatCompletionMessage(role="assistant", content=None),
+            )
+        ],
+        usage=CompletionUsage(
+            completion_tokens=0,
+            prompt_tokens=7,
+            total_tokens=7,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=2),
+        ),
+    )
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return chat
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    with trace(workflow_name="truncation-usage"):
+        with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+            await model.get_response(
+                system_instructions=None,
+                input="",
+                model_settings=ModelSettings(),
+                tools=[],
+                output_schema=None,
+                handoffs=[],
+                tracing=ModelTracing.ENABLED,
+                previous_response_id=None,
+                conversation_id=None,
+                prompt=None,
+            )
+
+    generation = next(span for span in fetch_ordered_spans() if span.span_data.type == "generation")
+    assert generation.span_data.usage is not None
+    assert generation.span_data.usage["requests"] == 1
+    assert generation.span_data.usage["input_tokens"] == 7
+    assert generation.span_data.usage["total_tokens"] == 7
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -428,6 +428,108 @@ async def test_get_response_preserves_empty_nonfiltered_output(monkeypatch) -> N
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_get_response_surfaces_truncated_empty_turn_as_refusal(monkeypatch) -> None:
+    resp = await _get_response_for_choice(
+        monkeypatch,
+        Choice(
+            index=0,
+            finish_reason="length",
+            message=ChatCompletionMessage(role="assistant", content=None),
+        ),
+    )
+
+    assert len(resp.output) == 1
+    assert isinstance(resp.output[0], ResponseOutputMessage)
+    assert len(resp.output[0].content) == 1
+    assert isinstance(resp.output[0].content[0], ResponseOutputRefusal)
+    assert (
+        resp.output[0].content[0].refusal
+        == "Response truncated because the provider's maximum token limit was reached."
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_traces_synthesized_truncation_refusal(monkeypatch) -> None:
+    with trace(workflow_name="truncation-refusal"):
+        await _get_response_for_choice(
+            monkeypatch,
+            Choice(
+                index=0,
+                finish_reason="length",
+                message=ChatCompletionMessage(role="assistant", content=None),
+            ),
+            tracing=ModelTracing.ENABLED,
+        )
+
+    generation_spans = [
+        span for span in fetch_ordered_spans() if span.span_data.type == "generation"
+    ]
+    assert len(generation_spans) == 1
+    exported_span = generation_spans[0].export()
+    assert exported_span is not None
+    assert exported_span["span_data"]["output"][0]["refusal"] == (
+        "Response truncated because the provider's maximum token limit was reached."
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("message", "expected_output_type", "expected_content_type"),
+    [
+        (
+            ChatCompletionMessage(role="assistant", content="partial"),
+            ResponseOutputMessage,
+            ResponseOutputText,
+        ),
+        (
+            ChatCompletionMessage(role="assistant", content=None, refusal="provider refusal"),
+            ResponseOutputMessage,
+            ResponseOutputRefusal,
+        ),
+        (
+            ChatCompletionMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ChatCompletionMessageFunctionToolCall(
+                        id="call-1",
+                        type="function",
+                        function=Function(name="do_thing", arguments="{}"),
+                    )
+                ],
+            ),
+            ResponseFunctionToolCall,
+            None,
+        ),
+    ],
+)
+async def test_get_response_preserves_nonempty_truncated_output(
+    monkeypatch,
+    message: ChatCompletionMessage,
+    expected_output_type: type[object],
+    expected_content_type: type[object] | None,
+) -> None:
+    resp = await _get_response_for_choice(
+        monkeypatch,
+        Choice(index=0, finish_reason="length", message=message),
+    )
+
+    assert len(resp.output) == 1
+    assert isinstance(resp.output[0], expected_output_type)
+    if expected_content_type is not None:
+        assert isinstance(resp.output[0], ResponseOutputMessage)
+        assert len(resp.output[0].content) == 1
+        assert isinstance(resp.output[0].content[0], expected_content_type)
+    if isinstance(resp.output[0], ResponseOutputMessage) and isinstance(
+        resp.output[0].content[0], ResponseOutputRefusal
+    ):
+        assert resp.output[0].content[0].refusal == "provider refusal"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("previous_response_id", "conversation_id", "expected_param"),
     [

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -3781,9 +3781,9 @@ async def test_buffer_tool_call_stream_forwards_content_filter_finish_reason() -
 
 
 @pytest.mark.asyncio
-async def test_handler_stream_synthesizes_refusal_on_length_truncation() -> None:
+async def test_handler_stream_raises_on_length_truncation() -> None:
     """A stream that terminates with finish_reason == "length" and no emitted
-    content must synthesize a ResponseOutputRefusal instead of an empty turn,
+    content must raise ModelBehaviorError instead of manufacturing a refusal,
     matching the non-streaming path."""
     terminal = ChatCompletionChunk(
         id="chunk-id",
@@ -3793,28 +3793,8 @@ async def test_handler_stream_synthesizes_refusal_on_length_truncation() -> None
         choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
     )
 
-    output_events = await _collect_handler_events(terminal)
-
-    types = [e.type for e in output_events]
-    assert "response.refusal.delta" in types
-    assert types[-1] == "response.completed"
-
-    refusal_deltas = [e for e in output_events if e.type == "response.refusal.delta"]
-    assert refusal_deltas and refusal_deltas[0].delta == (
-        "Response truncated because the provider's maximum token limit was reached."
-    )
-
-    completed_event = output_events[-1]
-    assert isinstance(completed_event, ResponseCompletedEvent)
-    assistant_msg = completed_event.response.output[0]
-    assert isinstance(assistant_msg, ResponseOutputMessage)
-    assert len(assistant_msg.content) == 1
-    refusal_part = assistant_msg.content[0]
-    assert isinstance(refusal_part, ResponseOutputRefusal)
-    assert (
-        refusal_part.refusal
-        == "Response truncated because the provider's maximum token limit was reached."
-    )
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await _collect_handler_events(terminal)
 
 
 @pytest.mark.asyncio
@@ -3838,10 +3818,10 @@ async def test_handler_stream_length_does_not_clobber_text() -> None:
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
-async def test_buffered_stream_synthesizes_refusal_on_length_truncation(monkeypatch) -> None:
+async def test_buffered_stream_raises_on_length_truncation(monkeypatch) -> None:
     """With tool-call buffering enabled, a stream that terminates with
-    finish_reason == "length" and no emitted content must still synthesize a
-    ResponseOutputRefusal, mirroring the content_filter buffered behavior."""
+    finish_reason == "length" and no emitted content must still raise
+    ModelBehaviorError, mirroring the non-buffered behavior."""
     chunk1 = ChatCompletionChunk(
         id="chunk-id",
         created=1,
@@ -3858,26 +3838,8 @@ async def test_buffered_stream_synthesizes_refusal_on_length_truncation(monkeypa
         usage=CompletionUsage(completion_tokens=0, prompt_tokens=7, total_tokens=7),
     )
 
-    output_events = await _buffered_stream_events(monkeypatch, [chunk1, chunk2])
-
-    types = [e.type for e in output_events]
-    assert "response.refusal.delta" in types
-    assert types[-1] == "response.completed"
-
-    refusal_deltas = [e for e in output_events if e.type == "response.refusal.delta"]
-    assert refusal_deltas and refusal_deltas[0].delta
-
-    completed_event = output_events[-1]
-    assert isinstance(completed_event, ResponseCompletedEvent)
-    assistant_msg = completed_event.response.output[0]
-    assert isinstance(assistant_msg, ResponseOutputMessage)
-    assert len(assistant_msg.content) == 1
-    refusal_part = assistant_msg.content[0]
-    assert isinstance(refusal_part, ResponseOutputRefusal)
-    assert (
-        refusal_part.refusal
-        == "Response truncated because the provider's maximum token limit was reached."
-    )
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await _buffered_stream_events(monkeypatch, [chunk1, chunk2])
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -3930,10 +3930,7 @@ async def test_buffer_tool_call_stream_forwards_length_finish_reason() -> None:
     buffered = [c async for c in ChatCmplStreamHandler.buffer_tool_call_stream(source())]
 
     terminal_choices = [
-        choice
-        for chunk in buffered
-        for choice in chunk.choices
-        if choice.finish_reason == "length"
+        choice for chunk in buffered for choice in chunk.choices if choice.finish_reason == "length"
     ]
     assert len(terminal_choices) == 1
     # The forwarded copy carries no delta output.

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -83,11 +83,15 @@ async def _completion_stream(
 async def _collect_handler_events(
     *chunks: ChatCompletionChunk,
     model: str | None = None,
+    raise_on_length_truncation: bool = False,
 ) -> list[Any]:
     return [
         event
         async for event in ChatCmplStreamHandler.handle_stream(
-            _empty_response(), cast(Any, _completion_stream(*chunks)), model=model
+            _empty_response(),
+            cast(Any, _completion_stream(*chunks)),
+            model=model,
+            raise_on_length_truncation=raise_on_length_truncation,
         )
     ]
 
@@ -3784,7 +3788,7 @@ async def test_buffer_tool_call_stream_forwards_content_filter_finish_reason() -
 async def test_handler_stream_raises_on_length_truncation() -> None:
     """A stream that terminates with finish_reason == "length" and no emitted
     content must raise ModelBehaviorError instead of manufacturing a refusal,
-    matching the non-streaming path."""
+    matching the non-streaming path, when the internal option is enabled."""
     terminal = ChatCompletionChunk(
         id="chunk-id",
         created=1,
@@ -3794,7 +3798,31 @@ async def test_handler_stream_raises_on_length_truncation() -> None:
     )
 
     with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
-        await _collect_handler_events(terminal)
+        await _collect_handler_events(terminal, raise_on_length_truncation=True)
+
+
+@pytest.mark.asyncio
+async def test_handler_stream_length_is_ignored_without_internal_option() -> None:
+    """Without the internal option, a length terminal with no output must keep the
+    released behavior: no error and no refusal synthesis (an empty turn).
+
+    The shared handler also serves LiteLLM and AnyLLM, so the length-error behavior
+    must be opt-in rather than changing those providers' streaming output.
+    """
+    terminal = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
+    )
+
+    output_events = await _collect_handler_events(terminal)
+
+    assert "response.refusal.delta" not in [e.type for e in output_events]
+    completed_event = output_events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assert completed_event.response.output == []
 
 
 @pytest.mark.asyncio
@@ -3804,7 +3832,7 @@ async def test_handler_stream_length_does_not_clobber_text() -> None:
     chunk1 = _chunk_with([Choice(index=0, delta=ChoiceDelta(content="answer"))])
     chunk2 = _chunk_with([Choice(index=0, delta=ChoiceDelta(), finish_reason="length")])
 
-    output_events = await _collect_handler_events(chunk1, chunk2)
+    output_events = await _collect_handler_events(chunk1, chunk2, raise_on_length_truncation=True)
 
     assert "response.refusal.delta" not in [e.type for e in output_events]
     completed_event = output_events[-1]
@@ -4333,3 +4361,134 @@ async def test_stream_span_is_recorded_for_a_consumer_that_stops_at_the_terminal
     generation = next(s for s in fetch_ordered_spans() if s.span_data.type == "generation")
     assert generation.span_data.usage is not None
     assert generation.span_data.usage["requests"] == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_streamed_span_preserves_usage_on_length_truncation(monkeypatch) -> None:
+    """A stream terminated by finish_reason == "length" with no output raises
+    ModelBehaviorError, but the request and reported token usage must still be
+    preserved on the generation span before the error surfaces."""
+
+    def _length_stream_patch():
+        chunk = ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
+            usage=CompletionUsage(
+                completion_tokens=0,
+                prompt_tokens=7,
+                total_tokens=7,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=2),
+            ),
+        )
+
+        async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+            yield chunk
+
+        async def patched_fetch_response(self, *args, **kwargs):
+            resp = Response(
+                id="resp-id",
+                created_at=0,
+                model="fake-model",
+                object="response",
+                output=[],
+                tool_choice="none",
+                tools=[],
+                parallel_tool_calls=False,
+            )
+            return resp, fake_stream()
+
+        return patched_fetch_response
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", _length_stream_patch())
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    with trace(workflow_name="stream-length-truncation"):
+        with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+            async for _ in model.stream_response(
+                system_instructions=None,
+                input="",
+                model_settings=ModelSettings(),
+                tools=[],
+                output_schema=None,
+                handoffs=[],
+                tracing=ModelTracing.ENABLED,
+                previous_response_id=None,
+                conversation_id=None,
+                prompt=None,
+            ):
+                pass
+
+    generation = next(s for s in fetch_ordered_spans() if s.span_data.type == "generation")
+    exported_span = generation.export()
+    assert exported_span is not None
+    assert exported_span["error"] is not None
+    assert generation.span_data.usage is not None
+    assert generation.span_data.usage["requests"] == 1
+    assert generation.span_data.usage["input_tokens"] == 7
+    assert generation.span_data.usage["total_tokens"] == 7
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_streamed_span_counts_request_on_length_truncation_without_usage(
+    monkeypatch,
+) -> None:
+    """When the provider omits usage, a length-truncated empty completion still
+    counts the request on the generation span (tokens stay at zero), mirroring
+    the non-streaming path."""
+
+    def _length_stream_patch():
+        chunk = ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
+            usage=None,
+        )
+
+        async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+            yield chunk
+
+        async def patched_fetch_response(self, *args, **kwargs):
+            resp = Response(
+                id="resp-id",
+                created_at=0,
+                model="fake-model",
+                object="response",
+                output=[],
+                tool_choice="none",
+                tools=[],
+                parallel_tool_calls=False,
+            )
+            return resp, fake_stream()
+
+        return patched_fetch_response
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", _length_stream_patch())
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    with trace(workflow_name="stream-length-no-usage"):
+        with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+            async for _ in model.stream_response(
+                system_instructions=None,
+                input="",
+                model_settings=ModelSettings(),
+                tools=[],
+                output_schema=None,
+                handoffs=[],
+                tracing=ModelTracing.ENABLED,
+                previous_response_id=None,
+                conversation_id=None,
+                prompt=None,
+            ):
+                pass
+
+    generation = next(s for s in fetch_ordered_spans() if s.span_data.type == "generation")
+    assert generation.span_data.usage is not None
+    assert generation.span_data.usage["requests"] == 1
+    assert generation.span_data.usage["total_tokens"] == 0

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -3781,6 +3781,166 @@ async def test_buffer_tool_call_stream_forwards_content_filter_finish_reason() -
 
 
 @pytest.mark.asyncio
+async def test_handler_stream_synthesizes_refusal_on_length_truncation() -> None:
+    """A stream that terminates with finish_reason == "length" and no emitted
+    content must synthesize a ResponseOutputRefusal instead of an empty turn,
+    matching the non-streaming path."""
+    terminal = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
+    )
+
+    output_events = await _collect_handler_events(terminal)
+
+    types = [e.type for e in output_events]
+    assert "response.refusal.delta" in types
+    assert types[-1] == "response.completed"
+
+    refusal_deltas = [e for e in output_events if e.type == "response.refusal.delta"]
+    assert refusal_deltas and refusal_deltas[0].delta == (
+        "Response truncated because the provider's maximum token limit was reached."
+    )
+
+    completed_event = output_events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assistant_msg = completed_event.response.output[0]
+    assert isinstance(assistant_msg, ResponseOutputMessage)
+    assert len(assistant_msg.content) == 1
+    refusal_part = assistant_msg.content[0]
+    assert isinstance(refusal_part, ResponseOutputRefusal)
+    assert (
+        refusal_part.refusal
+        == "Response truncated because the provider's maximum token limit was reached."
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_stream_length_does_not_clobber_text() -> None:
+    """A length finish_reason arriving after real text was streamed must not
+    synthesize a refusal."""
+    chunk1 = _chunk_with([Choice(index=0, delta=ChoiceDelta(content="answer"))])
+    chunk2 = _chunk_with([Choice(index=0, delta=ChoiceDelta(), finish_reason="length")])
+
+    output_events = await _collect_handler_events(chunk1, chunk2)
+
+    assert "response.refusal.delta" not in [e.type for e in output_events]
+    completed_event = output_events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assistant_msg = completed_event.response.output[0]
+    assert isinstance(assistant_msg, ResponseOutputMessage)
+    text_part = assistant_msg.content[0]
+    assert isinstance(text_part, ResponseOutputText)
+    assert text_part.text == "answer"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_buffered_stream_synthesizes_refusal_on_length_truncation(monkeypatch) -> None:
+    """With tool-call buffering enabled, a stream that terminates with
+    finish_reason == "length" and no emitted content must still synthesize a
+    ResponseOutputRefusal, mirroring the content_filter buffered behavior."""
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(role="assistant", content=""))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
+        usage=CompletionUsage(completion_tokens=0, prompt_tokens=7, total_tokens=7),
+    )
+
+    output_events = await _buffered_stream_events(monkeypatch, [chunk1, chunk2])
+
+    types = [e.type for e in output_events]
+    assert "response.refusal.delta" in types
+    assert types[-1] == "response.completed"
+
+    refusal_deltas = [e for e in output_events if e.type == "response.refusal.delta"]
+    assert refusal_deltas and refusal_deltas[0].delta
+
+    completed_event = output_events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assistant_msg = completed_event.response.output[0]
+    assert isinstance(assistant_msg, ResponseOutputMessage)
+    assert len(assistant_msg.content) == 1
+    refusal_part = assistant_msg.content[0]
+    assert isinstance(refusal_part, ResponseOutputRefusal)
+    assert (
+        refusal_part.refusal
+        == "Response truncated because the provider's maximum token limit was reached."
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_buffered_stream_length_does_not_clobber_text(monkeypatch) -> None:
+    """A length finish_reason arriving after real text was streamed must not
+    synthesize a refusal, even with buffering enabled."""
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="answer"))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=7, total_tokens=8),
+    )
+
+    output_events = await _buffered_stream_events(monkeypatch, [chunk1, chunk2])
+
+    assert "response.refusal.delta" not in [e.type for e in output_events]
+    completed_event = output_events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assistant_msg = completed_event.response.output[0]
+    assert isinstance(assistant_msg, ResponseOutputMessage)
+    text_part = assistant_msg.content[0]
+    assert isinstance(text_part, ResponseOutputText)
+    assert text_part.text == "answer"
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_forwards_length_finish_reason() -> None:
+    """The buffering layer must forward a length-truncated terminal choice even
+    though its delta is empty, so the finish_reason reaches the handler instead
+    of being swallowed (mirrors the content_filter forwarding behavior)."""
+    chunks = [
+        _chunk_with([Choice(index=0, delta=ChoiceDelta(content=""))]),
+        _chunk_with([Choice(index=0, delta=ChoiceDelta(), finish_reason="length")]),
+    ]
+
+    async def source() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in chunks:
+            yield chunk
+
+    buffered = [c async for c in ChatCmplStreamHandler.buffer_tool_call_stream(source())]
+
+    terminal_choices = [
+        choice
+        for chunk in buffered
+        for choice in chunk.choices
+        if choice.finish_reason == "length"
+    ]
+    assert len(terminal_choices) == 1
+    # The forwarded copy carries no delta output.
+    assert not ChatCmplStreamHandler._delta_has_passthrough_output(terminal_choices[0].delta)
+
+
+@pytest.mark.asyncio
 async def test_buffer_tool_call_stream_does_not_duplicate_tool_calls_finish() -> None:
     """finish_reason == "tool_calls" is still emitted only by the synthesized
     buffered chunk, so the terminal choice is not forwarded twice."""


### PR DESCRIPTION
Fixes #4510

## Summary

A Chat Completions completion truncated at zero visible tokens (`finish_reason="length"`, empty content) currently converts to **zero output items**. Neither `ModelResponse` nor the streamed events carry `finish_reason`, so callers cannot tell this apart from a model that genuinely returned nothing — agent loops retry into the same max-token wall.

This surfaces that condition as a `ModelBehaviorError` on both the non-streaming (`OpenAIChatCompletionsModel.get_response`) and streaming (`ChatCmplStreamHandler.handle_stream`) paths. A `finish_reason="length"` completion with no assistant text, tool call, or refusal raises a `ModelBehaviorError` instead of collapsing into an empty turn, so the agent loop stops instead of retrying into the same token wall. `finish_reason="stop"` with empty content remains an empty turn (the asymmetry is intentional).

This deliberately does **not** synthesize a `ResponseOutputRefusal`: token-budget exhaustion is not a policy refusal and should not route through `model_refusal` handlers.

## Fix

### Non-streaming (`openai_chatcompletions.py`)

`get_response` raises when the first choice is terminal with `finish_reason="length"` and the message is otherwise empty:

```python
if (
    message is not None
    and first_choice is not None
    and first_choice.finish_reason == "length"
    and not message.content
    and not message.refusal
    and not message.tool_calls
):
    raise ModelBehaviorError(
        "Chat Completions response terminated with finish_reason='length' "
        "but produced no assistant text, tool call, or refusal."
    )
```

The content-filter refusal synthesis is unchanged.

### Streaming (`chatcmpl_stream_handler.py`)

`ChatCmplStreamHandler.handle_stream` tracks `finish_reason == "length"` alongside the existing `saw_content_filter` flag and raises the same `ModelBehaviorError` at end-of-stream when nothing was emitted (text / refusal / tool calls). The tool-call buffering layer forwards a length-truncated terminal choice (delta-stripped) exactly like it already does for `content_filter`, so the finish_reason reaches the handler.

The length-error behavior is gated behind an internal `raise_on_length_truncation` option that only `OpenAIChatCompletionsModel.stream_response` enables. The shared handler also serves LiteLLM and AnyLLM, whose streaming behavior is unchanged.

### Span usage preserved on the error

Before raising, both paths record the request and any reported token usage on the generation span, so a truncated empty completion does not silently drop the request from tracing/usage accounting. Focused tracing assertions cover the streaming and non-streaming error paths, with and without provider-reported usage.

## Verification

Driving `OpenAIChatCompletionsModel.get_response` against a mocked completion with empty assistant content, varying only `finish_reason`:

**Before**
```
finish_reason      output items   what the caller sees
length             0              []
content_filter     1              ['message'] -> ResponseOutputRefusal
stop               0              []            (genuine empty, unchanged)
```

**After (non-streaming)**
```
finish_reason      output items   what the caller sees
length             raises         ModelBehaviorError
content_filter     1              ['message'] -> ResponseOutputRefusal (unchanged)
stop               0              []             (genuine empty, unchanged)
```

**After (streaming)** — `ChatCmplStreamHandler.handle_stream` on a terminal `length` chunk with no emitted content:
```
finish_reason      events                                        response.output
length             raises                                        ModelBehaviorError
content_filter     ... refusal.delta ... response.completed      [message -> ResponseOutputRefusal] (unchanged)
stop               response.created, response.completed           []
```

Non-empty `length` completions (text / refusal / tool calls) are untouched on both paths.

## Tests

Non-streaming (`test_openai_chatcompletions.py`):
- `test_get_response_raises_on_truncated_empty_turn`
- `test_get_response_raises_on_truncated_empty_string_turn`
- `test_get_response_traces_error_on_truncated_empty_turn` (span records the request)
- `test_get_response_traces_usage_on_truncated_empty_turn` (reported tokens preserved on the span)
- `test_get_response_preserves_nonempty_truncated_output` (parametrized: text / refusal / tool call)

Streaming (`test_openai_chatcompletions_stream.py`):
- `test_handler_stream_raises_on_length_truncation` (option enabled)
- `test_handler_stream_length_is_ignored_without_internal_option` (LiteLLM/AnyLLM behavior unchanged)
- `test_handler_stream_length_does_not_clobber_text`
- `test_buffered_stream_raises_on_length_truncation`
- `test_buffered_stream_length_does_not_clobber_text`
- `test_buffer_tool_call_stream_forwards_length_finish_reason`
- `test_streamed_span_preserves_usage_on_length_truncation`
- `test_streamed_span_counts_request_on_length_truncation_without_usage`

`test_openai_chatcompletions.py` + `test_openai_chatcompletions_stream.py` green (161 passed); ruff clean; mypy at baseline (no new errors).

## Scope note

The same gap still exists on the sibling Chat Completions model paths (`litellm_model.py`, `any_llm_model.py`). I kept this PR to the `openai_chatcompletions` non-streaming + streaming paths to match how the `content_filter` fixes were merged individually (#3769, #3897, #4188, #4234) — happy to extend the same treatment to those two sibling paths in a follow-up.