### PR TITLE
fix(models): reject terminal failed/incomplete responses in non-streaming get_response

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -405,6 +405,9 @@ class AnyLLMModel(Model):
                 prompt=prompt,
             )
 
+            if getattr(response, "status", None) in {"failed", "incomplete"}:
+                raise response_terminal_failure_error(f"response.{response.status}", response)
+
             if _debug.DONT_LOG_MODEL_DATA:
                 logger.debug("LLM responded")
             else:

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -822,6 +822,8 @@ class OpenAIResponsesModel(Model):
 
         if not stream:
             response = await client.responses.create(**create_kwargs)
+            if getattr(response, "status", None) in {"failed", "incomplete"}:
+                raise response_terminal_failure_error(f"response.{response.status}", response)
             _mark_transport_request_without_usage(response)
             return cast(Response, response)
 

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -23,6 +23,7 @@ from openai.types.responses import (
     ResponseOutputMessage,
     ResponseOutputRefusal,
 )
+from openai.types.responses.response import IncompleteDetails
 from openai.types.responses.response_created_event import ResponseCreatedEvent
 from openai.types.responses.response_error_event import ResponseErrorEvent
 from openai.types.responses.response_failed_event import ResponseFailedEvent
@@ -172,6 +173,24 @@ def _response(text: str, response_id: str = "resp_123") -> Response:
                 {"cache_write_tokens": 0, "cached_tokens": 0}
             ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        ),
+    )
+
+
+def _responses_response_with_terminal_status(status: str) -> Response:
+    return Response(
+        id="resp_terminal",
+        created_at=123,
+        model="fake-model",
+        object="response",
+        output=[],
+        tool_choice="none",
+        tools=[],
+        parallel_tool_calls=False,
+        usage=None,
+        status=status,
+        incomplete_details=(
+            IncompleteDetails(reason="max_output_tokens") if status == "incomplete" else None
         ),
     )
 
@@ -762,6 +781,34 @@ async def test_any_llm_responses_path_is_used_when_supported(monkeypatch) -> Non
     assert kwargs["extra_headers"]["User-Agent"] == f"Agents/Python {__version__}"
     assert response.response_id == "resp_123"
     assert response.output[0].content[0].text == "Hello"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["incomplete", "failed"])
+async def test_any_llm_responses_path_rejects_failed_terminal_status(
+    monkeypatch, status: str
+) -> None:
+    provider = FakeAnyLLMProvider(
+        supports_responses=True,
+        responses_response=_responses_response_with_terminal_status(status),
+    )
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    model = module.AnyLLMModel(model="openai/gpt-5.4-mini", api_key="openai-key")
+    with pytest.raises(ModelBehaviorError, match=f"response.{status}"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -9,6 +9,7 @@ import httpx2
 import pytest
 from openai import NOT_GIVEN, APIConnectionError, AsyncOpenAI, RateLimitError, omit
 from openai.types.responses import Response, ResponseCompletedEvent, ResponseErrorEvent
+from openai.types.responses.response import IncompleteDetails
 from openai.types.responses.response_create_params import ContextManagement, PromptCacheOptions
 from openai.types.responses.response_usage import ResponseUsage
 from openai.types.shared.reasoning import Reasoning
@@ -2130,6 +2131,32 @@ async def test_websocket_model_get_response_rejects_failed_terminal_response_pay
     monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
 
     with pytest.raises(ModelBehaviorError, match=terminal_event_type):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["incomplete", "failed"])
+async def test_get_response_rejects_failed_terminal_response_status(status: str) -> None:
+    class Responses:
+        async def create(self, **kwargs: Any) -> Response:
+            return _response_with_terminal_status(status)
+
+    class Client:
+        responses = Responses()
+        base_url = httpx2.URL("https://custom.example.test/v1/")
+
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=cast(Any, Client()))
+
+    with pytest.raises(ModelBehaviorError, match=f"response.{status}"):
         await model.get_response(
             system_instructions=None,
             input="hi",
@@ -4439,6 +4466,25 @@ def _response_without_usage() -> Response:
         top_p=None,
         parallel_tool_calls=False,
         usage=None,
+    )
+
+
+def _response_with_terminal_status(status: str) -> Response:
+    return Response(
+        id="resp-terminal",
+        created_at=0,
+        model="fake",
+        object="response",
+        output=[],
+        tool_choice="none",
+        tools=[],
+        top_p=None,
+        parallel_tool_calls=False,
+        usage=None,
+        status=status,
+        incomplete_details=(
+            IncompleteDetails(reason="max_output_tokens") if status == "incomplete" else None
+        ),
     )
 
 


### PR DESCRIPTION
Refs #4515

### Summary

The HTTP **non-streaming** `get_response()` path treats a terminal `response.failed` / `response.incomplete` payload as a successful empty turn: `OpenAIResponsesModel.get_response()` and `AnyLLMModel._get_response_via_responses()` return `ModelResponse(output=[])` instead of surfacing the terminal state.

Every other path already rejects these states as `ModelBehaviorError` (streaming `stream_response()`, websocket `get_response()`, streamed runner finalization — fixed in #3106, May 2026). The non-streaming HTTP path was never covered by that fix.

### Fix

Raise the same `response_terminal_failure_error(...)` used elsewhere when the non-streaming response carries a terminal status:

```python
if getattr(response, "status", None) in {"failed", "incomplete"}:
    raise response_terminal_failure_error(f"response.{response.status}", response)
```

in `_fetch_response()` (non-stream branch) and `_get_response_via_responses()`. `getattr` keeps custom/mock clients that return plain objects working.

### Verification

Broken (main, mocked `client.responses.create` returning `status="incomplete"`, `reason="max_output_tokens"`):

```text
output = []          # treated as a successful empty turn, no error
```

Fixed (this branch):

```text
ModelBehaviorError: Responses stream ended with terminal event `response.incomplete`.
status=incomplete; incomplete_details=IncompleteDetails(reason='max_output_tokens').
```

- New tests: `test_get_response_rejects_failed_terminal_response_status` (openai model, parametrized `incomplete`/`failed`) and `test_any_llm_responses_path_rejects_failed_terminal_status` (any_llm model, parametrized).
- `tests/models`: 816 passed, 11 skipped.
- `ruff check` / `ruff format --check`: clean.

### Issue number

Closes #4515

### Checks

- [x] I've added new tests, if relevant
- [x] `tests/models`: 816 passed, 11 skipped (includes the new tests)
- [x] `ruff check` / `ruff format --check` on the changed files: clean