### PR TITLE
fix: validate realtime playback durations

### DIFF
--- a/src/agents/realtime/model.py
+++ b/src/agents/realtime/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import math
 from collections.abc import Callable
 
 from typing_extensions import NotRequired, TypedDict
@@ -57,12 +58,18 @@ class RealtimePlaybackTracker:
             item_content_index: The index of the audio content in `item.content`
             ms: The number of milliseconds of audio that have been played.
         """
+        if not math.isfinite(ms) or ms < 0:
+            raise ValueError("Playback duration must be a finite, non-negative number.")
+
         if self._current_item != (item_id, item_content_index):
+            new_elapsed_ms = ms
             self._current_item = (item_id, item_content_index)
-            self._elapsed_ms = ms
         else:
             assert self._elapsed_ms is not None
-            self._elapsed_ms += ms
+            new_elapsed_ms = self._elapsed_ms + ms
+        if not math.isfinite(new_elapsed_ms):
+            raise ValueError("Playback duration total must be finite.")
+        self._elapsed_ms = new_elapsed_ms
 
     def on_interrupted(self) -> None:
         """Called by the model when the audio playback has been interrupted."""

--- a/tests/realtime/test_playback_tracker.py
+++ b/tests/realtime/test_playback_tracker.py
@@ -1,3 +1,4 @@
+import math
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -16,6 +17,28 @@ class TestPlaybackTracker:
     def model(self):
         """Create a fresh model instance for each test."""
         return OpenAIRealtimeWebSocketModel()
+
+    @pytest.mark.parametrize("duration", [-1.0, math.nan, math.inf, -math.inf])
+    def test_tracker_rejects_invalid_playback_duration(self, duration: float) -> None:
+        tracker = RealtimePlaybackTracker()
+
+        with pytest.raises(ValueError, match="finite, non-negative"):
+            tracker.on_play_ms("item", 0, duration)
+
+        assert tracker.get_state() == {
+            "current_item_id": None,
+            "current_item_content_index": None,
+            "elapsed_ms": None,
+        }
+
+    def test_tracker_rejects_overflowing_playback_total(self) -> None:
+        tracker = RealtimePlaybackTracker()
+        tracker.on_play_ms("item", 0, 1e308)
+
+        with pytest.raises(ValueError, match="total must be finite"):
+            tracker.on_play_ms("item", 0, 1e308)
+
+        assert tracker.get_state()["elapsed_ms"] == 1e308
 
     @pytest.mark.asyncio
     async def test_interrupt_timing_with_custom_playback_tracker(self, model):


### PR DESCRIPTION
### Summary

`RealtimePlaybackTracker.on_play_ms` accepted negative, non-finite, and overflowing cumulative playback durations. A later interruption could then fail while converting the invalid elapsed time to the integer `audio_end_ms` sent to Realtime. This change validates each duration and the prospective cumulative total before mutating tracker state.

### Test plan

- Added focused regressions for negative, `NaN`, positive/negative infinity, and cumulative float overflow.
- `tests/realtime/test_playback_tracker.py`: 26 passed.
- Broader realtime tests: 105 passed; 9 local websocket integration tests were blocked by the sandbox refusing local socket binding.
- `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck, and full tests passed.
- `git diff --check`: passed.

### Issue number

Not linked to an issue; this is a directly reproducible public playback-tracker boundary bug.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
