### PR TITLE
fix(provider): reuse falsy websocket models

### DIFF
--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -259,8 +259,8 @@ class OpenAIProvider(ModelProvider):
                 if running_loop is not None
                 else None
             )
-            if loop_cache is not None and (cached_model := loop_cache.get(cache_key)):
-                return cached_model
+            if loop_cache is not None and cache_key in loop_cache:
+                return loop_cache[cache_key]
         client = self._get_client()
         model: Model
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -298,6 +298,38 @@ def test_openai_provider_scopes_websocket_model_cache_to_running_loop():
     assert model2 is not model1
 
 
+def test_openai_provider_reuses_falsy_websocket_model(monkeypatch):
+    class DummyAsyncOpenAI:
+        pass
+
+    class FalsyWebsocketModel:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def __bool__(self) -> bool:
+            return False
+
+    monkeypatch.setattr("agents.models.openai_provider.OpenAIResponsesWSModel", FalsyWebsocketModel)
+    provider = OpenAIProvider(
+        use_responses=True,
+        use_responses_websocket=True,
+        openai_client=DummyAsyncOpenAI(),  # type: ignore[arg-type]
+    )
+
+    async def get_model():
+        return provider.get_model("gpt-4")
+
+    loop = asyncio.new_event_loop()
+    try:
+        model = loop.run_until_complete(get_model())
+        model_again = loop.run_until_complete(get_model())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+    assert model is model_again
+
+
 def test_openai_provider_websocket_loop_cache_does_not_keep_closed_loop_alive(monkeypatch):
     class DummyAsyncOpenAI:
         pass


### PR DESCRIPTION
### Summary

`OpenAIProvider` uses truthiness to detect a cached websocket model. A valid `Model` instance with falsey truthiness is therefore recreated on every lookup in the same running loop. Check cache-key presence instead so all cached model instances are reused.

### Test plan

- Added regression coverage for a falsey websocket model and identity reuse.
- Focused: `2 passed` (`tests/test_config.py -k falsy_websocket_model or scopes_websocket_model_cache`).
- Full verification: `UV_CACHE_DIR=/tmp/uv-verify-pr5-b2 UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` — all commands passed (format, lint, typecheck, tests).

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR