### PR TITLE
fix(core): detach aggregated request usage entries

### DIFF
--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -297,7 +297,7 @@ class Usage:
         # (this preserves nested token details that would otherwise be discarded
         # when synthesizing an entry from only the top-level fields).
         if other.request_usage_entries:
-            self.request_usage_entries.extend(other.request_usage_entries)
+            self.request_usage_entries.extend(copy.deepcopy(other.request_usage_entries))
         elif other.requests == 1 and other.total_tokens > 0:
             # Otherwise, if the other Usage represents a single request with tokens, record it.
             input_details = other.input_tokens_details or _make_input_tokens_details()
@@ -306,8 +306,8 @@ class Usage:
                 input_tokens=other.input_tokens,
                 output_tokens=other.output_tokens,
                 total_tokens=other.total_tokens,
-                input_tokens_details=input_details,
-                output_tokens_details=output_details,
+                input_tokens_details=copy.deepcopy(input_details),
+                output_tokens_details=copy.deepcopy(output_details),
             )
             self.request_usage_entries.append(request_usage)
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -366,6 +366,58 @@ def test_usage_add_preserves_existing_entries_when_top_level_also_set():
     assert entry.output_tokens_details.reasoning_tokens == 5
 
 
+def test_usage_add_detaches_pre_existing_request_usage_entries():
+    source_entry = RequestUsage(
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 10}
+        ),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
+    )
+    source = Usage(
+        requests=1,
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        request_usage_entries=[source_entry],
+    )
+    aggregate = Usage()
+
+    aggregate.add(source)
+    source_entry.input_tokens = 999
+    source_entry.input_tokens_details.cached_tokens = 99
+    source_entry.output_tokens_details.reasoning_tokens = 99
+
+    aggregate_entry = aggregate.request_usage_entries[0]
+    assert aggregate_entry.input_tokens == 100
+    assert aggregate_entry.input_tokens_details.cached_tokens == 10
+    assert aggregate_entry.output_tokens_details.reasoning_tokens == 5
+
+
+def test_usage_add_detaches_synthesized_request_usage_details():
+    source = Usage(
+        requests=1,
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 10}
+        ),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
+    )
+    aggregate = Usage()
+
+    aggregate.add(source)
+    source.input_tokens_details.cached_tokens = 99
+    source.output_tokens_details.reasoning_tokens = 99
+
+    aggregate_entry = aggregate.request_usage_entries[0]
+    assert aggregate_entry.input_tokens_details.cached_tokens == 10
+    assert aggregate_entry.output_tokens_details.reasoning_tokens == 5
+
+
 def test_usage_request_usage_entries_default_empty():
     """Test that request_usage_entries defaults to an empty list."""
     u = Usage()


### PR DESCRIPTION
### Summary

`Usage.add()` previously reused mutable per-request usage objects from the source `Usage`. Mutating the source after aggregation could therefore change the aggregate's request breakdown while its scalar totals stayed unchanged.

This change:

- deep-copies pre-existing `request_usage_entries` before appending them;
- detaches input and output token details when synthesizing a single-request entry; and
- adds regression coverage for both aggregation paths.

Public fields, totals, entry ordering, and entry-synthesis conditions are unchanged.

### Test plan

- `git diff --check`
- Python syntax compilation for `src/agents/usage.py` and `tests/test_usage.py`
- Dependency-free focused isolation probe covering both existing-entry and synthesized-entry paths
- Two independent repository-protocol final reviews on the same fingerprint (both clean)
- GitHub Actions for full formatting, lint, type checking, and tests (pending)

The local checkout is intentionally dependency-free. Running the repository verification wrapper would first require installing 192 packages (187 downloads), so full verification is delegated to the GitHub-hosted checks rather than modifying the contributor machine.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
