### PR TITLE
fix: validate Responses compaction modes before routing

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -29,6 +29,20 @@ DEFAULT_COMPACTION_THRESHOLD = 10
 _ALL_SESSION_ITEMS_LIMIT = 2_147_483_647
 
 OpenAIResponsesCompactionMode = Literal["previous_response_id", "input", "auto"]
+_VALID_COMPACTION_MODES: tuple[OpenAIResponsesCompactionMode, ...] = (
+    "auto",
+    "input",
+    "previous_response_id",
+)
+
+
+def _validate_compaction_mode(mode: object) -> OpenAIResponsesCompactionMode:
+    if issubclass(type(mode), str):
+        string_mode = cast(str, mode)
+        for valid_mode in _VALID_COMPACTION_MODES:
+            if str.__eq__(string_mode, valid_mode):
+                return valid_mode
+    raise ValueError("compaction_mode must be one of 'auto', 'input', or 'previous_response_id'.")
 
 
 def select_compaction_candidate_items(
@@ -122,11 +136,13 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         if not is_openai_model_name(model):
             raise ValueError(f"Unsupported model for OpenAI responses compaction: {model}")
 
+        validated_compaction_mode = _validate_compaction_mode(compaction_mode)
+
         self.session_id = session_id
         self.underlying_session = underlying_session
         self._client = client
         self.model = model
-        self.compaction_mode = compaction_mode
+        self.compaction_mode = validated_compaction_mode
         self.should_trigger_compaction = (
             should_trigger_compaction
             if should_trigger_compaction is not None
@@ -157,7 +173,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         store: bool | None,
         requested_mode: OpenAIResponsesCompactionMode | None,
     ) -> _ResolvedCompactionMode:
-        mode = requested_mode or self.compaction_mode
+        mode = _validate_compaction_mode(
+            requested_mode if requested_mode is not None else self.compaction_mode
+        )
         if (
             mode == "auto"
             and store is None
@@ -178,9 +196,13 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         When a run context is provided, the billed compaction request contributes to
         that run's usage totals.
         """
+        requested_mode = _validate_compaction_mode(
+            args["compaction_mode"]
+            if args is not None and "compaction_mode" in args
+            else self.compaction_mode
+        )
         if args and args.get("response_id"):
             self._response_id = args["response_id"]
-        requested_mode = args.get("compaction_mode") if args else None
         if args and "store" in args:
             store = args["store"]
             if store is False and self._response_id:
@@ -386,12 +408,12 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
     async def _defer_compaction(self, response_id: str, store: bool | None = None) -> None:
         if self._deferred_response_id is not None:
             return
-        compaction_candidate_items, session_items = await self._ensure_compaction_candidates()
         resolved_mode = self._resolve_compaction_mode_for_response(
             response_id=response_id,
             store=store,
             requested_mode=None,
         )
+        compaction_candidate_items, session_items = await self._ensure_compaction_candidates()
         should_compact = self.should_trigger_compaction(
             {
                 "response_id": response_id,

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -94,6 +94,21 @@ class TestSelectCompactionCandidateItems:
 
 
 class TestOpenAIResponsesCompactionSession:
+    class SpoofedCompactionMode(str):
+        def __eq__(self, other: object) -> bool:
+            return other == "auto"
+
+        __hash__ = str.__hash__
+
+    class SpoofedStringClass:
+        @property
+        def __class__(self) -> type[str]:
+            return str
+
+    class FailingRepr:
+        def __repr__(self) -> str:
+            raise RuntimeError("repr exploded")
+
     def test_client_preserves_falsy_default_client(self) -> None:
         mock_client = MagicMock()
         mock_client.__bool__.return_value = False
@@ -136,6 +151,35 @@ class TestOpenAIResponsesCompactionSession:
         )
         assert session.model == "gpt-4.1"
 
+    @pytest.mark.parametrize(
+        "invalid_mode",
+        [
+            pytest.param("", id="empty-string"),
+            pytest.param("typo", id="unknown-string"),
+            pytest.param(["auto"], id="non-string"),
+            pytest.param(SpoofedCompactionMode("unsupported"), id="spoofed-string-subclass"),
+            pytest.param(SpoofedStringClass(), id="spoofed-string-class"),
+            pytest.param(FailingRepr(), id="failing-repr"),
+        ],
+    )
+    def test_init_rejects_invalid_compaction_mode(self, invalid_mode: Any) -> None:
+        with pytest.raises(ValueError, match="compaction_mode must be one of"):
+            OpenAIResponsesCompactionSession(
+                session_id="test",
+                underlying_session=self.create_mock_session(),
+                compaction_mode=cast(Any, invalid_mode),
+            )
+
+    def test_init_canonicalizes_valid_string_subclass(self) -> None:
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=self.create_mock_session(),
+            compaction_mode=cast(Any, self.SpoofedCompactionMode("input")),
+        )
+
+        assert session.compaction_mode == "input"
+        assert type(session.compaction_mode) is str
+
     @pytest.mark.asyncio
     async def test_add_items_delegates(self) -> None:
         mock_session = self.create_mock_session()
@@ -176,6 +220,97 @@ class TestOpenAIResponsesCompactionSession:
 
         with pytest.raises(ValueError, match="previous_response_id compaction"):
             await session.run_compaction()
+
+    @pytest.mark.parametrize(
+        "invalid_mode",
+        [
+            pytest.param("", id="empty-string"),
+            pytest.param(SpoofedStringClass(), id="spoofed-string-class"),
+            pytest.param(FailingRepr(), id="failing-repr"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_run_compaction_rejects_invalid_mode_before_side_effects(
+        self, invalid_mode: Any
+    ) -> None:
+        mock_session = self.create_mock_session()
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock()
+        decision_hook = MagicMock(return_value=True)
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=mock_session,
+            client=mock_client,
+            should_trigger_compaction=decision_hook,
+        )
+        session._response_id = "resp-original"
+        session._last_unstored_response_id = "resp-original"
+
+        with pytest.raises(ValueError, match="compaction_mode must be one of"):
+            await session.run_compaction(
+                cast(
+                    Any,
+                    {
+                        "response_id": "resp-new",
+                        "compaction_mode": invalid_mode,
+                        "store": False,
+                        "force": True,
+                    },
+                )
+            )
+
+        assert session._response_id == "resp-original"
+        assert session._last_unstored_response_id == "resp-original"
+        mock_session.get_items.assert_not_awaited()
+        mock_client.responses.compact.assert_not_awaited()
+        decision_hook.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_compaction_revalidates_mutated_default_mode_before_side_effects(
+        self,
+    ) -> None:
+        mock_session = self.create_mock_session()
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock()
+        decision_hook = MagicMock(return_value=True)
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=mock_session,
+            client=mock_client,
+            should_trigger_compaction=decision_hook,
+        )
+        session._response_id = "resp-original"
+        session._last_unstored_response_id = "resp-original"
+        session.compaction_mode = cast(Any, "typo")
+
+        with pytest.raises(ValueError, match="compaction_mode must be one of"):
+            await session.run_compaction({"response_id": "resp-new", "store": False, "force": True})
+
+        assert session._response_id == "resp-original"
+        assert session._last_unstored_response_id == "resp-original"
+        mock_session.get_items.assert_not_awaited()
+        mock_client.responses.compact.assert_not_awaited()
+        decision_hook.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deferred_compaction_revalidates_mutated_default_mode_before_history_read(
+        self,
+    ) -> None:
+        mock_session = self.create_mock_session()
+        decision_hook = MagicMock(return_value=True)
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=mock_session,
+            should_trigger_compaction=decision_hook,
+        )
+        session.compaction_mode = cast(Any, "typo")
+
+        with pytest.raises(ValueError, match="compaction_mode must be one of"):
+            await session._defer_compaction("resp-new", store=True)
+
+        assert session._deferred_response_id is None
+        mock_session.get_items.assert_not_awaited()
+        decision_hook.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_run_compaction_honors_falsey_decision_hook(self) -> None:


### PR DESCRIPTION
### Summary

This pull request fixes `OpenAIResponsesCompactionSession` accepting unsupported compaction modes and silently routing them through input-based compaction, which could send locally stored session history instead of using a supplied response chain.

- Validate constructor, per-call, mutable-default, and deferred-compaction modes before response-state mutation, session-history reads, decision hooks, or API calls.
- Canonicalize supported string values and consistently raise `ValueError` for unsupported runtime objects without invoking caller-controlled equality, type-spoofing, or representation hooks.
- Preserve the existing routing behavior for `auto`, `input`, and `previous_response_id`.

### Test plan

- Added regression coverage for empty and unknown strings, non-string values, adversarial string subclasses, spoofed `__class__`, failing `__repr__`, post-construction mutation, and deferred compaction.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`; formatting, lint, type checking, and the full test suite passed.
- Completed the repository-required independent final review; both final reviewers returned clean verdicts on the verified fingerprint.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
