### PR TITLE
fix(voice): include current OpenAI TTS voices

### DIFF
--- a/src/agents/voice/model.py
+++ b/src/agents/voice/model.py
@@ -14,7 +14,21 @@ DEFAULT_TTS_INSTRUCTIONS = (
 )
 DEFAULT_TTS_BUFFER_SIZE = 120
 
-TTSVoice = Literal["alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"]
+TTSVoice = Literal[
+    "alloy",
+    "ash",
+    "ballad",
+    "coral",
+    "echo",
+    "fable",
+    "onyx",
+    "nova",
+    "sage",
+    "shimmer",
+    "verse",
+    "marin",
+    "cedar",
+]
 """Exportable type for the TTSModelSettings voice enum"""
 
 

--- a/tests/voice/test_tts_voice_types.py
+++ b/tests/voice/test_tts_voice_types.py
@@ -1,0 +1,7 @@
+from typing import get_args
+
+from agents.voice.model import TTSVoice
+
+
+def test_tts_voice_type_includes_current_openai_builtin_voices() -> None:
+    assert {"ballad", "verse", "marin", "cedar"} <= set(get_args(TTSVoice))


### PR DESCRIPTION
### Summary

Bring the public `TTSVoice` type in line with the built-in voices currently accepted by OpenAI speech generation.

`TTSModelSettings.voice` is typed as `TTSVoice`, but the literal currently omits `ballad`, `verse`, `marin`, and `cedar`. The underlying `OpenAITTSModel` already forwards voice values directly to the OpenAI speech client, whose current API supports these voices, so valid configurations are unnecessarily rejected by static type checkers.

Fixes #4534.

### Fix

- add `ballad`, `verse`, `marin`, and `cedar` to `TTSVoice`
- keep the existing voices unchanged
- add focused regression coverage for the newly supported literals

### Test plan

Added a type-contract regression asserting that the current OpenAI built-in voices omitted from the previous literal are present in `TTSVoice`.

The branch is based directly on current `main` at `7e55afc9500d12937687988f1e91e900dcb4ad09` and is 0 commits behind it.

### Risk

Very low. This widens the static type contract to match values already accepted by the runtime API; it does not change request construction or runtime behavior.