### PR TITLE
fix: validate function tool concurrency type

### DIFF
--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -122,9 +122,12 @@ class ToolExecutionConfig:
     """
 
     def __post_init__(self) -> None:
-        if self.max_function_tool_concurrency is not None and (
-            self.max_function_tool_concurrency < 1
-        ):
+        value = self.max_function_tool_concurrency
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+            raise TypeError(
+                "tool_execution.max_function_tool_concurrency must be a positive integer or None"
+            )
+        if value is not None and value < 1:
             raise ValueError("tool_execution.max_function_tool_concurrency must be at least 1")
         if not isinstance(self.pre_approval_tool_input_guardrails, bool):
             raise ValueError("tool_execution.pre_approval_tool_input_guardrails must be a bool")

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -334,6 +334,17 @@ def test_tool_execution_config_rejects_invalid_function_tool_concurrency() -> No
         ToolExecutionConfig(max_function_tool_concurrency=0)
 
 
+@pytest.mark.parametrize("value", [True, 1.5])
+def test_tool_execution_config_rejects_non_integer_function_tool_concurrency(
+    value: object,
+) -> None:
+    with pytest.raises(
+        TypeError,
+        match="tool_execution.max_function_tool_concurrency must be a positive integer or None",
+    ):
+        ToolExecutionConfig(max_function_tool_concurrency=cast(Any, value))
+
+
 def test_tool_execution_config_is_public_from_agents_package() -> None:
     config = RunConfig(tool_execution=ToolExecutionConfig(max_function_tool_concurrency=2))
 


### PR DESCRIPTION
### Summary

- reject boolean and non-integer `max_function_tool_concurrency` values when constructing `ToolExecutionConfig`
- preserve the existing behavior for `None`, positive integers, and integers below one
- prevent fractional values from being interpreted as an unintended ceiling-like task count and `True` from acting as a limit of one

### Test plan

- [x] Added tests for the behavior being changed
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh`
- [x] Ran all relevant verification commands
- [x] Ran `/review`

Focused validation:

- `uv run pytest tests/test_run_config.py -q` (`44 passed`)
- `uv run pytest tests/test_run_step_execution.py -q -k function_tool_concurrency` (`3 passed, 105 deselected`)
- independent review tests (`4 passed, 40 deselected`)
- mandatory verification wrapper (format, lint, typecheck, and tests all passed)

The separate parallel `make tests` run completed with `8954 passed, 28 skipped, 38 failed`; all failures require local socket binding, multiprocessing, or native macOS sandbox execution, which this environment blocks. None touched the changed configuration tests or execution path.

### Issue number

N/A

### Checks

- [x] I added tests for the behavior being changed
- [x] I ran the repository verification script
- [x] All relevant validation passes
- [x] I reviewed the final diff
