### PR TITLE
fix: make sensitive trace payloads opt-in by default

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -87,7 +87,7 @@ app = FastAPI()
 
 def process_in_background(prompt: str) -> None:
     try:
-        with trace("celery_task"):
+        with trace("background_job"):
             Runner.run_sync(agent, prompt)
     finally:
         flush_traces()
@@ -106,7 +106,6 @@ async def run(prompt: str, background_tasks: BackgroundTasks):
 Sometimes, you might want multiple calls to `run()` to be part of a single trace. You can do this by wrapping the entire code in a `trace()`.
 
 ```python
-import asyncio
 from agents import Agent, Runner, trace
 
 async def main():
@@ -163,7 +162,7 @@ The high level architecture for tracing is:
 
 To customize this default setup, to send traces to alternative or additional backends or modifying exporter behavior, you have two options:
 
-1. [`add_trace_processor()`][agents.tracing.add_trace_processor] lets you add an **additional** trace processor that will receive traces as they are ready. This lets you do your own processing in addition to sending them to OpenAI's backend.
+1. [`add_trace_processor()`][agents.tracing.add_trace_processor] lets you add an **additional** trace processor that will receive traces and spans as they are ready. This lets you do your own processing in addition to sending traces to OpenAI's backend.
 2. [`set_trace_processors()`][agents.tracing.set_trace_processors] lets you **replace** the default processors with your own trace processors. This means traces will not be sent to the OpenAI backend unless you include a `TracingProcessor` that does so.
 
 
@@ -221,14 +220,14 @@ The following community and vendor integrations support the tracing API surface 
 -   [Pydantic Logfire](https://logfire.pydantic.dev/docs/integrations/llms/openai/#openai-agents)
 -   [AgentOps](https://docs.agentops.ai/v1/integrations/agentssdk)
 -   [Scorecard](https://docs.scorecard.io/docs/documentation/features/tracing#openai-agents-sdk-integration)
--   [Respan](https://respan.ai/docs/integrations/openai-agents)
--   [LangSmith](https://docs.smith.langchain.com/observability/how_to_guides/trace_with_openai_agents)
+-   [Respan](https://respan.ai/docs/integrations/tracing/openai-agents-sdk)
+-   [LangSmith](https://docs.smith.langchain.com/observability/how_to_guides/trace_with_openai_agents_sdk)
 -   [Maxim AI](https://www.getmaxim.ai/docs/observe/integrations/openai-agents-sdk)
 -   [Comet Opik](https://www.comet.com/docs/opik/tracing/integrations/openai_agents)
 -   [Langfuse](https://langfuse.com/docs/integrations/openaiagentssdk/openai-agents)
 -   [Langtrace](https://docs.langtrace.ai/supported-integrations/llm-frameworks/openai-agents-sdk)
 -   [Okahu-Monocle](https://github.com/monocle2ai/monocle)
--   [Galileo](https://v2docs.galileo.ai/integrations/openai-agent-integration#openai-agents)
+-   [Galileo](https://v2docs.galileo.ai/integrations/openai-agent-integration#openai-agent-integration)
 -   [Portkey AI](https://portkey.ai/docs/integrations/agents/openai-agents)
 -   [LangDB AI](https://docs.langdb.ai/getting-started/working-with-agent-frameworks/working-with-openai-agents-sdk)
 -   [Agenta](https://docs.agenta.ai/observability/integrations/openai-agents)

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -87,7 +87,7 @@ app = FastAPI()
 
 def process_in_background(prompt: str) -> None:
     try:
-        with trace("background_job"):
+        with trace("celery_task"):
             Runner.run_sync(agent, prompt)
     finally:
         flush_traces()
@@ -106,6 +106,7 @@ async def run(prompt: str, background_tasks: BackgroundTasks):
 Sometimes, you might want multiple calls to `run()` to be part of a single trace. You can do this by wrapping the entire code in a `trace()`.
 
 ```python
+import asyncio
 from agents import Agent, Runner, trace
 
 async def main():
@@ -139,11 +140,19 @@ Spans are automatically part of the current trace, and are nested under the near
 
 Certain spans may capture potentially sensitive data.
 
-The `generation_span()` stores the inputs/outputs of the LLM generation, and `function_span()` stores the inputs/outputs of function calls. These may contain sensitive data, so you can disable capturing that data via [`RunConfig.trace_include_sensitive_data`][agents.run.RunConfig.trace_include_sensitive_data].
+The `generation_span()` stores the inputs/outputs of the LLM generation, and `function_span()` stores the inputs/outputs of function calls. These may contain sensitive data, so you can control capturing that data via [`RunConfig.trace_include_sensitive_data`][agents.run.RunConfig.trace_include_sensitive_data].
 
 Similarly, Audio spans include base64-encoded PCM data for input and output audio by default. You can disable capturing this audio data by configuring [`VoicePipelineConfig.trace_include_sensitive_audio_data`][agents.voice.pipeline_config.VoicePipelineConfig.trace_include_sensitive_audio_data].
 
-By default, `trace_include_sensitive_data` is `True`. You can set the default without code by exporting the `OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA` environment variable to `true/1` or `false/0` before running your app.
+By default, `trace_include_sensitive_data` is `False`. Applications that intentionally need model and tool inputs/outputs in traces must opt in explicitly, either in code:
+
+```python
+from agents import RunConfig
+
+run_config = RunConfig(trace_include_sensitive_data=True)
+```
+
+or by exporting `OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA=true` (also accepts `1`, `yes`, or `on`). Setting the option explicitly is recommended for applications migrating from releases where sensitive trace data was included by default.
 
 ## Custom tracing processors
 
