### PR TITLE
fix(voice): preserve falsey custom pipeline models

### DIFF
--- a/src/agents/voice/pipeline.py
+++ b/src/agents/voice/pipeline.py
@@ -75,12 +75,12 @@ class VoicePipeline:
             raise UserError(f"Unsupported audio input type: {type(audio_input)}")
 
     def _get_tts_model(self) -> TTSModel:
-        if not self.tts_model:
+        if self.tts_model is None:
             self.tts_model = self.config.model_provider.get_tts_model(self._tts_model_name)
         return self.tts_model
 
     def _get_stt_model(self) -> STTModel:
-        if not self.stt_model:
+        if self.stt_model is None:
             self.stt_model = self.config.model_provider.get_stt_model(self._stt_model_name)
         return self.stt_model
 

--- a/tests/voice/test_pipeline_falsey_models.py
+++ b/tests/voice/test_pipeline_falsey_models.py
@@ -1,0 +1,71 @@
+from collections.abc import AsyncIterator
+from typing import cast
+
+from agents.voice import AudioInput, StreamedAudioInput
+from agents.voice.model import (
+    STTModel,
+    STTModelSettings,
+    StreamedTranscriptionSession,
+    TTSModel,
+    TTSModelSettings,
+)
+from agents.voice.pipeline import VoicePipeline
+from agents.voice.workflow import VoiceWorkflowBase
+
+
+class _FalseySTTModel(STTModel):
+    def __bool__(self) -> bool:
+        return False
+
+    @property
+    def model_name(self) -> str:
+        return "falsey-stt"
+
+    async def transcribe(
+        self,
+        input: AudioInput,
+        settings: STTModelSettings,
+        trace_include_sensitive_data: bool,
+        trace_include_sensitive_audio_data: bool,
+    ) -> str:
+        return ""
+
+    async def create_session(
+        self,
+        input: StreamedAudioInput,
+        settings: STTModelSettings,
+        trace_include_sensitive_data: bool,
+        trace_include_sensitive_audio_data: bool,
+    ) -> StreamedTranscriptionSession:
+        raise NotImplementedError
+
+
+class _FalseyTTSModel(TTSModel):
+    def __bool__(self) -> bool:
+        return False
+
+    @property
+    def model_name(self) -> str:
+        return "falsey-tts"
+
+    async def run(self, text: str, settings: TTSModelSettings) -> AsyncIterator[bytes]:
+        if False:
+            yield b""
+
+
+def _workflow() -> VoiceWorkflowBase:
+    return cast(VoiceWorkflowBase, object())
+
+
+def test_voice_pipeline_preserves_falsey_custom_stt_model() -> None:
+    model = _FalseySTTModel()
+    pipeline = VoicePipeline(workflow=_workflow(), stt_model=model)
+
+    assert pipeline._get_stt_model() is model
+
+
+def test_voice_pipeline_preserves_falsey_custom_tts_model() -> None:
+    model = _FalseyTTSModel()
+    pipeline = VoicePipeline(workflow=_workflow(), tts_model=model)
+
+    assert pipeline._get_tts_model() is model


### PR DESCRIPTION
### Summary

Preserve explicitly supplied custom STT and TTS model instances even when they are falsey.

`VoicePipeline.__init__()` correctly recognizes custom `STTModel` / `TTSModel` instances, but `_get_stt_model()` and `_get_tts_model()` later use truthiness checks. A valid custom model that defines `__bool__()` or `__len__()` as false is therefore discarded and silently replaced with a model from the configured provider.

### Fix

- treat only `None` as the signal that a pipeline model still needs to be resolved
- preserve every explicitly supplied `STTModel` / `TTSModel` instance regardless of truthiness
- leave string model-name resolution and default-provider behavior unchanged

This also matches the existing Realtime runner behavior, which explicitly preserves falsey custom model instances.

### Test plan

Added focused regressions for falsey custom STT and TTS subclasses and verified `_get_stt_model()` / `_get_tts_model()` return the exact supplied instances.

The branch is based directly on current `main` at `7e55afc9500d12937687988f1e91e900dcb4ad09` and is 0 commits behind it. The production diff is two truthiness checks changed to explicit `is None` checks.

### Risk

Very low. The only behavior change is for explicitly supplied model objects that evaluate to false. `None`, string model names, and normal truthy model instances behave exactly as before.

### Issue number

None. Found while auditing custom-model preservation across Voice and Realtime.