### PR TITLE
fix(tracing): sanitize non-finite span payloads

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -320,7 +320,12 @@ class BackendSpanExporter(TracingExporter):
 
     def _value_json_size_bytes(self, value: Any) -> int:
         try:
-            serialized = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+            serialized = json.dumps(
+                value,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
         except (TypeError, ValueError):
             return self._OPENAI_TRACING_MAX_FIELD_BYTES + 1
         return len(serialized.encode("utf-8"))

--- a/tests/test_trace_processor_nonfinite_fields.py
+++ b/tests/test_trace_processor_nonfinite_fields.py
@@ -1,0 +1,39 @@
+import math
+
+import pytest
+
+from agents.tracing.processors import BackendSpanExporter
+
+
+@pytest.mark.parametrize("non_finite", [float("nan"), float("inf"), float("-inf")])
+@pytest.mark.parametrize("field_name", ["input", "output"])
+def test_openai_tracing_sanitizes_non_finite_span_fields(
+    non_finite: float, field_name: str
+) -> None:
+    exporter = BackendSpanExporter(api_key="test_key")
+    original = {"finite": 1.5, "invalid": non_finite}
+    payload = {
+        "object": "trace.span",
+        "span_data": {"type": "generation", field_name: original},
+    }
+
+    sanitized = exporter._sanitize_for_openai_tracing_api(payload)
+
+    assert sanitized["span_data"][field_name] == {"finite": 1.5}
+    assert sanitized is not payload
+    assert math.isfinite(original["finite"])
+    assert not math.isfinite(original["invalid"])
+    exporter.close()
+
+
+@pytest.mark.parametrize("field_name", ["input", "output"])
+def test_openai_tracing_keeps_small_finite_span_fields(field_name: str) -> None:
+    exporter = BackendSpanExporter(api_key="test_key")
+    field = {"score": 1.25, "nested": [0.0, -4.5]}
+    payload = {
+        "object": "trace.span",
+        "span_data": {"type": "generation", field_name: field},
+    }
+
+    assert exporter._sanitize_for_openai_tracing_api(payload) is payload
+    exporter.close()


### PR DESCRIPTION
This pull request fixes OpenAI tracing normalization so non-finite float values cannot bypass the existing JSON sanitizer merely because the surrounding `input` or `output` field is small.

`BackendSpanExporter._value_json_size_bytes()` now measures payloads using strict JSON semantics with `allow_nan=False`. A field containing `NaN`, `Infinity`, or `-Infinity` therefore follows the existing unserializable-value path, where `_sanitize_json_compatible_value()` removes the invalid nested value before the tracing payload is sent. Finite JSON payloads keep the existing fast path and are unchanged.

The change deliberately reuses the current OpenAI-ingest sanitization boundary instead of introducing another recursive traversal. Focused regression coverage exercises both `input` and `output`, all three non-finite float forms, preservation of valid sibling data, and a finite control case.

This pull request resolves #4551.