### PR TITLE
fix(memory): skip malformed encrypted session envelopes

### DIFF
--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -165,10 +165,22 @@ class EncryptedSession(SessionABC):
             return cast(TResponseInputItem, item)
 
         try:
-            token = item["payload"].encode("utf-8")
+            payload = item["payload"]
+            if not isinstance(payload, str):
+                return None
+            token = payload.encode("utf-8")
             plaintext = self.cipher.decrypt(token, ttl=self.ttl)
-            return cast(TResponseInputItem, _from_json_bytes(plaintext))
-        except (InvalidToken, KeyError):
+            decoded = _from_json_bytes(plaintext)
+            if not isinstance(decoded, dict):
+                return None
+            return cast(TResponseInputItem, decoded)
+        except (
+            InvalidToken,
+            KeyError,
+            UnicodeDecodeError,
+            UnicodeEncodeError,
+            json.JSONDecodeError,
+        ):
             return None
 
     def _unwrap_valid_items(

--- a/tests/extensions/memory/test_encrypt_session.py
+++ b/tests/extensions/memory/test_encrypt_session.py
@@ -33,6 +33,20 @@ def _invalid_encrypted_envelope() -> TResponseInputItem:
     )
 
 
+def _malformed_encrypted_envelope() -> TResponseInputItem:
+    return cast(
+        TResponseInputItem,
+        {"__enc__": 1, "v": 1, "kid": "hkdf-v1", "payload": None},
+    )
+
+
+def _malformed_unicode_encrypted_envelope() -> TResponseInputItem:
+    return cast(
+        TResponseInputItem,
+        {"__enc__": 1, "v": 1, "kid": "hkdf-v1", "payload": "\ud800"},
+    )
+
+
 @pytest.fixture
 def agent() -> Agent:
     """Fixture for a basic agent with a scripted model."""
@@ -377,6 +391,40 @@ async def test_encrypted_session_get_items_limit_skips_invalid_latest_envelope(
 
     limited = await session.get_items(limit=1)
     assert [item.get("content") for item in limited] == ["older valid"]
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_skips_malformed_envelopes(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """Malformed persisted envelopes should be skipped like invalid tokens."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    await session.add_items([{"role": "user", "content": "valid"}])
+    await underlying_session.add_items(
+        [_malformed_encrypted_envelope(), _malformed_unicode_encrypted_envelope()]
+    )
+    await underlying_session.add_items(
+        [
+            cast(
+                TResponseInputItem,
+                {
+                    "__enc__": 1,
+                    "v": 1,
+                    "kid": "hkdf-v1",
+                    "payload": session.cipher.encrypt(b"[]").decode("utf-8"),
+                },
+            )
+        ]
+    )
+
+    items = await session.get_items()
+    assert [item.get("content") for item in items] == ["valid"]
 
     underlying_session.close()
 


### PR DESCRIPTION
### Summary

`EncryptedSession` documents that invalid or expired stored envelopes are skipped, but malformed payload types, invalid UTF-8, invalid JSON, and valid JSON with a non-object shape could abort session reads. Harden `_unwrap` to skip those malformed envelopes while preserving valid response-item mappings.

### Test plan

- Added regression coverage for non-string, lone-surrogate, and non-object encrypted payloads.
- Focused: `21 passed` (`tests/extensions/memory/test_encrypt_session.py`).
- Full verification: `UV_CACHE_DIR=/tmp/uv-verify-pr5-a2 UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` — all commands passed (format, lint, typecheck, tests).

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR