### PR TITLE
fix(items): strip created_by when replaying RunItems as input

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -484,8 +484,7 @@ class ToolCallOutputItem(RunItemBase[Any]):
                         if isinstance(outcome, dict):
                             if outcome.get("type") == "exit":
                                 entry["outcome"] = outcome
-            payload.pop("created_by", None)
-            return cast(TResponseInputItem, payload)
+            return _output_item_to_input_item(payload)
 
         return super().to_input_item()
 

--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -150,14 +150,7 @@ class RunItemBase(Generic[T], abc.ABC):
 
     def to_input_item(self) -> TResponseInputItem:
         """Converts this item into an input item suitable for passing to the model."""
-        if isinstance(self.raw_item, dict):
-            # We know that input items are dicts, so we can ignore the type error
-            return self.raw_item  # type: ignore
-        elif isinstance(self.raw_item, BaseModel):
-            # All output items are Pydantic models that can be converted to input items.
-            return self.raw_item.model_dump(exclude_unset=True)  # type: ignore
-        else:
-            raise AgentsException(f"Unexpected raw item type: {type(self.raw_item)}")
+        return _output_item_to_input_item(self.raw_item)
 
 
 @dataclass
@@ -491,6 +484,7 @@ class ToolCallOutputItem(RunItemBase[Any]):
                         if isinstance(outcome, dict):
                             if outcome.get("type") == "exit":
                                 entry["outcome"] = outcome
+            payload.pop("created_by", None)
             return cast(TResponseInputItem, payload)
 
         return super().to_input_item()

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -661,6 +661,45 @@ def test_tool_call_output_item_to_input_item_strips_created_by() -> None:
     assert item.raw_item["created_by"] == "server"
 
 
+def test_dict_shell_call_output_item_to_input_item_sanitizes_without_mutation() -> None:
+    agent = Agent(name="A")
+    raw_item = {
+        "type": "shell_call_output",
+        "call_id": "call_1",
+        "status": "completed",
+        "shell_output": "legacy",
+        "provider_data": {"provider": "value"},
+        "created_by": "server",
+        "output": [
+            {
+                "stdout": "ok",
+                "stderr": "",
+                "outcome": {"type": "exit", "exit_code": 0},
+                "created_by": "server",
+            }
+        ],
+    }
+    original_chunk = raw_item["output"][0]
+    item = ToolCallOutputItem(agent=agent, raw_item=raw_item, output="ok")
+
+    replayed = item.to_input_item()
+
+    assert replayed == {
+        "type": "shell_call_output",
+        "call_id": "call_1",
+        "output": [
+            {
+                "stdout": "ok",
+                "stderr": "",
+                "outcome": {"type": "exit", "exit_code": 0},
+            }
+        ],
+    }
+    assert raw_item["created_by"] == "server"
+    assert original_chunk["created_by"] == "server"
+    assert raw_item["output"][0] is original_chunk
+
+
 def test_to_input_items_strips_nested_created_by_from_shell_call_output() -> None:
     """``shell_call_output`` carries ``created_by`` at the item level and inside each output chunk.
 

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -621,6 +621,46 @@ def test_to_input_items_strips_created_by_for_non_tool_search_items() -> None:
     assert all("created_by" not in item for item in input_items)
 
 
+def test_tool_call_item_to_input_item_strips_created_by() -> None:
+    """RunItem replay must strip output-only created_by, matching ModelResponse.to_input_items."""
+    agent = Agent(name="A")
+    call = ResponseFunctionToolCall.model_validate(
+        {
+            "id": "fc_1",
+            "arguments": "{}",
+            "call_id": "call_1",
+            "name": "lookup",
+            "type": "function_call",
+            "created_by": "server",
+        }
+    )
+    item = ToolCallItem(agent=agent, raw_item=call)
+    replayed = item.to_input_item()
+    assert isinstance(replayed, dict)
+    assert replayed["type"] == "function_call"
+    assert "created_by" not in replayed
+    assert getattr(call, "created_by", None) == "server"
+
+
+def test_tool_call_output_item_to_input_item_strips_created_by() -> None:
+    agent = Agent(name="A")
+    item = ToolCallOutputItem(
+        agent=agent,
+        raw_item={
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "ok",
+            "created_by": "server",
+        },
+        output="ok",
+    )
+    replayed = item.to_input_item()
+    assert isinstance(replayed, dict)
+    assert replayed["type"] == "function_call_output"
+    assert "created_by" not in replayed
+    assert item.raw_item["created_by"] == "server"
+
+
 def test_to_input_items_strips_nested_created_by_from_shell_call_output() -> None:
     """``shell_call_output`` carries ``created_by`` at the item level and inside each output chunk.
 

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -898,6 +898,29 @@ def test_run_item_to_input_item_strips_tool_search_created_by() -> None:
     assert "created_by" not in converted_output
 
 
+def test_run_item_to_input_item_strips_function_call_created_by() -> None:
+    agent = Agent(name="A")
+    tool_call = ToolCallItem(
+        agent=agent,
+        raw_item=ResponseFunctionToolCall.model_validate(
+            {
+                "id": "fc_1",
+                "arguments": "{}",
+                "call_id": "call_1",
+                "name": "lookup",
+                "type": "function_call",
+                "created_by": "server",
+            }
+        ),
+    )
+
+    converted = run_items.run_item_to_input_item(tool_call)
+
+    assert isinstance(converted, dict)
+    assert converted["type"] == "function_call"
+    assert "created_by" not in converted
+
+
 def test_run_item_to_input_item_omits_tool_call_metadata() -> None:
     agent = Agent(name="A")
     tool_call = ToolCallItem(


### PR DESCRIPTION
### Summary

This pull request fixes a gap left by #4308: `ModelResponse.to_input_items()` already strips output-only `created_by` before Responses replay, but public RunItem continuation still leaked it.

`RunItem.to_input_item()` dumped function-call and tool-output payloads with `created_by` intact. That same conversion feeds `run_item_to_input_item()`, session persistence, and `RunResult.to_input_list()`, so a later Responses request can include a field that is not part of the input schema.

The base converter now routes through `_output_item_to_input_item()`, and the dict path on `ToolCallOutputItem` pops `created_by` from the copied payload without mutating `raw_item`.

### Test plan

- [x] Added tests for `ToolCallItem.to_input_item`, `ToolCallOutputItem.to_input_item`, and `run_item_to_input_item` on function calls/outputs that carry `created_by`
- [x] `uv run pytest tests/test_items_helpers.py tests/test_run_internal_items.py`
- [x] `make format`, `make lint`, `make typecheck`
- [ ] Full `make tests` — one pre-existing local failure on this host, unrelated to this change: `tests/sandbox/test_run_cwd.py::test_python_skill_uses_absolute_root_from_nested_workdir` (`WorkspaceReadNotFoundError` for `tasks/task-a/nested/output.txt`). The same failure occurs on unpatched `upstream/main`.

### Issue number

N/A — small fix, no existing issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR