### PR TITLE
examples: add verification guardrail example (verify before act)

### DIFF
--- a/examples/verification_guardrail/README.md
+++ b/examples/verification_guardrail/README.md
@@ -1,0 +1,55 @@
+# Verification guardrail
+
+An OpenAI Agents SDK example demonstrating the **verify before act** pattern: an agent may only claim (and finalize) a delivery after deterministic verification passes, and an output guardrail trips if it claims completion without a verification receipt.
+
+## What this example demonstrates
+
+- A minimal **MCP server** exposes `verify_claim(claimType, evidence)`.
+- **Tool-level enforcement**: `finalize_delivery` re-runs the verification core and refuses unless it passes. This is the real gate — guardrails are the visible layer, tool checks are the binding one.
+- **Output guardrail**: if the agent's final output claims the delivery is finalized without a `receiptId`, the run trips.
+- The scenario is intentionally generic (delivery confirmation) and runs with a **mock evidence service** — no API keys, no web3. Swap in your own verifier by replacing `verification_core.py`.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `verification_core.py` | Deterministic six-step verification chain (capture → integrity → authenticity → consistency → judgment → anchor) + mock delivery service |
+| `verify_claim_mcp_server.py` | FastMCP server exposing `verify_claim` |
+| `agent.py` | OpenAI Agents SDK agent: `finalize_delivery` tool + output guardrail + MCP server |
+| `demo.py` | Run everything: MCP calls, tool enforcement, guardrail check, and (with a key) the live agent |
+
+## Setup
+
+```bash
+python -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+## Run
+
+```bash
+.venv/bin/python demo.py
+```
+
+Parts 1-3 are deterministic and need no API key. Part 4 runs the live agent and requires a valid `OPENAI_API_KEY`.
+
+To run Part 4 against an OpenAI-compatible provider (e.g. DeepSeek), set `DEEPSEEK_API_KEY` (optionally `OPENAI_BASE_URL` and `OPENAI_MODEL`). When a custom model is used, the demo falls back to plain-text output, since some providers do not support structured outputs.
+
+## How it works
+
+```text
+Agent receives a delivery claim + evidence
+        │
+        ▼
+verify_claim (MCP) → verdict + receipt        # discoverable, optional pre-check
+        │
+        ▼
+finalize_delivery (tool) → re-verifies        # binding: refuses without a pass
+        │
+        ▼
+Output guardrail → trips if "finalized" is claimed without a receiptId
+```
+
+## Extending
+
+Replace `verification_core.run_delivery_verification` with any verifier (real carrier API, image forensics, on-chain checks, human review webhook). The MCP tool, the tool-level gate, and the guardrail stay the same.

--- a/examples/verification_guardrail/agent.py
+++ b/examples/verification_guardrail/agent.py
@@ -1,0 +1,213 @@
+"""OpenAI Agents SDK demo: verification guardrail.
+
+Pattern demonstrated: verify before act. The agent may query verification via
+the mounted MCP server, but finalizing a delivery re-runs the deterministic
+verification core inside the tool and refuses without a pass. An output
+guardrail trips if the agent claims completion without a receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+from pydantic import BaseModel
+from verification_core import run_delivery_verification
+
+from agents import Agent, GuardrailFunctionOutput, Runner, function_tool, output_guardrail
+from agents.mcp import MCPServerStdio
+
+
+class DeliveryResult(BaseModel):
+    status: str
+    order_ref: str
+    receipt_id: str | None = None
+
+
+def build_model():
+    """Return an OpenAI-compatible model when configured, else None.
+
+    Set DEEPSEEK_API_KEY (optionally OPENAI_BASE_URL) to run the demo against
+    DeepSeek or another OpenAI-compatible endpoint instead of OpenAI.
+    """
+    key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+    if not key:
+        return None
+    from openai import AsyncOpenAI
+
+    from agents import OpenAIChatCompletionsModel
+
+    client = AsyncOpenAI(
+        api_key=key,
+        base_url=os.environ.get("OPENAI_BASE_URL", "https://api.deepseek.com"),
+    )
+    return OpenAIChatCompletionsModel(
+        model=os.environ.get("OPENAI_MODEL", "deepseek-chat"),
+        openai_client=client,
+    )
+
+
+def finalize_delivery_fn(
+    order_ref: str,
+    captured_at: str,
+    gps_lat: float,
+    gps_lng: float,
+    image_hash: str,
+) -> str:
+    """Finalize a delivery. Refuses unless deterministic verification passes.
+
+    Args:
+        order_ref: Delivery reference id (e.g. ORD-1001).
+        captured_at: ISO timestamp when the delivery photo was captured.
+        gps_lat / gps_lng: GPS coordinates of the claimed delivery location.
+        image_hash: sha256 hash of the delivery photo.
+    """
+    evidence = {
+        "time": {"capturedAt": captured_at},
+        "location": {"gps": {"lat": gps_lat, "lng": gps_lng}},
+        "content": {"referenceId": order_ref, "imageHashes": [normalize_image_hash(image_hash)]},
+        "process": {"source": "in_app_capture"},
+    }
+    record = run_delivery_verification(evidence)
+    if record["verdict"] == "pass":
+        return json.dumps(
+            {
+                "status": "finalized",
+                "orderRef": order_ref,
+                "receiptId": record["receipt"]["receiptId"],
+                "checks": record["checks"],
+            }
+        )
+    failed = [c for c in record["checks"] if not c.get("passed")]
+    return json.dumps({"status": "refused", "reasons": failed, "missing": record["missing"]})
+
+
+finalize_delivery = function_tool(finalize_delivery_fn)
+
+
+def normalize_image_hash(value: str) -> str:
+    """Accept a bare 64-hex hash and normalize it to sha256:<hex>."""
+    cleaned = str(value or "").strip().lower()
+    if re.fullmatch(r"[0-9a-f]{64}", cleaned):
+        return f"sha256:{cleaned}"
+    return cleaned
+
+
+async def completion_guardrail_fn(context, agent: Agent, output) -> GuardrailFunctionOutput:
+    """Trip if the agent claims completion without a verification receipt."""
+    if isinstance(output, DeliveryResult):
+        claims_done = output.status == "finalized"
+        has_receipt = bool(output.receipt_id)
+        detail = f"status={output.status} receipt={output.receipt_id}"
+    else:
+        text = str(output)
+        lower = text.lower()
+        has_receipt = "receiptid" in lower or "receipt_id" in lower
+        refusal_markers = [
+            "refused",
+            "cannot be finalized",
+            "cannot finalize",
+            "not finalized",
+            "verification failed",
+            "could not finalize",
+            "was refused",
+        ]
+        is_refusal = any(marker in lower for marker in refusal_markers)
+        claims_done = ("finalized" in lower or "delivered" in lower) and not is_refusal
+        detail = text[:120]
+    if claims_done and not has_receipt:
+        return GuardrailFunctionOutput(
+            tripwire_triggered=True,
+            output_info={
+                "reason": "completion claimed without a verification receipt",
+                "output": detail,
+            },
+        )
+    return GuardrailFunctionOutput(tripwire_triggered=False, output_info={})
+
+
+completion_guardrail = output_guardrail(completion_guardrail_fn)
+
+
+def build_agent(mcp_server: MCPServerStdio, model=None) -> Agent:
+    structured = model is None
+    base_instructions = (
+        "You finalize delivery claims. Evidence: order reference, capture timestamp, "
+        "GPS, image hash. You may call verify_claim (MCP) to pre-check. To finalize, "
+        "call finalize_delivery with the exact evidence. "
+    )
+    if structured:
+        instructions = base_instructions + (
+            "Return the structured result: set status to 'finalized' ONLY if "
+            "finalize_delivery returned 'finalized', and ALWAYS include its receiptId "
+            "in receipt_id. If finalize_delivery is refused, set status to 'refused' "
+            "and receipt_id to null. Never claim completion without a receipt_id."
+        )
+    else:
+        instructions = base_instructions + (
+            "NEVER claim a delivery is finalized unless finalize_delivery returns "
+            "'finalized'. When it does, end your final answer with exactly: "
+            "Finalized receiptId=r_<id>. If it is refused, end with: Refused."
+        )
+    kwargs = {
+        "name": "delivery-agent",
+        "instructions": instructions,
+        "tools": [finalize_delivery],
+        "mcp_servers": [mcp_server],
+        "output_guardrails": [completion_guardrail],
+    }
+    if structured:
+        kwargs["output_type"] = DeliveryResult
+    if model is not None:
+        kwargs["model"] = model
+    return Agent(**kwargs)
+
+
+async def run_scenarios(mcp_server: MCPServerStdio, model=None) -> None:
+    agent = build_agent(mcp_server, model)
+
+    print("=== Scenario A: valid evidence ===")
+    result_a = await Runner.run(
+        agent,
+        "The rider reports order ORD-1001 was delivered. Evidence: captured at "
+        "2026-08-20T12:30:00Z, gps 31.23,121.47, image hash "
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa. Verify and finalize.",
+    )
+    print("A output:", result_a.final_output)
+
+    print("\n=== Scenario B: invalid evidence (unknown order) ===")
+    result_b = await Runner.run(
+        agent,
+        "The rider reports order ORD-9999 was delivered. Evidence: captured at "
+        "2026-08-20T12:30:00Z, gps 31.23,121.47, image hash "
+        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb. Verify and finalize.",
+    )
+    print("B output:", result_b.final_output)
+
+    print("\n=== Guardrail direct check: completion claim without receipt must trip ===")
+    check = await completion_guardrail(agent, "The delivery is finalized.")
+    print("tripwire_triggered:", check.tripwire_triggered)
+    assert check.tripwire_triggered is True
+    print("Guardrail OK.")
+
+
+async def main() -> None:
+    from pathlib import Path
+
+    model = build_model()
+    server = MCPServerStdio(
+        params={
+            "command": sys.executable,
+            "args": [str(Path(__file__).parent / "verify_claim_mcp_server.py")],
+        }
+    )
+    async with server:
+        await run_scenarios(server, model)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/examples/verification_guardrail/demo.py
+++ b/examples/verification_guardrail/demo.py
@@ -1,0 +1,137 @@
+"""Run the demo end to end.
+
+Parts 1-3 (MCP verify, tool-level enforcement, guardrail) need no API key and
+are deterministic. Part 4 runs the live OpenAI Agents SDK agent when a valid
+OPENAI_API_KEY is available.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+VALID_EVIDENCE = {
+    "time": {"capturedAt": "2026-08-20T12:30:00Z"},
+    "location": {"gps": {"lat": 31.23, "lng": 121.47}},
+    "content": {"referenceId": "ORD-1001", "imageHashes": [f"sha256:{'a' * 64}"]},
+    "process": {"source": "in_app_capture"},
+}
+INVALID_EVIDENCE = {
+    "time": {"capturedAt": "2026-08-20T12:30:00Z"},
+    "location": {"gps": {"lat": 31.23, "lng": 121.47}},
+    "content": {"referenceId": "ORD-9999", "imageHashes": [f"sha256:{'b' * 64}"]},
+    "process": {"source": "in_app_capture"},
+}
+
+VALID_PROMPT = (
+    "The rider reports order ORD-1001 was delivered. Evidence: captured at "
+    "2026-08-20T12:30:00Z, gps 31.23,121.47, image hash "
+    f"sha256:{'a' * 64}. Verify and finalize."
+)
+INVALID_PROMPT = (
+    "The rider reports order ORD-9999 was delivered. Evidence: captured at "
+    "2026-08-20T12:30:00Z, gps 31.23,121.47, image hash "
+    f"sha256:{'b' * 64}. Verify and finalize."
+)
+
+
+async def part1_mcp() -> None:
+    """Call verify_claim through the MCP server directly (no LLM, no key)."""
+    print("=== Part 1: verify_claim via MCP server ===")
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=[str(Path(__file__).parent / "verify_claim_mcp_server.py")],
+    )
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            for label, evidence in [("valid", VALID_EVIDENCE), ("invalid", INVALID_EVIDENCE)]:
+                result = await session.call_tool(
+                    "verify_claim",
+                    {"claimType": "delivery_confirmed", "evidence": evidence},
+                )
+                text = result.content[0].text if result.content else "{}"
+                record = json.loads(text)
+                receipt = record.get("receipt", {}).get("receiptId", "no-receipt")
+                print(f"  {label}: verdict={record.get('verdict')} receipt={receipt}")
+
+
+def part2_tool() -> None:
+    """finalize_delivery refuses unless deterministic verification passes."""
+    print("=== Part 2: tool-level enforcement (finalize_delivery) ===")
+    from agent import finalize_delivery_fn
+
+    ok = json.loads(
+        finalize_delivery_fn(
+            "ORD-1001", "2026-08-20T12:30:00Z", 31.23, 121.47, f"sha256:{'a' * 64}"
+        )
+    )
+    refused = json.loads(
+        finalize_delivery_fn(
+            "ORD-9999", "2026-08-20T12:30:00Z", 31.23, 121.47, f"sha256:{'b' * 64}"
+        )
+    )
+    print(f"  valid evidence -> {ok['status']} receiptId={ok.get('receiptId', 'none')}")
+    print(f"  invalid evidence -> {refused['status']} reasons={len(refused.get('reasons', []))}")
+
+
+async def part3_guardrail() -> None:
+    """Output guardrail trips when completion is claimed without a receipt."""
+    print("=== Part 3: output guardrail (no receipt -> trip) ===")
+    from agent import DeliveryResult, completion_guardrail_fn
+
+    check = await completion_guardrail_fn(
+        None, None, DeliveryResult(status="finalized", order_ref="ORD-1001")
+    )
+    print(f"  'finalized' without receiptId -> tripwire={check.tripwire_triggered}")
+    assert check.tripwire_triggered is True
+    check_ok = await completion_guardrail_fn(
+        None, None, DeliveryResult(status="finalized", order_ref="ORD-1001", receipt_id="r_1")
+    )
+    print(f"  'finalized' with receiptId -> tripwire={check_ok.tripwire_triggered}")
+    assert check_ok.tripwire_triggered is False
+
+
+async def part4_live_agent() -> None:
+    """Live OpenAI Agents SDK run (needs a valid OPENAI_API_KEY)."""
+    print("=== Part 4: live OpenAI Agents SDK agent ===")
+    if not os.environ.get("OPENAI_API_KEY", "").strip():
+        print("  skipped: OPENAI_API_KEY not set")
+        return
+    from agent import build_agent, build_model
+
+    from agents import Runner
+    from agents.mcp import MCPServerStdio
+
+    server = MCPServerStdio(
+        params={
+            "command": sys.executable,
+            "args": [str(Path(__file__).parent / "verify_claim_mcp_server.py")],
+        }
+    )
+    try:
+        async with server:
+            agent = build_agent(server, build_model())
+            result_a = await Runner.run(agent, VALID_PROMPT)
+            print("  A (valid):", result_a.final_output)
+            result_b = await Runner.run(agent, INVALID_PROMPT)
+            print("  B (invalid):", result_b.final_output)
+    except Exception as err:  # noqa: BLE001 - keep the demo runnable without a valid key
+        print(f"  skipped: {type(err).__name__}: {str(err)[:160]}")
+
+
+async def main() -> None:
+    await part1_mcp()
+    part2_tool()
+    await part3_guardrail()
+    await part4_live_agent()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/verification_guardrail/requirements.txt
+++ b/examples/verification_guardrail/requirements.txt
@@ -1,0 +1,3 @@
+openai-agents>=0.3.0
+mcp>=1.2,<2
+openai>=1.60.0

--- a/examples/verification_guardrail/verification_core.py
+++ b/examples/verification_guardrail/verification_core.py
@@ -1,0 +1,167 @@
+"""Shared verification core for the delivery-confirmed demo.
+
+This module is imported by both the MCP server (verify_claim tool) and the
+agent's finalize tool so enforcement is deterministic and framework-independent.
+In production, swap ``check_delivery`` for a real carrier / delivery system API.
+"""
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+
+MOCK_DELIVERIES = {
+    "ORD-1001": {
+        "status": "delivered",
+        "delivered_at": "2026-08-20T12:00:00Z",
+        "order_id": "ORD-1001",
+    },
+    "ORD-1002": {"status": "in_transit", "delivered_at": "", "order_id": "ORD-1002"},
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def check_delivery(reference_id: str) -> dict:
+    """Look up a delivery reference (mock). Returns found/status/delivered_at."""
+    record = MOCK_DELIVERIES.get(str(reference_id or "").strip().upper())
+    if not record:
+        return {"found": False, "status": "not_found"}
+    return {
+        "found": True,
+        "status": record["status"],
+        "delivered_at": record["delivered_at"],
+        "order_id": record["order_id"],
+    }
+
+
+def plausible_gps(lat, lng) -> bool:
+    try:
+        return abs(float(lat)) <= 90 and abs(float(lng)) <= 180
+    except (TypeError, ValueError):
+        return False
+
+
+def valid_image_hash(value) -> bool:
+    return bool(re.fullmatch(r"sha256:[0-9a-f]{64}", str(value or "").strip().lower()))
+
+
+def hash_json(value) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def run_delivery_verification(evidence: dict) -> dict:
+    """Run the six-step verification chain for a delivery claim."""
+    content = evidence.get("content") or {}
+    time_dim = evidence.get("time") or {}
+    location = evidence.get("location") or {}
+    process = evidence.get("process") or {}
+    ref = content.get("referenceId")
+    captured_at = time_dim.get("capturedAt")
+    gps = location.get("gps") or {}
+    hashes = content.get("imageHashes") or []
+    source = process.get("source") or "unknown"
+
+    checks = []
+    checks.append(
+        {
+            "name": "capture",
+            "passed": bool(ref and captured_at),
+            "detail": f"order {ref} captured at {captured_at}"
+            if ref and captured_at
+            else "referenceId and capturedAt are required",
+        }
+    )
+    checks.append(
+        {
+            "name": "integrity",
+            "passed": len(hashes) > 0 and all(valid_image_hash(h) for h in hashes),
+            "detail": f"{len(hashes)} image hash(es) present",
+        }
+    )
+    checks.append(
+        {
+            "name": "authenticity",
+            "passed": source in ("in_app_capture", "unknown"),
+            "detail": f"capture source: {source}",
+        }
+    )
+
+    delivery = check_delivery(ref or "")
+    consistency_ok = False
+    detail = "delivery reference not found"
+    if delivery["found"]:
+        if delivery["status"] == "delivered":
+            try:
+                captured = datetime.fromisoformat(captured_at.replace("Z", "+00:00"))
+                delivered = datetime.fromisoformat(delivery["delivered_at"].replace("Z", "+00:00"))
+                consistency_ok = abs((captured - delivered).total_seconds()) < 3600
+                detail = (
+                    f"order {ref} delivered, capture within 1h"
+                    if consistency_ok
+                    else "capture time far from delivery time"
+                )
+            except ValueError:
+                detail = "could not parse timestamps"
+        else:
+            detail = f"order {ref} is {delivery['status']}, not delivered"
+    checks.append({"name": "consistency", "passed": consistency_ok, "detail": detail})
+
+    gps_ok = plausible_gps(gps.get("lat"), gps.get("lng")) if gps else False
+    checks.append(
+        {
+            "name": "judgment",
+            "passed": gps_ok,
+            "detail": f"gps {gps} plausible"
+            if gps_ok
+            else "gps coordinates implausible or missing",
+        }
+    )
+    checks.append({"name": "anchor", "passed": True, "detail": "receipt issued by engine"})
+
+    missing = []
+    if not captured_at:
+        missing.append("time")
+    if not gps:
+        missing.append("location")
+    if not ref:
+        missing.append("content")
+
+    failed = [c for c in checks if not c.get("passed")]
+    if missing:
+        verdict = "resubmit"
+    elif failed:
+        verdict = "fail"
+    else:
+        verdict = "pass"
+
+    record = {
+        "verificationId": f"v_{len(_RECEIPTS) + 1}",
+        "claimType": "delivery_confirmed",
+        "policy": {"policyId": "delivery_confirmed", "version": 1, "level": "L3"},
+        "status": {"pass": "passed", "fail": "failed", "resubmit": "resubmission"}[verdict],
+        "verdict": verdict,
+        "checks": checks,
+        "missing": missing,
+        "evidence": evidence,
+    }
+    if verdict in ("pass", "fail"):
+        receipt = {
+            "schemaVersion": 1,
+            "receiptId": f"r_{len(_RECEIPTS) + 1}",
+            "verificationId": record["verificationId"],
+            "claimHash": hash_json({"claimType": "delivery_confirmed"}),
+            "evidenceHash": hash_json(evidence),
+            "checksHash": hash_json(checks),
+            "verdict": verdict,
+            "signer": "ai2human-verify",
+            "issuedAt": _now(),
+        }
+        record["receipt"] = receipt
+        _RECEIPTS[receipt["receiptId"]] = record
+    return record
+
+
+_RECEIPTS: dict[str, dict] = {}

--- a/examples/verification_guardrail/verify_claim_mcp_server.py
+++ b/examples/verification_guardrail/verify_claim_mcp_server.py
@@ -1,0 +1,24 @@
+"""Minimal MCP server exposing verify_claim for the demo."""
+
+from mcp.server.fastmcp import FastMCP
+from verification_core import run_delivery_verification
+
+mcp = FastMCP("ai2human-verify-demo")
+
+
+@mcp.tool()
+def verify_claim(claimType: str, evidence: dict) -> dict:
+    """Verify a claim against an evidence bundle.
+
+    Supports claimType="delivery_confirmed". Evidence uses six dimensions:
+    identity, time, location, content, process, corroboration.
+    Returns verdict (pass/fail/resubmit), per-check results, and a receipt
+    when the claim is finalized.
+    """
+    if claimType != "delivery_confirmed":
+        return {"error": f"Unknown claimType '{claimType}'. Supported: delivery_confirmed"}
+    return run_delivery_verification(evidence)
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")


### PR DESCRIPTION
# PR Description

**Title:** examples: add verification guardrail example (verify before act)

**Body:**

Agents often claim completion without proof ("your package is delivered") — a well-known hallucination failure. This example shows a generic, framework-native pattern to close that gap:

- A minimal MCP server exposes `verify_claim(claimType, evidence)`
- An output guardrail trips when the agent claims "done" without a passed verification receipt
- The `finalize_delivery` tool refuses to run unless deterministic verification passes (guardrail + tool-level enforcement)

The scenario (delivery confirmation) is intentionally generic and runs with a mock evidence service — no API keys beyond the standard OpenAI model call, no web3. It demonstrates the `verify before act` pattern that any agent team can adapt by swapping in their own verifier.

Verified locally: `demo.py` runs both the pass and blocked paths; the guardrail direct check trips as expected.
