### PR TITLE
fix: fail closed on invalid debug logging flags

### DIFF
--- a/src/agents/_debug.py
+++ b/src/agents/_debug.py
@@ -5,8 +5,13 @@ def _debug_flag_enabled(flag: str, default: bool = False) -> bool:
     flag_value = os.getenv(flag)
     if flag_value is None:
         return default
-    else:
-        return flag_value == "1" or flag_value.lower() == "true"
+
+    normalized = flag_value.strip().lower()
+    if normalized in {"1", "true"}:
+        return True
+    if normalized in {"0", "false"}:
+        return False
+    return default
 
 
 def _load_dont_log_model_data() -> bool:

--- a/tests/test_debug_flag_parsing.py
+++ b/tests/test_debug_flag_parsing.py
@@ -1,0 +1,30 @@
+import pytest
+
+from agents._debug import _load_dont_log_model_data, _load_dont_log_tool_data
+
+
+@pytest.mark.parametrize(
+    ("env_name", "loader"),
+    [
+        ("OPENAI_AGENTS_DONT_LOG_MODEL_DATA", _load_dont_log_model_data),
+        ("OPENAI_AGENTS_DONT_LOG_TOOL_DATA", _load_dont_log_tool_data),
+    ],
+)
+def test_dont_log_flags_strip_whitespace(env_name, loader, monkeypatch) -> None:
+    monkeypatch.setenv(env_name, " true ")
+    assert loader() is True
+
+    monkeypatch.setenv(env_name, " false ")
+    assert loader() is False
+
+
+@pytest.mark.parametrize(
+    ("env_name", "loader"),
+    [
+        ("OPENAI_AGENTS_DONT_LOG_MODEL_DATA", _load_dont_log_model_data),
+        ("OPENAI_AGENTS_DONT_LOG_TOOL_DATA", _load_dont_log_tool_data),
+    ],
+)
+def test_dont_log_flags_use_safe_default_for_invalid_values(env_name, loader, monkeypatch) -> None:
+    monkeypatch.setenv(env_name, "tru")
+    assert loader() is True


### PR DESCRIPTION
This pull request fixes parsing of the privacy-oriented `OPENAI_AGENTS_DONT_LOG_MODEL_DATA` and `OPENAI_AGENTS_DONT_LOG_TOOL_DATA` environment settings so malformed values do not silently enable sensitive logging.

`_debug_flag_enabled()` now trims surrounding whitespace, recognizes explicit `1`/`true` and `0`/`false` values, and falls back to the caller-supplied default for any unrecognized value. Because both `DONT_LOG_*` settings use `default=True`, a typo or deployment value such as `" true "` now preserves redaction instead of flipping it off.

Valid existing configurations retain their behavior. Focused regression coverage exercises whitespace-padded true/false values and invalid values for both model-data and tool-data logging controls.

This pull request resolves #4554.