### PR TITLE
[codex] reject empty AnyLLM Chat Completions responses

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -609,6 +609,14 @@ class AnyLLMModel(Model):
                 prompt=prompt,
             )
 
+            if not response.choices:
+                provider_error = getattr(response, "error", None)
+                error_details = f": {provider_error}" if provider_error is not None else ""
+                raise ModelBehaviorError(
+                    f"ChatCompletion response has no choices (possible provider error payload)"
+                    f"{error_details}"
+                )
+
             message: ChatCompletionMessage | None = None
             first_choice: Choice | None = None
             if response.choices:

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -661,6 +661,37 @@ async def test_any_llm_chat_path_content_filter_keeps_real_content(monkeypatch) 
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_any_llm_chat_path_rejects_empty_choices(monkeypatch) -> None:
+    provider = FakeAnyLLMProvider(
+        supports_responses=False,
+        chat_response=ChatCompletion(
+            id="chatcmpl_empty",
+            created=0,
+            model="fake-model",
+            object="chat.completion",
+            choices=[],
+        ),
+    )
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    with pytest.raises(ModelBehaviorError, match="ChatCompletion response has no choices"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "chat_response",
     [


### PR DESCRIPTION
### What changed

This pull request fixes #4552 by making the AnyLLM Chat Completions path reject normalized responses with an empty `choices` list.

### Why

`AnyLLMModel._get_response_via_chat()` previously treated an empty provider response as a successful `ModelResponse(output=[])`. The native Chat Completions adapter already raises `ModelBehaviorError` for this malformed response shape, so this change keeps the provider adapters consistent and prevents malformed responses from entering the runner as successful turns.

### Validation

- `uv run pytest -q tests/models/test_any_llm_model.py -k any_llm_chat_path` — 8 passed
- `uv run pytest -q tests/models/test_any_llm_model.py` — 72 passed, 11 skipped
- `make format` and `make lint` — passed
- `make typecheck` and the full test suite were attempted; unrelated optional-dependency and existing extension/voice/runloop failures remain in the local environment.

### Scope

The change is limited to the non-streaming AnyLLM Chat Completions path and its regression test. Responses, streaming, valid choices, and existing content-filter handling remain unchanged.
