### PR TITLE
fix(voice): refresh callable API keys before streamed STT

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -58,6 +58,13 @@ def _audio_buffer_to_base64(buffer: npt.NDArray[np.int16 | np.float32]) -> str:
     return base64.b64encode(buffer.tobytes()).decode("utf-8")
 
 
+async def _refresh_openai_client_api_key_if_supported(client: Any) -> None:
+    """Refresh callable/rotating OpenAI credentials before a manual websocket handshake."""
+    refresh_api_key = getattr(client, "_refresh_api_key", None)
+    if callable(refresh_api_key):
+        await refresh_api_key()
+
+
 async def _wait_for_event(
     event_queue: asyncio.Queue[dict[str, Any] | ErrorSentinel],
     expected_types: list[str],
@@ -303,6 +310,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
 
     async def _process_websocket_connection(self) -> None:
         try:
+            await _refresh_openai_client_api_key_if_supported(self._client)
             async with websockets.connect(
                 "wss://api.openai.com/v1/realtime?intent=transcription",
                 additional_headers={

--- a/tests/voice/test_openai_stt_api_key_refresh.py
+++ b/tests/voice/test_openai_stt_api_key_refresh.py
@@ -46,7 +46,11 @@ async def test_streamed_stt_refreshes_callable_api_key_before_handshake(monkeypa
         return _WebSocketContext()
 
     monkeypatch.setattr(openai_stt.websockets, "connect", connect)
-    session._setup_connection = AsyncMock(side_effect=RuntimeError("stop after handshake"))
+    monkeypatch.setattr(
+        session,
+        "_setup_connection",
+        AsyncMock(side_effect=RuntimeError("stop after handshake")),
+    )
 
     with pytest.raises(RuntimeError, match="stop after handshake"):
         await session._process_websocket_connection()

--- a/tests/voice/test_openai_stt_api_key_refresh.py
+++ b/tests/voice/test_openai_stt_api_key_refresh.py
@@ -1,0 +1,55 @@
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from openai import AsyncOpenAI
+
+from agents.voice import STTModelSettings, StreamedAudioInput
+from agents.voice.models import openai_stt
+from agents.voice.models.openai_stt import OpenAISTTTranscriptionSession
+
+
+class _RotatingClient:
+    def __init__(self) -> None:
+        self.api_key = ""
+        self.refresh_calls = 0
+
+    async def _refresh_api_key(self) -> None:
+        self.refresh_calls += 1
+        self.api_key = "sk-refreshed"
+
+
+class _WebSocketContext:
+    async def __aenter__(self) -> Any:
+        return object()
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_streamed_stt_refreshes_callable_api_key_before_handshake(monkeypatch) -> None:
+    client = _RotatingClient()
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=cast(AsyncOpenAI, client),
+        model="gpt-4o-mini-transcribe",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+
+    captured_headers: dict[str, str] = {}
+
+    def connect(_url: str, *, additional_headers: dict[str, str]) -> _WebSocketContext:
+        captured_headers.update(additional_headers)
+        return _WebSocketContext()
+
+    monkeypatch.setattr(openai_stt.websockets, "connect", connect)
+    session._setup_connection = AsyncMock(side_effect=RuntimeError("stop after handshake"))
+
+    with pytest.raises(RuntimeError, match="stop after handshake"):
+        await session._process_websocket_connection()
+
+    assert client.refresh_calls == 1
+    assert captured_headers["Authorization"] == "Bearer sk-refreshed"


### PR DESCRIPTION
### Summary

Refresh callable or rotating `AsyncOpenAI` API keys before opening the streamed STT WebSocket connection.

The OpenAI Python client supports API-key providers and refreshes them before normal requests. Streamed STT opens its WebSocket manually, however, and currently reads `client.api_key` directly for the `Authorization` header without invoking the client's refresh hook first. With a callable key provider, that can send the initial empty/stale key instead of the current credential.

The Responses WebSocket transport in this SDK already performs the same refresh before preparing its handshake.

### Fix

- invoke the OpenAI client's refresh hook when available before the streamed-STT handshake
- keep the refresh feature-detected so compatible custom clients without the hook remain unchanged
- build the existing authorization header only after refresh completes

### Test plan

Added a focused regression with a rotating client whose initial API key is empty and whose refresh hook installs a new key. The test verifies that:

- the refresh hook is called exactly once before the handshake
- the WebSocket `Authorization` header contains the refreshed key

The branch is based directly on current `main` at `7e55afc9500d12937687988f1e91e900dcb4ad09` and is 0 commits behind it. The production change is limited to the refresh helper and one pre-handshake call.

### Risk

Low. Static API keys behave as before. The additional work only occurs when the supplied OpenAI client exposes the refresh hook used for dynamic credentials.

### Issue number

None. Found while auditing streamed STT parity with the existing Responses WebSocket authentication path.