### PR TITLE
fix: close all cached websocket models after failures

### DIFF
--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -195,17 +195,34 @@ class OpenAIProvider(ModelProvider):
             await self._close_models(models)
             return
         if loop.is_running():
-            for model in models:
-                future = asyncio.run_coroutine_threadsafe(model.close(), loop)
-                await asyncio.wrap_future(future)
+            await self._close_models(models, owner_loop=loop)
             return
         # Do not run an inactive foreign loop on another thread. This also covers closed loops.
         # Close from the current loop and rely on model-specific cross-loop cleanup fallbacks.
         await self._close_models(models)
 
-    async def _close_models(self, models: list[Model]) -> None:
+    async def _close_models(
+        self,
+        models: list[Model],
+        *,
+        owner_loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        first_error: Exception | None = None
         for model in models:
-            await model.close()
+            try:
+                if owner_loop is None:
+                    await model.close()
+                else:
+                    future = asyncio.run_coroutine_threadsafe(model.close(), owner_loop)
+                    await asyncio.wrap_future(future)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+
+        if first_error is not None:
+            raise first_error
 
     def _clear_ws_loop_cache_entry(
         self, loop: asyncio.AbstractEventLoop, loop_cache: _WSLoopModelCache
@@ -302,7 +319,17 @@ class OpenAIProvider(ModelProvider):
         current_loop = self._get_running_loop()
         if current_loop is None:
             return
+        first_error: Exception | None = None
         for loop, loop_cache in list(self._ws_model_cache_by_loop.items()):
             models_to_close = self._collect_unique_cached_models(loop_cache, seen)
-            await self._close_ws_models_for_loop(loop, models_to_close, current_loop)
+            try:
+                await self._close_ws_models_for_loop(loop, models_to_close, current_loop)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
             self._clear_ws_loop_cache_entry(loop, loop_cache)
+
+        if first_error is not None:
+            raise first_error

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -467,6 +467,42 @@ def test_openai_provider_aclose_closes_websocket_models_from_other_loops(monkeyp
     assert model2_again is not model2
 
 
+@pytest.mark.asyncio
+async def test_openai_provider_aclose_continues_and_preserves_first_failure(monkeypatch):
+    class DummyAsyncOpenAI:
+        pass
+
+    provider = OpenAIProvider(
+        use_responses=True,
+        use_responses_websocket=True,
+        openai_client=DummyAsyncOpenAI(),  # type: ignore[arg-type]
+    )
+
+    models = [provider.get_model(name) for name in ("gpt-4", "gpt-5", "gpt-6")]
+    assert all(isinstance(model, OpenAIResponsesWSModel) for model in models)
+    model1, model2, model3 = cast(list[OpenAIResponsesWSModel], models)
+
+    first_error = RuntimeError("first close failed")
+    second_error = RuntimeError("second close failed")
+    closed_models: list[OpenAIResponsesWSModel] = []
+
+    async def fake_close(self: OpenAIResponsesWSModel) -> None:
+        closed_models.append(self)
+        if self is model1:
+            raise first_error
+        if self is model3:
+            raise second_error
+
+    monkeypatch.setattr(OpenAIResponsesWSModel, "close", fake_close)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await provider.aclose()
+
+    assert exc_info.value is first_error
+    assert closed_models == [model1, model2, model3]
+    assert list(provider._ws_model_cache_by_loop.items()) == []
+
+
 def test_openai_provider_aclose_closes_websocket_models_when_original_loop_is_closed(monkeypatch):
     class DummyAsyncOpenAI:
         pass


### PR DESCRIPTION
### Summary

This pull request fixes `OpenAIProvider.aclose()` so a failure while closing one cached WebSocket model no longer prevents the provider from attempting to close the remaining unique models.

The provider preserves the first normal close exception, clears processed loop caches, and keeps cleanup on a running owner loop when possible. Cancellation and other `BaseException` values remain fail-fast, and the shared `AsyncOpenAI` client remains open.

### Test plan

- Ran `.agents/skills/code-change-verification/scripts/run.sh` with all formatting, lint, type-checking, and test steps passing.
- Completed two independent final reviews of the lifecycle, cancellation, compatibility, and test boundaries.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
