### PR TITLE
fix(voice): honor provider options over the default client

### DIFF
--- a/src/agents/voice/models/openai_model_provider.py
+++ b/src/agents/voice/models/openai_model_provider.py
@@ -81,12 +81,27 @@ class OpenAIVoiceModelProvider(VoiceModelProvider):
     # AsyncOpenAI() raises an error if you don't have an API key set.
     def _get_client(self) -> AsyncOpenAI:
         if self._client is None:
-            default_client = _openai_shared.get_default_openai_client()
+            has_explicit_client_options = any(
+                value is not None
+                for value in (
+                    self._stored_api_key,
+                    self._stored_base_url,
+                    self._stored_organization,
+                    self._stored_project,
+                )
+            )
+            default_client = (
+                None if has_explicit_client_options else _openai_shared.get_default_openai_client()
+            )
             self._client = (
                 default_client
                 if default_client is not None
                 else AsyncOpenAI(
-                    api_key=self._stored_api_key or _openai_shared.get_default_openai_key(),
+                    api_key=(
+                        self._stored_api_key
+                        if self._stored_api_key is not None
+                        else _openai_shared.get_default_openai_key()
+                    ),
                     base_url=self._stored_base_url,
                     organization=self._stored_organization,
                     project=self._stored_project,

--- a/tests/voice/test_openai_model_provider.py
+++ b/tests/voice/test_openai_model_provider.py
@@ -8,6 +8,7 @@ import pytest
 
 from agents.exceptions import UserError
 from agents.models import _openai_shared
+from agents.voice.models import openai_model_provider
 from agents.voice.models.openai_model_provider import OpenAIVoiceModelProvider, shared_http_client
 
 
@@ -48,3 +49,57 @@ def test_voice_provider_preserves_falsy_default_client(monkeypatch):
     monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: client)
 
     assert OpenAIVoiceModelProvider()._get_client() is client
+
+
+@pytest.mark.parametrize(
+    ("option_name", "option_value"),
+    [
+        ("api_key", "sk-voice-provider"),
+        ("base_url", "https://voice-provider.example.test/v1"),
+        ("organization", "org-voice-provider"),
+        ("project", "proj-voice-provider"),
+    ],
+)
+def test_voice_provider_explicit_options_override_default_client(
+    monkeypatch: pytest.MonkeyPatch,
+    option_name: str,
+    option_value: str,
+) -> None:
+    default_client = cast(openai.AsyncOpenAI, object())
+    created_client = cast(openai.AsyncOpenAI, object())
+    captured_kwargs: dict[str, Any] = {}
+
+    def create_client(**kwargs: Any) -> openai.AsyncOpenAI:
+        captured_kwargs.update(kwargs)
+        return created_client
+
+    monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: default_client)
+    monkeypatch.setattr(openai_model_provider, "AsyncOpenAI", create_client)
+    monkeypatch.setattr(openai_model_provider, "shared_http_client", object)
+
+    provider = OpenAIVoiceModelProvider(**cast(dict[str, Any], {option_name: option_value}))
+
+    assert provider._get_client() is created_client
+    assert captured_kwargs[option_name] == option_value
+
+
+def test_voice_provider_preserves_explicit_empty_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_client = cast(openai.AsyncOpenAI, object())
+    created_client = cast(openai.AsyncOpenAI, object())
+    captured_kwargs: dict[str, Any] = {}
+
+    def create_client(**kwargs: Any) -> openai.AsyncOpenAI:
+        captured_kwargs.update(kwargs)
+        return created_client
+
+    monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: default_client)
+    monkeypatch.setattr(_openai_shared, "get_default_openai_key", lambda: "sk-global")
+    monkeypatch.setattr(openai_model_provider, "AsyncOpenAI", create_client)
+    monkeypatch.setattr(openai_model_provider, "shared_http_client", object)
+
+    provider = OpenAIVoiceModelProvider(api_key="")
+
+    assert provider._get_client() is created_client
+    assert captured_kwargs["api_key"] == ""


### PR DESCRIPTION
### Summary

Make `OpenAIVoiceModelProvider` honor provider-specific client options when a global default OpenAI client is configured.

When no explicit `openai_client` is supplied, the voice provider currently checks the global default client first. If one exists, constructor options such as `api_key`, `base_url`, `organization`, and `project` are silently ignored and STT/TTS models use the global client's configuration instead.

### Fix

- reuse the global default client only when the voice provider has no explicit client-construction options
- construct a provider-local `AsyncOpenAI` client when any voice-provider option is explicitly supplied
- preserve an explicitly supplied empty API key instead of replacing it with the global default key
- keep the existing no-options path unchanged, including support for falsy default-client objects

This is the voice-provider counterpart to the client-option precedence being fixed for `OpenAIProvider` in #4530. The two providers have separate client construction paths, so the voice path requires its own correction.

### Test plan

Extended the existing voice-provider tests to verify that, with a global default client present:

- explicit `api_key`, `base_url`, `organization`, and `project` each cause a provider-local client to be created and receive the requested value
- an explicit empty API key is preserved
- the existing no-option path continues to reuse the global default client

The branch is based directly on current `main` and is 0 commits behind it.

### Risk

Low. Providers without explicit client options retain the existing global-default behavior. The change only affects configurations that supplied voice-provider options which were previously ignored.

### Issue number

None. Found while checking voice-provider client-option precedence alongside #4530.