### PR TITLE
fix(voice): use monotonic STT event deadlines

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -66,9 +66,11 @@ async def _wait_for_event(
     """
     Wait for an event from event_queue whose type is in expected_types within the specified timeout.
     """
-    start_time = time.time()
+    # Wall-clock adjustments can move a deadline forwards or backwards. Timeout
+    # accounting must use a monotonic clock instead.
+    start_time = time.monotonic()
     while True:
-        remaining = timeout - (time.time() - start_time)
+        remaining = timeout - (time.monotonic() - start_time)
         if remaining <= 0:
             raise TimeoutError(f"Timeout waiting for event(s): {expected_types}")
         evt = await asyncio.wait_for(event_queue.get(), timeout=remaining)

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -769,12 +769,12 @@ async def test_inactivity_timeout():
     )
 
     # We'll artificially manipulate the "time" to simulate inactivity quickly.
-    # The code checks time.time() for inactivity over EVENT_INACTIVITY_TIMEOUT.
+    # The code checks time.monotonic() for inactivity over EVENT_INACTIVITY_TIMEOUT.
     # We'll increment the return_value manually.
     with (
         patch("websockets.connect", return_value=mock_ws),
         patch(
-            "time.time",
+            "time.monotonic",
             side_effect=[
                 1000.0,
                 1000.0 + EVENT_INACTIVITY_TIMEOUT + 1,

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -32,6 +32,7 @@ try:
         ErrorSentinel,
         WebsocketDoneSentinel,
         _audio_buffer_to_base64,
+        _wait_for_event,
     )
 
     from .pipeline_test_models import StreamedAudioInputFactory
@@ -53,6 +54,16 @@ def create_mock_websocket(messages: list[str]) -> AsyncMock:
     # The incoming_messages are strings that we pretend come from the server
     mock_ws.__aiter__.return_value = iter(messages)
     return mock_ws
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_returns_matching_event() -> None:
+    queue: asyncio.Queue[dict[str, str]] = asyncio.Queue()
+    await queue.put({"type": "session.created"})
+
+    event = await _wait_for_event(queue, ["session.created"], timeout=1)
+
+    assert event == {"type": "session.created"}
 
 
 def fake_time(increment: int):
@@ -579,8 +590,8 @@ async def test_timeout_waiting_for_created_event(monkeypatch):
     def fake_time_func():
         return next(time_gen)
 
-    # Monkey-patch time.time with our fake_time_func
-    monkeypatch.setattr(time, "time", fake_time_func)
+    # Monkey-patch the monotonic clock used for event deadlines.
+    monkeypatch.setattr(time, "monotonic", fake_time_func)
 
     mock_ws = create_mock_websocket(
         [


### PR DESCRIPTION
## Summary
- use `time.monotonic()` for OpenAI STT event timeout accounting
- update the timeout regression test to control the monotonic clock

## Testing
- `python -m compileall -q` on changed source and test files
- focused pytest was attempted but this fresh worktree could not import the repository because optional dependency `httpx2` was unavailable; dependency sync was blocked by package-index DNS failures