### PR TITLE
fix(core/voice): honor OpenAI provider options over default clients

### DIFF
--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -137,15 +137,37 @@ class OpenAIProvider(ModelProvider):
     # AsyncOpenAI() raises an error if you don't have an API key set.
     def _get_client(self) -> AsyncOpenAI:
         if self._client is None:
-            default_client = _openai_shared.get_default_openai_client()
+            has_explicit_client_options = any(
+                value is not None
+                for value in (
+                    self._stored_api_key,
+                    self._stored_base_url,
+                    self._stored_websocket_base_url,
+                    self._stored_organization,
+                    self._stored_project,
+                )
+            )
+            default_client = (
+                None if has_explicit_client_options else _openai_shared.get_default_openai_client()
+            )
             self._client = (
                 default_client
                 if default_client is not None
                 else AsyncOpenAI(
-                    api_key=self._stored_api_key or _openai_shared.get_default_openai_key(),
-                    base_url=self._stored_base_url or os.getenv("OPENAI_BASE_URL"),
+                    api_key=(
+                        self._stored_api_key
+                        if self._stored_api_key is not None
+                        else _openai_shared.get_default_openai_key()
+                    ),
+                    base_url=(
+                        self._stored_base_url
+                        if self._stored_base_url is not None
+                        else os.getenv("OPENAI_BASE_URL")
+                    ),
                     websocket_base_url=(
-                        self._stored_websocket_base_url or os.getenv("OPENAI_WEBSOCKET_BASE_URL")
+                        self._stored_websocket_base_url
+                        if self._stored_websocket_base_url is not None
+                        else os.getenv("OPENAI_WEBSOCKET_BASE_URL")
                     ),
                     organization=self._stored_organization,
                     project=self._stored_project,

--- a/src/agents/voice/models/openai_model_provider.py
+++ b/src/agents/voice/models/openai_model_provider.py
@@ -81,12 +81,27 @@ class OpenAIVoiceModelProvider(VoiceModelProvider):
     # AsyncOpenAI() raises an error if you don't have an API key set.
     def _get_client(self) -> AsyncOpenAI:
         if self._client is None:
-            default_client = _openai_shared.get_default_openai_client()
+            has_explicit_client_options = any(
+                value is not None
+                for value in (
+                    self._stored_api_key,
+                    self._stored_base_url,
+                    self._stored_organization,
+                    self._stored_project,
+                )
+            )
+            default_client = (
+                None if has_explicit_client_options else _openai_shared.get_default_openai_client()
+            )
             self._client = (
                 default_client
                 if default_client is not None
                 else AsyncOpenAI(
-                    api_key=self._stored_api_key or _openai_shared.get_default_openai_key(),
+                    api_key=(
+                        self._stored_api_key
+                        if self._stored_api_key is not None
+                        else _openai_shared.get_default_openai_key()
+                    ),
                     base_url=self._stored_base_url,
                     organization=self._stored_organization,
                     project=self._stored_project,

--- a/tests/test_openai_provider_client_options.py
+++ b/tests/test_openai_provider_client_options.py
@@ -6,6 +6,7 @@ import pytest
 from openai import AsyncOpenAI
 
 from agents.exceptions import UserError
+from agents.models import _openai_shared, openai_provider
 from agents.models.openai_provider import OpenAIProvider
 
 
@@ -26,3 +27,70 @@ def test_openai_provider_rejects_ignored_options_with_explicit_client(
             openai_client=client,
             **cast(dict[str, Any], client_option),
         )
+
+
+@pytest.mark.parametrize(
+    ("option_name", "option_value"),
+    [
+        ("api_key", "sk-provider"),
+        ("base_url", "https://provider.example.test/v1"),
+        ("websocket_base_url", "wss://provider.example.test/v1"),
+        ("organization", "org-provider"),
+        ("project", "proj-provider"),
+    ],
+)
+def test_openai_provider_explicit_options_override_default_client(
+    monkeypatch: pytest.MonkeyPatch,
+    option_name: str,
+    option_value: str,
+) -> None:
+    default_client = cast(AsyncOpenAI, object())
+    created_client = cast(AsyncOpenAI, object())
+    captured_kwargs: dict[str, Any] = {}
+
+    def create_client(**kwargs: Any) -> AsyncOpenAI:
+        captured_kwargs.update(kwargs)
+        return created_client
+
+    monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: default_client)
+    monkeypatch.setattr(openai_provider, "AsyncOpenAI", create_client)
+    monkeypatch.setattr(openai_provider, "shared_http_client", object)
+
+    provider = OpenAIProvider(**cast(dict[str, Any], {option_name: option_value}))
+
+    assert provider._get_client() is created_client
+    assert captured_kwargs[option_name] == option_value
+
+
+@pytest.mark.parametrize(
+    ("option_name", "environment_name"),
+    [
+        ("api_key", None),
+        ("base_url", "OPENAI_BASE_URL"),
+        ("websocket_base_url", "OPENAI_WEBSOCKET_BASE_URL"),
+    ],
+)
+def test_openai_provider_preserves_explicit_empty_options(
+    monkeypatch: pytest.MonkeyPatch,
+    option_name: str,
+    environment_name: str | None,
+) -> None:
+    default_client = cast(AsyncOpenAI, object())
+    created_client = cast(AsyncOpenAI, object())
+    captured_kwargs: dict[str, Any] = {}
+
+    def create_client(**kwargs: Any) -> AsyncOpenAI:
+        captured_kwargs.update(kwargs)
+        return created_client
+
+    monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: default_client)
+    monkeypatch.setattr(_openai_shared, "get_default_openai_key", lambda: "sk-global")
+    monkeypatch.setattr(openai_provider, "AsyncOpenAI", create_client)
+    monkeypatch.setattr(openai_provider, "shared_http_client", object)
+    if environment_name is not None:
+        monkeypatch.setenv(environment_name, "https://global.example.test/v1")
+
+    provider = OpenAIProvider(**cast(dict[str, Any], {option_name: ""}))
+
+    assert provider._get_client() is created_client
+    assert captured_kwargs[option_name] == ""

--- a/tests/voice/test_openai_model_provider.py
+++ b/tests/voice/test_openai_model_provider.py
@@ -8,6 +8,7 @@ import pytest
 
 from agents.exceptions import UserError
 from agents.models import _openai_shared
+from agents.voice.models import openai_model_provider
 from agents.voice.models.openai_model_provider import OpenAIVoiceModelProvider, shared_http_client
 
 
@@ -48,3 +49,40 @@ def test_voice_provider_preserves_falsy_default_client(monkeypatch):
     monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: client)
 
     assert OpenAIVoiceModelProvider()._get_client() is client
+
+
+@pytest.mark.parametrize(
+    ("option_name", "option_value"),
+    [
+        ("api_key", "sk-voice"),
+        ("base_url", "https://voice.example.test/v1"),
+        ("organization", "org-voice"),
+        ("project", "proj-voice"),
+        ("api_key", ""),
+        ("base_url", ""),
+        ("organization", ""),
+        ("project", ""),
+    ],
+)
+def test_voice_provider_explicit_options_override_default_client(
+    monkeypatch: pytest.MonkeyPatch,
+    option_name: str,
+    option_value: str,
+) -> None:
+    default_client = cast(openai.AsyncOpenAI, object())
+    created_client = cast(openai.AsyncOpenAI, object())
+    captured_kwargs: dict[str, Any] = {}
+
+    def create_client(**kwargs: Any) -> openai.AsyncOpenAI:
+        captured_kwargs.update(kwargs)
+        return created_client
+
+    monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: default_client)
+    monkeypatch.setattr(_openai_shared, "get_default_openai_key", lambda: "sk-global")
+    monkeypatch.setattr(openai_model_provider, "AsyncOpenAI", create_client)
+    monkeypatch.setattr(openai_model_provider, "shared_http_client", object)
+
+    provider = OpenAIVoiceModelProvider(**cast(dict[str, Any], {option_name: option_value}))
+
+    assert provider._get_client() is created_client
+    assert captured_kwargs[option_name] == option_value


### PR DESCRIPTION
### Summary

This pull request fixes both `OpenAIProvider` and `OpenAIVoiceModelProvider` silently ignoring provider-specific client options when a global default OpenAI client is configured.

For `OpenAIProvider`, explicit `api_key`, `base_url`, `websocket_base_url`, `organization`, or `project` values now select a provider-specific client. For `OpenAIVoiceModelProvider`, explicit `api_key`, `base_url`, `organization`, or `project` values do the same.

Explicit empty values are preserved instead of falling through to global credentials or endpoint environment variables. Providers with all construction options omitted continue to reuse the exact global default client, and the existing explicit-client acceptance and conflict behavior remains unchanged.

### Test plan

- Ran the focused provider, voice-provider, and configuration suites: 56 passed.
- Confirmed the 8 new voice regression cases fail against the unmodified merge-base source and pass with this patch.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`; formatting, linting, type checking, and the full test suite all passed.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR