### PR TITLE
fix(core): fail closed on empty tool arguments

### DIFF
--- a/src/agents/util/_approvals.py
+++ b/src/agents/util/_approvals.py
@@ -17,9 +17,11 @@ def _reject_nonstandard_json_constant(value: str) -> NoReturn:
 
 def parse_function_tool_arguments(arguments: str | None) -> dict[str, Any] | None:
     """Return parsed object arguments, or None when an approval policy cannot inspect them."""
+    if arguments is None or not arguments.strip():
+        return None
     try:
         parsed = json.loads(
-            arguments or "{}",
+            arguments,
             parse_constant=_reject_nonstandard_json_constant,
         )
     except ValueError:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -3125,6 +3125,7 @@ class TestToolCallExecution:
     @pytest.mark.parametrize(
         "arguments",
         [
+            "",
             '{"subject": "refund"',
             "null",
             "[]",

--- a/tests/test_hitl_error_scenarios.py
+++ b/tests/test_hitl_error_scenarios.py
@@ -919,6 +919,7 @@ async def test_function_needs_approval_invalid_type_raises() -> None:
 @pytest.mark.parametrize(
     "arguments",
     [
+        "",
         '{"subject": "refund"',
         "null",
         "[]",


### PR DESCRIPTION
### Summary

This pull request treats missing or blank function-tool argument strings as uninspectable for callable `needs_approval` policies.

`parse_function_tool_arguments` previously used `arguments or \"{}\"`, so `\"\"` and `None` became an empty object. A content gate such as `\"refund\" in params.get(\"subject\", \"\")` then returned `False` and the tool ran without interruption. Invalid JSON already failed closed after #3867; empty/missing argument strings now do the same. An explicit `\"{}\"` payload is still a valid empty object.

The same helper is used by Runner tool execution and Realtime session tool calls.

### Test plan

- [x] `uv run pytest -q tests/test_hitl_error_scenarios.py::test_callable_function_approval_fails_closed_for_invalid_arguments tests/realtime/test_session.py::TestToolCallExecution::test_callable_function_approval_fails_closed_for_invalid_arguments`
- [x] `make format && make lint && make typecheck`
- [x] Confirmed empty argument strings interrupt and do not invoke the approval predicate

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed format, lint, typecheck, and focused approval tests pass
- [ ] If using Codex, I've run `/review` before submitting this PR