### PR TITLE
fix(visualization): expand handoff() targets in agent graphs

### DIFF
--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -22,6 +22,15 @@ def _escape_label(name: str) -> str:
     )
 
 
+def _handoff_target_agent(handoff: Handoff) -> Agent | None:
+    """Return the live Agent target for a ``handoff()`` object, if available."""
+    agent_ref = handoff._agent_ref
+    if agent_ref is None:
+        return None
+    target = agent_ref()
+    return target if isinstance(target, Agent) else None
+
+
 def get_main_graph(agent: Agent) -> str:
     """
     Generates the main graph structure in DOT format for the given agent.
@@ -99,13 +108,6 @@ def get_all_nodes(
         )
 
     for handoff in agent.handoffs:
-        if isinstance(handoff, Handoff):
-            name = _escape_label(handoff.agent_name)
-            parts.append(
-                f'"{name}" [label="{name}", '
-                f'shape=box, style="filled,rounded", '
-                f"fillcolor=lightyellow, width=1.5, height=0.8];"
-            )
         if isinstance(handoff, Agent):
             if handoff.name not in visited:
                 name = _escape_label(handoff.name)
@@ -115,6 +117,26 @@ def get_all_nodes(
                     f"fillcolor=lightyellow, width=1.5, height=0.8];"
                 )
             parts.append(get_all_nodes(handoff, agent, visited))
+            continue
+
+        if isinstance(handoff, Handoff):
+            target = _handoff_target_agent(handoff)
+            if target is not None:
+                if target.name not in visited:
+                    name = _escape_label(target.name)
+                    parts.append(
+                        f'"{name}" [label="{name}", '
+                        f'shape=box, style="filled,rounded", '
+                        f"fillcolor=lightyellow, width=1.5, height=0.8];"
+                    )
+                parts.append(get_all_nodes(target, agent, visited))
+            else:
+                name = _escape_label(handoff.agent_name)
+                parts.append(
+                    f'"{name}" [label="{name}", '
+                    f'shape=box, style="filled,rounded", '
+                    f"fillcolor=lightyellow, width=1.5, height=0.8];"
+                )
 
     return "".join(parts)
 
@@ -158,13 +180,21 @@ def get_all_edges(
         "{server_name}" -> "{agent_name}" [style=dashed, penwidth=1.5];""")
 
     for handoff in agent.handoffs:
-        if isinstance(handoff, Handoff):
-            parts.append(f"""
-            "{agent_name}" -> "{_escape_label(handoff.agent_name)}";""")
         if isinstance(handoff, Agent):
             parts.append(f"""
             "{agent_name}" -> "{_escape_label(handoff.name)}";""")
             parts.append(get_all_edges(handoff, agent, visited))
+            continue
+
+        if isinstance(handoff, Handoff):
+            target = _handoff_target_agent(handoff)
+            if target is not None:
+                parts.append(f"""
+            "{agent_name}" -> "{_escape_label(target.name)}";""")
+                parts.append(get_all_edges(target, agent, visited))
+            else:
+                parts.append(f"""
+            "{agent_name}" -> "{_escape_label(handoff.agent_name)}";""")
 
     if not agent.handoffs:
         parts.append(f'"{agent_name}" -> "__end__";')

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -270,7 +270,13 @@ def test_draw_graph_with_real_handoff_object():
     get_all_edges (rather than the ``isinstance(handoff, Agent)`` branches),
     using the public ``handoff()`` factory rather than ``Mock(spec=Handoff)``.
     """
-    child_agent = Agent(name="ChildAgent", instructions="Child instructions")
+    child_tool = Mock()
+    child_tool.name = "ChildTool"
+    child_agent = Agent(
+        name="ChildAgent",
+        instructions="Child instructions",
+        tools=[child_tool],
+    )
     real_handoff = handoff(child_agent)
     assert isinstance(real_handoff, Handoff)
 
@@ -284,12 +290,40 @@ def test_draw_graph_with_real_handoff_object():
 
     assert isinstance(graph, graphviz.Source)
     assert '"ParentAgent"' in graph.source
-    # Node uses agent_name from the Handoff object
+    # Node uses the live handoff target agent, matching Agent-in-handoffs graphs.
     assert (
         '"ChildAgent" [label="ChildAgent", shape=box, style="filled,rounded", '
         "fillcolor=lightyellow, width=1.5, height=0.8];" in graph.source
     )
-    # Edge points from parent to handoff agent_name
+    assert (
+        '"ChildTool" [label="ChildTool", shape=ellipse, style=filled, '
+        "fillcolor=lightgreen, width=0.5, height=0.3];" in graph.source
+    )
+    # Edge points from parent to handoff target
     assert '"ParentAgent" -> "ChildAgent";' in graph.source
     # Parent has handoffs, so should NOT connect directly to __end__
     assert '"ParentAgent" -> "__end__"' not in graph.source
+    # Child has no handoffs, so should connect to __end__ like Agent handoffs.
+    assert '"ChildAgent" -> "__end__"' in graph.source
+
+
+def test_draw_graph_keeps_stub_for_handoff_without_agent_ref():
+    """Handoff objects without a recoverable agent remain name-only stubs."""
+    stub_handoff = Mock(spec=Handoff)
+    stub_handoff.agent_name = "ExternalHandoff"
+    stub_handoff._agent_ref = None
+
+    parent_agent = Agent(
+        name="ParentAgent",
+        instructions="Parent instructions",
+        handoffs=[stub_handoff],
+    )
+
+    graph = draw_graph(parent_agent)
+
+    assert (
+        '"ExternalHandoff" [label="ExternalHandoff", shape=box, style="filled,rounded", '
+        "fillcolor=lightyellow, width=1.5, height=0.8];" in graph.source
+    )
+    assert '"ParentAgent" -> "ExternalHandoff";' in graph.source
+    assert '"ExternalHandoff" -> "__end__"' not in graph.source


### PR DESCRIPTION
### Summary

This pull request fixes incomplete agent graphs when handoffs use the recommended `handoff()` factory.

`draw_graph` already recurses into child agents when `handoffs` contains an `Agent`, but `Handoff` objects were rendered as name-only stubs. That skipped child tools, MCP servers, and `"Child" -> "__end__"` edges even though `handoff()` stores a recoverable `_agent_ref`.

When a live target agent is available, visualization now expands it the same way as an `Agent` handoff. Handoff objects without a recoverable agent reference stay name-only stubs.

### Test plan

- [x] `uv run pytest -q tests/test_visualization.py`
- [x] `.agents/skills/code-change-verification/scripts/run.sh`
- [x] Confirmed `handoff(child)` graphs include child tools and `__end__`
- [x] Confirmed stub `Handoff` objects without `_agent_ref` remain name-only

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR