### PR TITLE
fix: bound non-finite shell output limits

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -11,6 +11,7 @@ import dataclasses
 import functools
 import inspect
 import json
+import math
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
@@ -694,7 +695,12 @@ def coerce_shell_call(tool_call: Any) -> ShellCallData:
     max_length_value = get_mapping_or_attr(action_payload, "max_output_length")
     if max_length_value is None:
         max_length_value = get_mapping_or_attr(action_payload, "maxOutputLength")
-    max_output_length = int(max_length_value) if isinstance(max_length_value, int | float) else None
+    if isinstance(max_length_value, int):
+        max_output_length = max_length_value
+    elif isinstance(max_length_value, float):
+        max_output_length = int(max_length_value) if math.isfinite(max_length_value) else 0
+    else:
+        max_output_length = None
 
     action = ShellActionRequest(
         commands=commands,

--- a/tests/test_shell_call_serialization.py
+++ b/tests/test_shell_call_serialization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from agents.agent import Agent
@@ -21,6 +23,31 @@ def test_coerce_shell_call_reads_max_output_length() -> None:
     }
     result = run_loop.coerce_shell_call(tool_call)
     assert result.action.max_output_length == 512
+
+
+@pytest.mark.parametrize("max_output_length", [math.nan, math.inf, -math.inf])
+def test_coerce_shell_call_ignores_non_finite_max_output_length(
+    max_output_length: float,
+) -> None:
+    tool_call = {
+        "call_id": "shell-non-finite-length",
+        "action": {"commands": ["ls"], "max_output_length": max_output_length},
+    }
+
+    result = run_loop.coerce_shell_call(tool_call)
+
+    assert result.action.max_output_length == 0
+
+
+def test_coerce_shell_call_preserves_large_integer_max_output_length() -> None:
+    tool_call = {
+        "call_id": "shell-large-length",
+        "action": {"commands": ["ls"], "max_output_length": 10**400},
+    }
+
+    result = run_loop.coerce_shell_call(tool_call)
+
+    assert result.action.max_output_length == 10**400
 
 
 @pytest.mark.parametrize("timeout_key", ["timeout_ms", "timeoutMs", "timeout"])


### PR DESCRIPTION
### Summary

Malformed shell tool payloads with non-finite `max_output_length` values (`NaN` or infinities) previously escaped coercion as `ValueError`/`OverflowError`, and negative infinity could disable output truncation. This change bounds all non-finite numeric limits to zero while preserving integer limits, including arbitrarily large integers.

### Test plan

- Added focused regressions for `NaN`, positive/negative infinity, and a 400-digit integer.
- `tests/test_shell_call_serialization.py` and `tests/test_shell_tool.py`: 49 passed.
- `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck, and full tests passed.
- `git diff --check`: passed.

### Issue number

Not linked to an issue; this is a directly reproducible malformed model-payload bug.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