@@ -154,7 +163,7 @@ The high level architecture for tracing is:
 
 To customize this default setup, to send traces to alternative or additional backends or modifying exporter behavior, you have two options:
 
-1. [`add_trace_processor()`][agents.tracing.add_trace_processor] lets you add an **additional** trace processor that will receive traces and spans as they are ready. This lets you do your own processing in addition to sending traces to OpenAI's backend.
+1. [`add_trace_processor()`][agents.tracing.add_trace_processor] lets you add an **additional** trace processor that will receive traces as they are ready. This lets you do your own processing in addition to sending them to OpenAI's backend.
 2. [`set_trace_processors()`][agents.tracing.set_trace_processors] lets you **replace** the default processors with your own trace processors. This means traces will not be sent to the OpenAI backend unless you include a `TracingProcessor` that does so.
 
 
@@ -212,14 +221,14 @@ The following community and vendor integrations support the tracing API surface 
 -   [Pydantic Logfire](https://logfire.pydantic.dev/docs/integrations/llms/openai/#openai-agents)
 -   [AgentOps](https://docs.agentops.ai/v1/integrations/agentssdk)
 -   [Scorecard](https://docs.scorecard.io/docs/documentation/features/tracing#openai-agents-sdk-integration)
--   [Respan](https://respan.ai/docs/integrations/tracing/openai-agents-sdk)
--   [LangSmith](https://docs.smith.langchain.com/observability/how_to_guides/trace_with_openai_agents_sdk)
+-   [Respan](https://respan.ai/docs/integrations/openai-agents)
+-   [LangSmith](https://docs.smith.langchain.com/observability/how_to_guides/trace_with_openai_agents)
 -   [Maxim AI](https://www.getmaxim.ai/docs/observe/integrations/openai-agents-sdk)
 -   [Comet Opik](https://www.comet.com/docs/opik/tracing/integrations/openai_agents)
 -   [Langfuse](https://langfuse.com/docs/integrations/openaiagentssdk/openai-agents)
 -   [Langtrace](https://docs.langtrace.ai/supported-integrations/llm-frameworks/openai-agents-sdk)
 -   [Okahu-Monocle](https://github.com/monocle2ai/monocle)
--   [Galileo](https://v2docs.galileo.ai/integrations/openai-agent-integration#openai-agent-integration)
+-   [Galileo](https://v2docs.galileo.ai/integrations/openai-agent-integration#openai-agents)
 -   [Portkey AI](https://portkey.ai/docs/integrations/agents/openai-agents)
 -   [LangDB AI](https://docs.langdb.ai/getting-started/working-with-agent-frameworks/working-with-openai-agents-sdk)
 -   [Agenta](https://docs.agenta.ai/observability/integrations/openai-agents)

--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -28,7 +28,7 @@ DEFAULT_MAX_TURNS = 10
 
 def _default_trace_include_sensitive_data() -> bool:
     """Return the default for trace_include_sensitive_data based on environment."""
-    val = os.getenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", "true")
+    val = os.getenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", "false")
     return val.strip().lower() in ("1", "true", "yes", "on")
 
 

--- a/src/agents/voice/pipeline_config.py
+++ b/src/agents/voice/pipeline_config.py
@@ -22,9 +22,10 @@ class VoicePipelineConfig:
     tracing: TracingConfig | None = None
     """Tracing configuration for this pipeline."""
 
-    trace_include_sensitive_data: bool = True
-    """Whether to include sensitive data in traces. Defaults to `True`. This is specifically for the
-      voice pipeline, and not for anything that goes on inside your Workflow."""
+    trace_include_sensitive_data: bool = False
+    """Whether to include sensitive data in traces. Defaults to `False` for security. When enabled,
+      tool inputs/outputs and LLM generations may be exposed in traces. Only enable in trusted
+      environments."""
 
     trace_include_sensitive_audio_data: bool = True
     """Whether to include audio data in traces. Defaults to `True`."""

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -88,11 +88,11 @@ async def test_agent_model_object_is_used_when_present() -> None:
     assert result.final_output == "from-agent-object"
 
 
-def test_trace_include_sensitive_data_defaults_to_true_when_env_not_set(monkeypatch):
-    """By default, trace_include_sensitive_data should be True when the env is not set."""
+def test_trace_include_sensitive_data_defaults_to_false_when_env_not_set(monkeypatch):
+    """By default, trace_include_sensitive_data should be False for security when the env is not set."""
     monkeypatch.delenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", raising=False)
     config = RunConfig()
-    assert config.trace_include_sensitive_data is True
+    assert config.trace_include_sensitive_data is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request fixes the default handling of potentially sensitive trace payloads by making `trace_include_sensitive_data` opt-in when no explicit configuration is provided.

`RunConfig` now treats an unset `OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA` environment variable as `false`, while preserving every existing explicit override. The voice pipeline's corresponding non-audio sensitive-data setting also defaults to `False`. Audio tracing remains unchanged.

This is an intentional default-behavior change. Applications that rely on model generations or tool inputs/outputs being present in traces can preserve the previous behavior with either `RunConfig(trace_include_sensitive_data=True)` or `OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA=true`. The tracing guide now documents that migration path directly.

Existing tests continue to cover explicit true/false environment values and explicit `RunConfig` overrides, and the default expectation now verifies the secure-by-default behavior.

The earlier draft #2392 implemented the same core direction but was closed automatically after going stale without a maintainer rejection. This refreshes that focused change on current `main` and adds migration documentation requested in the issue discussion.

This pull request resolves #2393.