### PR TITLE
fix(voice): snapshot STT turn_detection settings

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -97,7 +97,10 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
         self._client = client
         self._model = model
         self._settings = settings
-        self._turn_detection = settings.turn_detection or DEFAULT_TURN_DETECTION
+        if settings.turn_detection is None:
+            self._turn_detection = dict(DEFAULT_TURN_DETECTION)
+        else:
+            self._turn_detection = dict(settings.turn_detection)
         self._trace_include_sensitive_data = trace_include_sensitive_data
         self._trace_include_sensitive_audio_data = trace_include_sensitive_audio_data
 

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -28,6 +28,7 @@ try:
     )
     from agents.voice.exceptions import STTWebsocketConnectionError
     from agents.voice.models.openai_stt import (
+        DEFAULT_TURN_DETECTION,
         EVENT_INACTIVITY_TIMEOUT,
         ErrorSentinel,
         WebsocketDoneSentinel,
@@ -838,3 +839,61 @@ async def test_stream_audio_buffers_turn_audio_only_for_audio_tracing(
         )
     else:
         assert session._turn_audio_buffer == []
+
+
+def test_transcription_session_snapshots_turn_detection() -> None:
+    """Caller and default turn_detection mappings must not alias session state."""
+    caller_turn_detection = {"type": "server_vad", "threshold": 0.5}
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(turn_detection=caller_turn_detection),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+
+    assert session._turn_detection == caller_turn_detection
+    assert session._turn_detection is not caller_turn_detection
+    caller_turn_detection["threshold"] = 0.9
+    assert session._turn_detection == {"type": "server_vad", "threshold": 0.5}
+
+    default_session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(turn_detection=None),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    original_default = dict(DEFAULT_TURN_DETECTION)
+
+    assert default_session._turn_detection == original_default
+    assert default_session._turn_detection is not DEFAULT_TURN_DETECTION
+    default_session._turn_detection["eagerness"] = "high"
+
+    later_session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    assert DEFAULT_TURN_DETECTION == original_default
+    assert later_session._turn_detection == original_default
+    assert later_session._turn_detection is not default_session._turn_detection
+
+
+def test_transcription_session_preserves_empty_turn_detection() -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(turn_detection={}),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+
+    assert session._turn_detection == {}
+    assert session._turn_detection is not DEFAULT_TURN_DETECTION


### PR DESCRIPTION
### Summary

This pull request fixes mutable aliasing of STT `turn_detection` settings in `OpenAISTTTranscriptionSession`.

The session previously stored `settings.turn_detection or DEFAULT_TURN_DETECTION` by reference. Mutating the caller mapping after construction changed the `session.update` payload, and mutating the default path poisoned later sessions that relied on `DEFAULT_TURN_DETECTION`.

Construction now copies the caller mapping, or copies the module default when `turn_detection` is `None`. An explicit empty mapping is preserved instead of falling through to the default.

### Test plan

- [x] `uv run pytest -q tests/voice/test_openai_stt.py -k "snapshots_turn_detection or preserves_empty_turn_detection"`
- [x] `make format && make lint && make typecheck`
- [x] Confirmed caller mutations no longer affect the session copy
- [x] Confirmed default-path sessions no longer share `DEFAULT_TURN_DETECTION`

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed format, lint, typecheck, and focused voice STT tests pass
- [ ] If using Codex, I've run `/review` before submitting this PR