### PR TITLE
fix(extensions): nest extra_body on the any-llm chat path

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -1363,12 +1363,12 @@ class AnyLLMModel(Model):
 
     def _build_chat_extra_kwargs(self, model_settings: ModelSettings) -> dict[str, Any]:
         extra_kwargs: dict[str, Any] = {}
-        if model_settings.extra_query:
+        if model_settings.extra_query is not None:
             extra_kwargs["extra_query"] = copy(model_settings.extra_query)
-        if model_settings.metadata:
+        if model_settings.metadata is not None:
             extra_kwargs["metadata"] = copy(model_settings.metadata)
-        if isinstance(model_settings.extra_body, dict):
-            extra_kwargs.update(model_settings.extra_body)
+        if model_settings.extra_body is not None:
+            extra_kwargs["extra_body"] = copy(model_settings.extra_body)
         if model_settings.extra_args:
             extra_kwargs.update(model_settings.extra_args)
         return extra_kwargs

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -373,6 +373,47 @@ async def test_any_llm_chat_preserves_falsy_reasoning(monkeypatch: pytest.Monkey
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_any_llm_chat_nests_extra_body_instead_of_flattening(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=_chat_completion("Hello"))
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    extra_body = {"cached_content": "some_cache", "foo": 123, "temperature": 0.9}
+    settings = ModelSettings(
+        temperature=0.1,
+        extra_body=extra_body,
+        extra_query={},
+        metadata={},
+    )
+
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=settings,
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    call = provider.chat_calls[0]
+    assert call["temperature"] == 0.1
+    assert call["extra_body"] == extra_body
+    assert call["extra_body"] is not extra_body
+    assert call["extra_query"] == {}
+    assert call["metadata"] == {}
+    assert "cached_content" not in call
+    assert "foo" not in call
+    extra_body["foo"] = 999
+    assert call["extra_body"]["foo"] == 123
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider_name", ["gemini", "vertexai"])
 @pytest.mark.parametrize("options_type", ["unset", "dictionary", "model"])
 async def test_any_llm_google_chat_headers_use_http_options(


### PR DESCRIPTION
### Summary

This pull request nests `ModelSettings.extra_body` on the AnyLLM chat Completions path instead of flattening it into top-level `acompletion` kwargs.

The Responses path and LiteLLM already copy `extra_body` under `extra_body`. The chat helper merged the mapping into kwargs, so provider fields such as `cached_content` became top-level arguments and a nested `temperature` collided with the explicit `temperature=` parameter (`TypeError: got multiple values for keyword argument 'temperature'`). Empty `extra_query` and `metadata` mappings are now forwarded when set, matching the Responses helper. `extra_args` still flatten as top-level kwargs.

### Test plan

- [x] `uv run pytest -q tests/models/test_any_llm_model.py`
- [x] `make format && make lint && make typecheck`
- [x] Confirmed extra_body stays nested, is copied, and does not override `temperature`

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed format, lint, typecheck, and focused AnyLLM tests pass
- [ ] If using Codex, I've run `/review` before submitting this PR