### PR TITLE
fix(mcp): deep-copy cached tools before returning them

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -128,6 +128,11 @@ _SAFE_EXCEPTION_GROUP_MESSAGE = "MCP request failed with additional errors."
 _SAFE_EXCEPTION_MESSAGE = "An additional error occurred during the MCP request."
 
 
+def _snapshot_tools(tools: list[MCPTool]) -> list[MCPTool]:
+    """Return deep-copied tools so callers cannot mutate cached schemas."""
+    return [tool.model_copy(deep=True) for tool in tools]
+
+
 def _client_session_read_timeout(timeout_seconds: float | None) -> timedelta | float | None:
     """Convert an MCP read timeout while intentionally treating zero as no timeout."""
     if timeout_seconds is None:
@@ -856,9 +861,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
     def cached_tools(self) -> list[MCPTool] | None:
         """A snapshot of the cached tools list, or `None` when nothing is cached.
 
-        This returns a new list so callers cannot mutate the server's cache in place.
+        This returns deep-copied tools so callers cannot mutate the server's cache.
         """
-        return None if self._tools_list is None else list(self._tools_list)
+        return None if self._tools_list is None else _snapshot_tools(self._tools_list)
 
     def __init__(
         self,
@@ -1478,12 +1483,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             filtered_tools = tools
             if self.tool_filter is not None:
                 filtered_tools = await self._apply_tool_filter(filtered_tools, run_context, agent)
-            if filtered_tools is self._tools_list:
-                # The filters build a new list, but an absent filter — or a static filter with
-                # neither key set — passes the cached list straight through. Returning it would
-                # let a caller mutate the cache and corrupt every later `list_tools()` result.
-                return list(filtered_tools)
-            return filtered_tools
+            # Always deep-copy tools. Even when filters build a new list, the Tool
+            # objects (and nested input schemas) would otherwise remain shared with
+            # the cache and let callers corrupt required-parameter validation.
+            return _snapshot_tools(filtered_tools)
         except mcp_compat.HTTP_STATUS_ERROR_TYPES as e:
             status_code = http_status_code(e)
             transport_error = UserError(

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1039,10 +1039,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         )
 
         filtered_tools = []
-        for tool in tools:
+        for tool, detached in zip(tools, _snapshot_tools(tools), strict=True):
             try:
-                # Call the filter function with context
-                result = tool_filter_func(filter_context, tool)
+                # Inspect a detached copy so a mutating filter cannot corrupt the cache.
+                result = tool_filter_func(filter_context, detached)
 
                 if inspect.isawaitable(result):
                     should_include = await result

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -185,6 +185,82 @@ async def test_cached_tools_returns_a_snapshot(
 @patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
 @patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
 @patch("mcp.client.session.ClientSession.list_tools")
+async def test_list_tools_snapshots_tool_objects(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    """Mutating a returned tool must not corrupt the cached tool or its schema."""
+    schema = {
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+        "required": ["q"],
+    }
+    server = MCPServerStdio(params={"command": tee}, cache_tools_list=True)
+    mock_list_tools.return_value = ListToolsResult(
+        tools=[MCPTool(name="tool1", inputSchema=schema)]
+    )
+
+    async with server:
+        run_context = RunContextWrapper(context=None)
+        agent = Agent(name="test_agent", instructions="Test agent")
+
+        returned = await server.list_tools(run_context, agent)
+        cached = server.cached_tools
+        assert cached is not None
+        assert returned[0] is not cached[0]
+        assert returned[0].input_schema is not cached[0].input_schema
+
+        returned[0].input_schema["required"] = []
+        returned[0].description = "mutated"
+
+        later = await server.list_tools(run_context, agent)
+        assert later[0].description is None
+        assert later[0].input_schema.get("required") == ["q"]
+        assert (server.cached_tools or [])[0].input_schema.get("required") == ["q"]
+        assert mock_list_tools.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.call_tool", new_callable=AsyncMock)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_list_tools_mutation_cannot_bypass_required_parameter_validation(
+    mock_list_tools: AsyncMock,
+    mock_call_tool: AsyncMock,
+    mock_initialize: AsyncMock,
+    mock_stdio_client,
+):
+    """Clearing required fields on a returned tool must not skip call-time validation."""
+    from mcp.types import CallToolResult, TextContent
+
+    from agents.exceptions import UserError
+
+    schema = {
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+        "required": ["q"],
+    }
+    server = MCPServerStdio(params={"command": tee}, cache_tools_list=True)
+    mock_list_tools.return_value = ListToolsResult(
+        tools=[MCPTool(name="tool1", inputSchema=schema)]
+    )
+    mock_call_tool.return_value = CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    async with server:
+        run_context = RunContextWrapper(context=None)
+        agent = Agent(name="test_agent", instructions="Test agent")
+        returned = await server.list_tools(run_context, agent)
+        returned[0].input_schema["required"] = []
+
+        with pytest.raises(UserError, match="missing required parameters: q"):
+            await server.call_tool("tool1", {})
+        assert mock_call_tool.call_count == 0
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
 async def test_cached_tools_is_none_before_the_first_list(
     mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
 ):

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -159,10 +159,20 @@ async def test_list_tools_does_not_expose_the_cache_with_a_no_op_static_filter(
 async def test_cached_tools_returns_a_snapshot(
     mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
 ):
-    """`cached_tools` must not hand out the live cache: appending to it would inject a tool."""
+    """`cached_tools` must not hand out the live cache: mutating it must not leak into listings."""
     server = MCPServerStdio(params={"command": tee}, cache_tools_list=True)
     mock_list_tools.return_value = ListToolsResult(
-        tools=[MCPTool(name="tool1", inputSchema={}), MCPTool(name="tool2", inputSchema={})]
+        tools=[
+            MCPTool(
+                name="tool1",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                    "required": ["q"],
+                },
+            ),
+            MCPTool(name="tool2", inputSchema={}),
+        ]
     )
 
     async with server:
@@ -173,12 +183,17 @@ async def test_cached_tools_returns_a_snapshot(
         snapshot = server.cached_tools
         assert snapshot is not None
         snapshot.append(MCPTool(name="injected", inputSchema={}))
+        snapshot[0].description = "mutated"
+        snapshot[0].input_schema["required"] = []
 
-        assert [tool.name for tool in (server.cached_tools or [])] == ["tool1", "tool2"]
-        assert [tool.name for tool in await server.list_tools(run_context, agent)] == [
-            "tool1",
-            "tool2",
-        ]
+        later_cached = server.cached_tools
+        later_listed = await server.list_tools(run_context, agent)
+        assert [tool.name for tool in (later_cached or [])] == ["tool1", "tool2"]
+        assert [tool.name for tool in later_listed] == ["tool1", "tool2"]
+        assert (later_cached or [])[0].description is None
+        assert later_listed[0].description is None
+        assert (later_cached or [])[0].input_schema.get("required") == ["q"]
+        assert later_listed[0].input_schema.get("required") == ["q"]
 
 
 @pytest.mark.asyncio
@@ -251,6 +266,63 @@ async def test_list_tools_mutation_cannot_bypass_required_parameter_validation(
         agent = Agent(name="test_agent", instructions="Test agent")
         returned = await server.list_tools(run_context, agent)
         returned[0].input_schema["required"] = []
+
+        with pytest.raises(UserError, match="missing required parameters: q"):
+            await server.call_tool("tool1", {})
+        assert mock_call_tool.call_count == 0
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.call_tool", new_callable=AsyncMock)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_dynamic_filter_mutation_cannot_corrupt_cached_tool_schemas(
+    mock_list_tools: AsyncMock,
+    mock_call_tool: AsyncMock,
+    mock_initialize: AsyncMock,
+    mock_stdio_client,
+):
+    """A callable filter that mutates nested schemas must not affect later listings or calls."""
+    from mcp.types import CallToolResult, TextContent
+
+    from agents.exceptions import UserError
+
+    schema = {
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+        "required": ["q"],
+    }
+
+    def mutating_filter(_context, tool: MCPTool) -> bool:
+        tool.input_schema["required"] = []
+        tool.description = "mutated"
+        return True
+
+    server = MCPServerStdio(
+        params={"command": tee},
+        cache_tools_list=True,
+        tool_filter=mutating_filter,
+    )
+    mock_list_tools.return_value = ListToolsResult(
+        tools=[MCPTool(name="tool1", inputSchema=schema)]
+    )
+    mock_call_tool.return_value = CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    async with server:
+        run_context = RunContextWrapper(context=None)
+        agent = Agent(name="test_agent", instructions="Test agent")
+        first = await server.list_tools(run_context, agent)
+        later = await server.list_tools(run_context, agent)
+        cached = server.cached_tools
+
+        assert first[0].input_schema.get("required") == ["q"]
+        assert later[0].input_schema.get("required") == ["q"]
+        assert cached is not None
+        assert cached[0].input_schema.get("required") == ["q"]
+        assert first[0].description is None
+        assert later[0].description is None
+        assert cached[0].description is None
 
         with pytest.raises(UserError, match="missing required parameters: q"):
             await server.call_tool("tool1", {})


### PR DESCRIPTION
### Summary

This pull request finishes cache isolation for MCP tool listings.

#4424 returned a new list from `list_tools()` / `cached_tools`, but the `Tool` objects and nested `input_schema` dicts remained shared with the server cache. Mutating a returned tool's schema could clear `required` fields and bypass `_validate_required_parameters` on later `call_tool()` invocations.

Returned tools are now deep-copied so callers cannot corrupt the cache or required-parameter checks. Callable `tool_filter` functions receive detached copies before invocation, so a filter that mutates nested schemas cannot rewrite `_tools_list`. No-filter and static-filter results stay isolated by the same return-path snapshot.

### Test plan

- [x] `uv run pytest -q tests/mcp/test_caching.py tests/mcp/test_tool_filtering.py`
- [x] `make format && make lint && make typecheck`
- [x] Confirmed mutating a returned tool's `input_schema["required"]` still fails call-time validation
- [x] Confirmed a dynamic filter that clears `required` cannot change later listings or `call_tool()` validation
- [x] Confirmed `cached_tools` nested schema mutation does not leak into later snapshots

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass, except pre-existing `tests/sandbox/test_run_cwd.py::test_python_skill_uses_absolute_root_from_nested_workdir` on this host
- [ ] If using Codex, I've run `/review` before submitting this PR