### PR TITLE
fix(extensions): surface length-truncated empty completions as refusal on litellm/any_llm paths

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -641,15 +641,23 @@ class AnyLLMModel(Model):
             # Some providers signal a filtered non-streaming completion only through
             # finish_reason="content_filter" and an otherwise empty message. Preserve
             # that terminal signal as a refusal instead of returning an empty output.
+            # A completion truncated before any visible token (finish_reason="length")
+            # has the same shape and must not collapse into an indistinguishable
+            # empty turn either.
             if (
                 message is not None
                 and first_choice is not None
-                and first_choice.finish_reason == "content_filter"
+                and first_choice.finish_reason in {"content_filter", "length"}
                 and not message.content
                 and not message.refusal
                 and not message.tool_calls
             ):
-                message.refusal = "Response withheld by the provider's content filter."
+                if first_choice.finish_reason == "content_filter":
+                    message.refusal = "Response withheld by the provider's content filter."
+                else:
+                    message.refusal = (
+                        "Response truncated because the provider's maximum token limit was reached."
+                    )
 
             if tracing.include_data():
                 span_generation.span_data.output = (

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -302,19 +302,6 @@ class LitellmModel(Model):
                 usage = Usage(requests=1)
                 logger.warning("No usage information returned from Litellm")
 
-            if tracing.include_data():
-                span_generation.span_data.output = (
-                    [message.model_dump()] if message is not None else []
-                )
-            span_generation.span_data.usage = {
-                "requests": usage.requests,
-                "input_tokens": usage.input_tokens,
-                "output_tokens": usage.output_tokens,
-                "total_tokens": usage.total_tokens,
-                "input_tokens_details": usage.input_tokens_details.model_dump(),
-                "output_tokens_details": usage.output_tokens_details.model_dump(),
-            }
-
             # Surface content-filter refusals explicitly. Some providers (e.g.
             # Anthropic on Amazon Bedrock) signal a safety block only via
             # ``finish_reason == "content_filter"`` with an empty message and no
@@ -324,7 +311,9 @@ class LitellmModel(Model):
             # refusal so downstream handling (ResponseOutputRefusal) fires.
             # A completion truncated before any visible token (``finish_reason ==
             # "length"``) has the same shape and must not collapse into an empty
-            # turn either.
+            # turn either. This runs before the span output is recorded so the
+            # synthesized refusal is reflected in tracing; a provider-supplied
+            # refusal (carried in ``provider_specific_fields``) is left as-is.
             if (
                 message is not None
                 and first_choice is not None
@@ -342,6 +331,19 @@ class LitellmModel(Model):
                     )
                     provider_specific_fields["refusal"] = refusal_message
                     message.provider_specific_fields = provider_specific_fields
+
+            if tracing.include_data():
+                span_generation.span_data.output = (
+                    [message.model_dump()] if message is not None else []
+                )
+            span_generation.span_data.usage = {
+                "requests": usage.requests,
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "total_tokens": usage.total_tokens,
+                "input_tokens_details": usage.input_tokens_details.model_dump(),
+                "output_tokens_details": usage.output_tokens_details.model_dump(),
+            }
 
             # Build provider_data for provider specific fields
             provider_data: dict[str, Any] = {"model": self.model}

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -322,18 +322,25 @@ class LitellmModel(Model):
             # output items and the caller sees an indistinguishable "empty turn",
             # which drives agent loops into fruitless retries. Synthesize a
             # refusal so downstream handling (ResponseOutputRefusal) fires.
+            # A completion truncated before any visible token (``finish_reason ==
+            # "length"``) has the same shape and must not collapse into an empty
+            # turn either.
             if (
                 message is not None
                 and first_choice is not None
-                and getattr(first_choice, "finish_reason", None) == "content_filter"
+                and getattr(first_choice, "finish_reason", None) in {"content_filter", "length"}
                 and not message.content
                 and not getattr(message, "tool_calls", None)
             ):
                 provider_specific_fields = getattr(message, "provider_specific_fields", None) or {}
                 if not provider_specific_fields.get("refusal"):
-                    provider_specific_fields["refusal"] = (
+                    refusal_message = (
                         "Response withheld by the provider's content filter."
+                        if first_choice.finish_reason == "content_filter"
+                        else "Response truncated because the provider's maximum token"
+                        " limit was reached."
                     )
+                    provider_specific_fields["refusal"] = refusal_message
                     message.provider_specific_fields = provider_specific_fields
 
             # Build provider_data for provider specific fields

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -529,6 +529,12 @@ def _content_filtered_chat_completion(content: str) -> ChatCompletion:
     return completion
 
 
+def _length_truncated_chat_completion(content: str) -> ChatCompletion:
+    completion = _chat_completion(content)
+    completion.choices[0].finish_reason = "length"
+    return completion
+
+
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 async def test_any_llm_chat_path_surfaces_content_filter_refusal(monkeypatch) -> None:
@@ -571,6 +577,79 @@ async def test_any_llm_chat_path_content_filter_keeps_real_content(monkeypatch) 
     provider = FakeAnyLLMProvider(
         supports_responses=False,
         chat_response=_content_filtered_chat_completion("here is the answer"),
+    )
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    response = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    refusals = [
+        content
+        for item in response.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert not refusals
+    assert response.output[0].content[0].text == "here is the answer"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_path_surfaces_length_truncation_refusal(monkeypatch) -> None:
+    """A zero-token truncated turn must become a refusal instead of an empty output,
+    mirroring the content_filter handling."""
+    provider = FakeAnyLLMProvider(
+        supports_responses=False,
+        chat_response=_length_truncated_chat_completion(""),
+    )
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    response = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    refusals = [
+        content
+        for item in response.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert refusals, f"expected a refusal item, got: {response.output}"
+    assert refusals[0].refusal == (
+        "Response truncated because the provider's maximum token limit was reached."
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_path_length_keeps_real_content(monkeypatch) -> None:
+    """A truncated turn that still carries text keeps the text and gains no refusal."""
+    provider = FakeAnyLLMProvider(
+        supports_responses=False,
+        chat_response=_length_truncated_chat_completion("here is the answer"),
     )
     module, _create_calls = _import_any_llm_module(monkeypatch, provider)
 

--- a/tests/models/test_litellm_content_filter.py
+++ b/tests/models/test_litellm_content_filter.py
@@ -75,6 +75,44 @@ async def test_content_filter_does_not_clobber_real_content(monkeypatch):
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_length_finish_reason_surfaces_refusal(monkeypatch):
+    """A zero-token truncated turn (empty message, finish_reason=length) must
+    become an explicit ResponseOutputRefusal, not zero output items, mirroring
+    the content_filter handling."""
+    resp = await _get_response(monkeypatch, finish_reason="length", content="")
+
+    refusals = [
+        content
+        for item in resp.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert refusals, f"expected a refusal item, got: {resp.output}"
+    assert refusals[0].refusal == (
+        "Response truncated because the provider's maximum token limit was reached."
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_length_does_not_clobber_real_content(monkeypatch):
+    """A length finish_reason that still carries text is left alone — we only
+    synthesize a refusal when the message is genuinely empty."""
+    resp = await _get_response(monkeypatch, finish_reason="length", content="here is the answer")
+
+    refusals = [
+        content
+        for item in resp.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert not refusals, "should not synthesize a refusal when content is present"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_normal_stop_is_unaffected(monkeypatch):
     """A normal completion is unchanged — no spurious refusal."""
     resp = await _get_response(monkeypatch, finish_reason="stop", content="all good")

--- a/tests/models/test_litellm_content_filter.py
+++ b/tests/models/test_litellm_content_filter.py
@@ -3,9 +3,11 @@ import pytest
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
 from openai.types.responses import ResponseOutputMessage, ResponseOutputRefusal
 
+from agents import trace
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
+from tests.testing_processor import fetch_ordered_spans
 
 
 async def _get_response(monkeypatch, *, finish_reason, content):
@@ -109,6 +111,45 @@ async def test_length_does_not_clobber_real_content(monkeypatch):
         if isinstance(content, ResponseOutputRefusal)
     ]
     assert not refusals, "should not synthesize a refusal when content is present"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_length_finish_reason_refusal_recorded_in_trace(monkeypatch) -> None:
+    """The synthesized truncation refusal must be recorded in the generation span
+    output (the synthesis happens before span_data.output is captured), matching
+    the non-streaming openai_chatcompletions tracing behavior."""
+    async def fake_acompletion(model, messages=None, **kwargs):
+        msg = Message(role="assistant", content=None)
+        choice = Choices(index=0, finish_reason="length", message=msg)
+        return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    model = LitellmModel(model="test-model")
+    with trace(workflow_name="litellm-length-truncation"):
+        await model.get_response(
+            system_instructions=None,
+            input=[],
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.ENABLED,
+            previous_response_id=None,
+        )
+
+    generation_spans = [
+        span for span in fetch_ordered_spans() if span.span_data.type == "generation"
+    ]
+    assert len(generation_spans) == 1
+    exported_span = generation_spans[0].export()
+    assert exported_span is not None
+    output = exported_span["span_data"]["output"]
+    assert output
+    provider_fields = output[0].get("provider_specific_fields") or {}
+    assert provider_fields.get("refusal") == (
+        "Response truncated because the provider's maximum token limit was reached."
+    )
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
Complements #4513 (which fixes the `openai_chatcompletions` non-streaming and streaming paths) and extends the same `finish_reason="length"` fix from #4510 to the two remaining sibling Chat Completions model implementations: `litellm_model.py` and `any_llm_model.py`.

## Summary

A zero-token truncation (`finish_reason="length"`, empty content) on the LiteLLM and AnyLLM model paths converts to **zero output items**, indistinguishable from a genuinely empty turn — driving agent loops into fruitless retries against the same max-token wall. Both already had the equivalent guard for `finish_reason="content_filter"`; this mirrors it for `"length"`.

## Fix

`litellm_model.py` — extend the existing content-filter guard (`finish_reason in {"content_filter", "length"}`), keeping the `provider_specific_fields["refusal"]` mechanism, with a distinct truncation message:

```python
if (
    message is not None
    and first_choice is not None
    and getattr(first_choice, "finish_reason", None) in {"content_filter", "length"}
    and not message.content
    and not getattr(message, "tool_calls", None)
):
    provider_specific_fields = getattr(message, "provider_specific_fields", None) or {}
    if not provider_specific_fields.get("refusal"):
        refusal_message = (
            "Response withheld by the provider's content filter."
            if first_choice.finish_reason == "content_filter"
            else "Response truncated because the provider's maximum token"
            " limit was reached."
        )
        provider_specific_fields["refusal"] = refusal_message
        message.provider_specific_fields = provider_specific_fields
```

`any_llm_model.py` — same guard extension using the `message.refusal` mechanism:

```python
if (
    message is not None
    and first_choice is not None
    and first_choice.finish_reason in {"content_filter", "length"}
    and not message.content
    and not message.refusal
    and not message.tool_calls
):
    if first_choice.finish_reason == "content_filter":
        message.refusal = "Response withheld by the provider's content filter."
    else:
        message.refusal = (
            "Response truncated because the provider's maximum token limit was reached."
        )
```

`finish_reason="stop"` with empty content stays an empty turn (the asymmetry is intentional); non-empty `length` completions are untouched.

## Verification

Driving each model's `get_response` with a mocked empty completion, varying `finish_reason`:

**Before (both paths)**: `length` → 0 items; `content_filter` → refusal; `stop` → 0 items
**After (both paths)**:
```
finish_reason      output items   what the caller sees
length             1              ['message'] -> ResponseOutputRefusal("Response truncated because the provider's maximum token limit was reached.")
content_filter     1              ['message'] -> ResponseOutputRefusal (unchanged)
stop               0              []             (genuine empty, unchanged)
length + text      1              ['message'] -> ResponseOutputText (unchanged)
```

## Tests

- `test_litellm_content_filter.py`: `test_length_finish_reason_surfaces_refusal`, `test_length_does_not_clobber_real_content`
- `test_any_llm_model.py`: `test_any_llm_chat_path_surfaces_length_truncation_refusal`, `test_any_llm_chat_path_length_keeps_real_content`

`tests/models/` all green (826 passed, 11 skipped); ruff clean; mypy clean on the touched lines (the pre-existing `litellm_model.py:969` tool-call error is unchanged by this PR).
