### PR TITLE
fix(tracing): flush buffered data after tracing is disabled

### DIFF
--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -497,10 +497,6 @@ class DefaultTraceProvider(TraceProvider):
 
     def force_flush(self) -> None:
         """Force all processors to flush their buffers immediately."""
-        self._refresh_disabled_flag()
-        if self._disabled:
-            return
-
         try:
             self._multi_processor.force_flush()
         except Exception as e:

--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -497,6 +497,7 @@ class DefaultTraceProvider(TraceProvider):
 
     def force_flush(self) -> None:
         """Force all processors to flush their buffers immediately."""
+        self._refresh_disabled_flag()
         try:
             self._multi_processor.force_flush()
         except Exception as e:

--- a/tests/test_disabled_trace_provider_flush.py
+++ b/tests/test_disabled_trace_provider_flush.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import agents.tracing as tracing
+from agents.tracing.provider import DefaultTraceProvider
+
+
+def test_flush_traces_still_flushes_registered_processors_when_disabled(monkeypatch) -> None:
+    provider = DefaultTraceProvider()
+    processor = MagicMock()
+    provider.register_processor(processor)
+    provider.set_disabled(True)
+    monkeypatch.setattr(tracing, "get_trace_provider", lambda: provider)
+
+    tracing.flush_traces()
+
+    processor.force_flush.assert_called_once_with()

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -360,7 +360,7 @@ def test_flush_traces_is_importable_from_top_level_agents_package():
     assert top_level_flush_traces is flush_traces
 
 
-def test_default_trace_provider_force_flush_respects_disabled_flag():
+def test_default_trace_provider_force_flush_still_flushes_when_disabled():
     provider = DefaultTraceProvider()
     mock_processor = MagicMock()
     provider.register_processor(mock_processor)
@@ -368,7 +368,7 @@ def test_default_trace_provider_force_flush_respects_disabled_flag():
     provider.set_disabled(True)
     provider.force_flush()
 
-    mock_processor.force_flush.assert_not_called()
+    mock_processor.force_flush.assert_called_once_with()
 
 
 def test_trace_provider_force_flush_and_shutdown_default_to_noops():
@@ -497,7 +497,6 @@ def test_backend_span_exporter_4xx_client_error(mock_client, monkeypatch, caplog
 
     mock_response = Response()
     mock_client.return_value.post.return_value = mock_response
-
     exporter = BackendSpanExporter(api_key="test_key")
     with caplog.at_level(logging.ERROR, logger="openai.agents"):
         exporter.export([get_span(mock_processor())])

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -497,6 +497,7 @@ def test_backend_span_exporter_4xx_client_error(mock_client, monkeypatch, caplog
 
     mock_response = Response()
     mock_client.return_value.post.return_value = mock_response
+
     exporter = BackendSpanExporter(api_key="test_key")
     with caplog.at_level(logging.ERROR, logger="openai.agents"):
         exporter.export([get_span(mock_processor())])

--- a/tests/tracing/test_tracing_env_disable.py
+++ b/tests/tracing/test_tracing_env_disable.py
@@ -39,6 +39,19 @@ def test_disabled_span_logging_respects_data_policy(monkeypatch, caplog, redacte
     assert "Tracing is disabled. Not creating span" in caplog.text
 
 
+def test_force_flush_initializes_env_disable_cache(monkeypatch):
+    """Force flush preserves the first-use timing for the env disable flag."""
+    monkeypatch.setenv("OPENAI_AGENTS_DISABLE_TRACING", "1")
+    provider = DefaultTraceProvider()
+
+    provider.force_flush()
+
+    monkeypatch.setenv("OPENAI_AGENTS_DISABLE_TRACING", "0")
+    trace = provider.create_trace("still-disabled")
+
+    assert isinstance(trace, NoOpTrace)
+
+
 def test_env_cached_after_first_use(monkeypatch):
     """Env flag is cached after the first trace and later env changes do not flip it."""
     monkeypatch.setenv("OPENAI_AGENTS_DISABLE_TRACING", "0")


### PR DESCRIPTION
### Summary

Keep the public `flush_traces()` operation effective after tracing has been disabled.

`DefaultTraceProvider.force_flush()` currently returns early when the provider's disabled flag is set. That means an application can create buffered trace data, call `set_tracing_disabled(True)` to stop collecting new traces, and then call `flush_traces()` before a worker or request exits, but the explicit flush silently does nothing.

Disabling tracing should control creation of new trace data. It should not prevent already-registered processors from flushing data they already own. This follows the same lifecycle distinction as processor shutdown.

### Reproduction

```python
# traces/spans have already been queued
set_tracing_disabled(True)
flush_traces()
```

On current `main`, `flush_traces()` reaches `DefaultTraceProvider.force_flush()` and returns before calling any registered processor.

### Change

Remove the disabled-state early return from `DefaultTraceProvider.force_flush()`. Trace and span creation remain disabled exactly as before.

### Test plan

Adds a regression test through the public `flush_traces()` function and verifies that a registered processor receives `force_flush()` even after the provider is disabled.

### Issue number

N/A