### PR TITLE
fix(voice) reject ignored explicit-client options

### DIFF
--- a/src/agents/voice/models/openai_model_provider.py
+++ b/src/agents/voice/models/openai_model_provider.py
@@ -59,8 +59,11 @@ class OpenAIVoiceModelProvider(VoiceModelProvider):
             agent_registration: Optional agent registration configuration.
         """
         if openai_client is not None:
-            if api_key is not None or base_url is not None:
-                raise UserError("Don't provide api_key or base_url if you provide openai_client")
+            if any(value is not None for value in (api_key, base_url, organization, project)):
+                raise UserError(
+                    "Don't provide api_key, base_url, organization, or project if you provide "
+                    "openai_client"
+                )
             self._client: AsyncOpenAI | None = openai_client
         else:
             self._client = None

--- a/tests/voice/test_openai_model_provider.py
+++ b/tests/voice/test_openai_model_provider.py
@@ -16,6 +16,8 @@ from agents.voice.models.openai_model_provider import OpenAIVoiceModelProvider, 
     [
         {"api_key": "other_key"},
         {"base_url": "https://example.com"},
+        {"organization": "org_test"},
+        {"project": "proj_test"},
         {"api_key": "other_key", "base_url": "https://example.com"},
     ],
 )


### PR DESCRIPTION
### Summary

Reject `organization` and `project` when `OpenAIVoiceModelProvider` receives an explicit `openai_client`.

An explicit `AsyncOpenAI` client already owns its organization and project settings. The voice provider currently rejects `api_key` and `base_url` in this configuration but silently accepts and ignores `organization` and `project` because those values are only stored when the provider constructs its own client.

This aligns the voice provider with the same explicit-client contract already used by `OpenAIProvider`.

### Reproduction

```python
client = AsyncOpenAI(api_key="test")
provider = OpenAIVoiceModelProvider(
    openai_client=client,
    organization="org_other",
)
```

On current `main`, construction succeeds but `organization="org_other"` has no effect. The provider continues using the organization configured on `client`.

### Test plan

Extends the existing explicit-client conflict regression test to cover both `organization` and `project` while preserving the valid client-only path.

### Issue number

N/A