### PR TITLE
docs: fix wording in handoff example prompts

### DIFF
--- a/examples/handoffs/message_filter.py
+++ b/examples/handoffs/message_filter.py
@@ -93,7 +93,7 @@ async def main():
             input=result.to_input_list()
             + [
                 {
-                    "content": "I live in New York City. Whats the population of the city?",
+                    "content": "I live in New York City. What's the population of the city?",
                     "role": "user",
                 }
             ],
@@ -152,7 +152,7 @@ async def main():
         "type": "message"
         }
         {
-        "content": "I live in New York City. Whats the population of the city?",
+        "content": "I live in New York City. What's the population of the city?",
         "role": "user"
         }
         {

--- a/examples/handoffs/message_filter_streaming.py
+++ b/examples/handoffs/message_filter_streaming.py
@@ -93,7 +93,7 @@ async def main():
             input=result.to_input_list()
             + [
                 {
-                    "content": "I live in New York City. Whats the population of the city?",
+                    "content": "I live in New York City. What's the population of the city?",
                     "role": "user",
                 }
             ],
@@ -152,7 +152,7 @@ async def main():
             "type": "message"
             }
             {
-            "content": "I live in New York City. Whats the population of the city?",
+            "content": "I live in New York City. What's the population of the city?",
             "role": "user"
             }
             {


### PR DESCRIPTION
This pull request fixes the missing apostrophe in the user prompts shared by the standard and streaming message-filter examples, keeping the paired examples consistent.