### PR TITLE
fix(sandbox): snapshot Instrumentation payload policies

### DIFF
--- a/src/agents/sandbox/session/manager.py
+++ b/src/agents/sandbox/session/manager.py
@@ -24,8 +24,14 @@ class Instrumentation:
         payload_policy_by_op: dict[OpName, EventPayloadPolicy] | None = None,
     ) -> None:
         self._sinks: list[EventSink] = list(sinks or [])
-        self.payload_policy = payload_policy if payload_policy is not None else EventPayloadPolicy()
-        self.payload_policy_by_op = dict(payload_policy_by_op or {})
+        self.payload_policy = (
+            payload_policy.model_copy(deep=True)
+            if payload_policy is not None
+            else EventPayloadPolicy()
+        )
+        self.payload_policy_by_op = {
+            op: policy.model_copy(deep=True) for op, policy in (payload_policy_by_op or {}).items()
+        }
         self._tasks: set[asyncio.Task[None]] = set()
 
     @property

--- a/tests/sandbox/test_session_manager.py
+++ b/tests/sandbox/test_session_manager.py
@@ -104,6 +104,65 @@ async def test_instrumentation_snapshots_per_op_policy_mapping(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_instrumentation_snapshots_default_policy_object(tmp_path: Path) -> None:
+    events: list[SandboxSessionEvent] = []
+    session = _build_session(tmp_path)
+    sink = CallbackSink(lambda event, _session: events.append(event), mode="sync")
+    sink.bind(session)
+    payload_policy = EventPayloadPolicy(include_exec_output=False)
+    instrumentation = Instrumentation(
+        sinks=[sink],
+        payload_policy=payload_policy,
+    )
+    payload_policy.include_exec_output = True
+    event = SandboxSessionFinishEvent(
+        session_id=uuid.uuid4(),
+        seq=1,
+        op="exec",
+        span_id="span_exec",
+        ok=True,
+        duration_ms=0.0,
+        stdout_bytes=b"secret",
+    )
+
+    await instrumentation.emit(event)
+
+    assert isinstance(events[0], SandboxSessionFinishEvent)
+    assert events[0].stdout is None
+    assert events[0].stdout_bytes is None
+
+
+@pytest.mark.asyncio
+async def test_instrumentation_snapshots_per_op_policy_objects(tmp_path: Path) -> None:
+    events: list[SandboxSessionEvent] = []
+    session = _build_session(tmp_path)
+    sink = CallbackSink(lambda event, _session: events.append(event), mode="sync")
+    sink.bind(session)
+    op_policy = EventPayloadPolicy(include_exec_output=False)
+    instrumentation = Instrumentation(
+        sinks=[sink],
+        payload_policy=EventPayloadPolicy(include_exec_output=True),
+        payload_policy_by_op={"exec": op_policy},
+    )
+    op_policy.include_exec_output = True
+    event = SandboxSessionFinishEvent(
+        session_id=uuid.uuid4(),
+        seq=1,
+        op="exec",
+        span_id="span_exec",
+        ok=True,
+        duration_ms=0.0,
+        stdout_bytes=b"secret",
+    )
+
+    await instrumentation.emit(event)
+
+    assert isinstance(events[0], SandboxSessionFinishEvent)
+    assert events[0].stdout is None
+    assert events[0].stdout_bytes is None
+
+
+@pytest.mark.asyncio
 async def test_instrumentation_per_sink_policy_overrides_per_op(tmp_path: Path) -> None:
     first: list[SandboxSessionEvent] = []
     second: list[SandboxSessionEvent] = []


### PR DESCRIPTION
### Summary

This pull request finishes constructor snapshotting for sandbox `Instrumentation` payload policies.

#4398 detached the `payload_policy_by_op` mapping, but the default `payload_policy` and the policy objects inside that mapping were still shared with the caller. Mutating `include_exec_output` (or other fields) on those objects after construction could undo audit redaction for later `emit()` calls.

`Instrumentation` now deep-copies the default policy and each per-op policy at construction time. Callers can still change `instrumentation.payload_policy*` after construction if they own that instance.

### Test plan

- [x] `uv run pytest -q tests/sandbox/test_session_manager.py -k snapshots`
- [x] `make format && make lint && make typecheck`
- [x] Confirmed mutating constructor-owned default and per-op policy fields no longer leaks exec stdout

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed format, lint, typecheck, and focused sandbox tests pass
- [ ] If using Codex, I've run `/review` before submitting this PR