### PR TITLE
fix(voice): accept async API-key providers

### DIFF
--- a/src/agents/voice/models/openai_model_provider.py
+++ b/src/agents/voice/models/openai_model_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx2
@@ -38,7 +39,7 @@ class OpenAIVoiceModelProvider(VoiceModelProvider):
     def __init__(
         self,
         *,
-        api_key: str | None = None,
+        api_key: str | Callable[[], Awaitable[str]] | None = None,
         base_url: str | None = None,
         openai_client: AsyncOpenAI | None = None,
         organization: str | None = None,
@@ -48,8 +49,8 @@ class OpenAIVoiceModelProvider(VoiceModelProvider):
         """Create a new OpenAI voice model provider.
 
         Args:
-            api_key: The API key to use for the OpenAI client. If not provided, we will use the
-                default API key.
+            api_key: The API key or async API-key provider to use for the OpenAI client. If not
+                provided, we will use the default API key.
             base_url: The base URL to use for the OpenAI client. If not provided, we will use the
                 default base URL.
             openai_client: An optional OpenAI client to use. If not provided, we will create a new

--- a/tests/voice/test_openai_model_provider.py
+++ b/tests/voice/test_openai_model_provider.py
@@ -86,3 +86,25 @@ def test_voice_provider_explicit_options_override_default_client(
 
     assert provider._get_client() is created_client
     assert captured_kwargs[option_name] == option_value
+
+
+def test_voice_provider_accepts_async_api_key_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def api_key_provider() -> str:
+        return "sk-rotating"
+
+    created_client = cast(openai.AsyncOpenAI, object())
+    captured_kwargs: dict[str, Any] = {}
+
+    def create_client(**kwargs: Any) -> openai.AsyncOpenAI:
+        captured_kwargs.update(kwargs)
+        return created_client
+
+    monkeypatch.setattr(openai_model_provider, "AsyncOpenAI", create_client)
+    monkeypatch.setattr(openai_model_provider, "shared_http_client", object)
+
+    provider = OpenAIVoiceModelProvider(api_key=api_key_provider)
+
+    assert provider._get_client() is created_client
+    assert captured_kwargs["api_key"] is api_key_provider


### PR DESCRIPTION
### Summary

Allow `OpenAIVoiceModelProvider(api_key=...)` to accept the async API-key provider shape supported by `AsyncOpenAI`.

The current OpenAI Python client accepts `Callable[[], Awaitable[str]]` for `AsyncOpenAI(api_key=...)` and refreshes that credential before requests. The voice provider already passes its stored `api_key` through unchanged, and streamed STT now refreshes dynamic credentials before its manual WebSocket handshake, but the public provider constructor still types `api_key` as `str | None`. Valid rotating-credential configurations therefore require a type-ignore or a manually constructed client.

### Fix

- widen the voice provider's `api_key` parameter to `str | Callable[[], Awaitable[str]] | None`
- document that an async API-key provider is accepted
- leave client construction and static-key behavior unchanged

### Test plan

Added a focused regression that supplies an async key provider through the public `OpenAIVoiceModelProvider` constructor and verifies the exact callable is forwarded to `AsyncOpenAI`.

The regression intentionally uses the public constructor without a cast, so repository typechecking covers the contract in addition to the runtime assertion.

The branch is based directly on current `main` at `e26a7d8aed59141ee13fb0a1fa16445017b0ccf1` and is 0 commits behind it.

### Risk

Very low. String API keys and default-key resolution are unchanged. This widens only the accepted type for a value that the provider already forwards directly to `AsyncOpenAI`.

### Issue number

None. Found while checking dynamic-credential parity after streamed STT gained callable-key refresh support.