### PR TITLE
fix(tracing): reject zero batch sizes

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -562,6 +562,9 @@ class BatchTraceProcessor(TracingProcessor):
             schedule_delay: The delay between checks for new spans to export.
             export_trigger_ratio: The ratio of the queue size at which we will trigger an export.
         """
+        if max_batch_size < 1:
+            raise ValueError("max_batch_size must be at least 1")
+
         self._exporter = exporter
         self._queue: queue.Queue[Trace | Span[Any]] = queue.Queue(maxsize=max_queue_size)
         self._max_queue_size = max_queue_size

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -77,6 +77,23 @@ def test_batch_trace_processor_on_trace_start(mocked_exporter):
     processor.shutdown()
 
 
+def test_batch_trace_processor_rejects_zero_max_batch_size(mocked_exporter):
+    with pytest.raises(ValueError, match="max_batch_size must be at least 1"):
+        BatchTraceProcessor(exporter=mocked_exporter, max_batch_size=0)
+
+
+def test_batch_trace_processor_force_flush_exports_every_queued_item(mocked_exporter):
+    processor = BatchTraceProcessor(exporter=mocked_exporter, max_batch_size=1)
+    processor.on_trace_start(get_trace(processor))
+    processor.on_span_end(get_span(processor))
+
+    processor.force_flush()
+
+    assert mocked_exporter.export.call_count == 2
+    assert processor._queue.empty()
+    processor.shutdown()
+
+
 def test_batch_trace_processor_on_span_end(mocked_exporter):
     processor = BatchTraceProcessor(exporter=mocked_exporter, schedule_delay=0.1)
     test_span = get_span(processor)


### PR DESCRIPTION
## Summary
- reject `max_batch_size=0` during BatchTraceProcessor construction
- prevent force_flush from silently leaving queued spans unexported

## Test plan
- [x] `UV_CACHE_DIR=/tmp/uv-pr6-b uv run pytest tests/test_trace_processor.py -q` (58 passed)
- [x] changed-file Pyright and mypy
- [x] full suite: 9031 passed, 39 skipped; 38 environment-restricted failures (forkserver/native macOS sandbox)

## Issue number
N/A

## Checks
- [x] Focused regression tests added
- [x] `git diff --check` clean