### PR TITLE
fix(voice): forward streamed STT language and prompt

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -175,6 +175,15 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
 
     async def _configure_session(self) -> None:
         assert self._websocket is not None, "Websocket not initialized"
+        transcription_config: dict[str, Any] = {"model": self._model}
+        if self._settings.language is not None:
+            if self._model in {"gpt-transcribe", "gpt-live-transcribe"}:
+                transcription_config["languages"] = [self._settings.language]
+            else:
+                transcription_config["language"] = self._settings.language
+        if self._settings.prompt is not None:
+            transcription_config["prompt"] = self._settings.prompt
+
         await self._websocket.send(
             json.dumps(
                 {
@@ -184,7 +193,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                         "audio": {
                             "input": {
                                 "format": {"type": "audio/pcm", "rate": 24000},
-                                "transcription": {"model": self._model},
+                                "transcription": transcription_config,
                                 "turn_detection": self._turn_detection,
                             }
                         },

--- a/tests/voice/test_openai_stt_session_config.py
+++ b/tests/voice/test_openai_stt_session_config.py
@@ -1,0 +1,61 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agents.voice import StreamedAudioInput, STTModelSettings
+from agents.voice.models.openai_stt import OpenAISTTTranscriptionSession
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "language_field", "language_value"),
+    [
+        ("gpt-4o-transcribe", "language", "fr"),
+        ("gpt-transcribe", "languages", ["fr"]),
+        ("gpt-live-transcribe", "languages", ["fr"]),
+    ],
+)
+async def test_streaming_stt_sends_language_and_prompt(
+    model: str,
+    language_field: str,
+    language_value: str | list[str],
+) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model=model,
+        settings=STTModelSettings(language="fr", prompt="domain vocabulary"),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    websocket = AsyncMock()
+    session._websocket = websocket
+
+    await session._configure_session()
+
+    payload = json.loads(websocket.send.await_args.args[0])
+    assert payload["session"]["audio"]["input"]["transcription"] == {
+        "model": model,
+        language_field: language_value,
+        "prompt": "domain vocabulary",
+    }
+
+
+@pytest.mark.asyncio
+async def test_streaming_stt_omits_unset_language_and_prompt() -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="gpt-4o-transcribe",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    websocket = AsyncMock()
+    session._websocket = websocket
+
+    await session._configure_session()
+
+    payload = json.loads(websocket.send.await_args.args[0])
+    assert payload["session"]["audio"]["input"]["transcription"] == {"model": "gpt-4o-transcribe"}


### PR DESCRIPTION
This pull request supersedes #4533 and fixes streamed OpenAI STT sessions silently dropping configured `STTModelSettings.language` and `STTModelSettings.prompt` values.

It forwards both settings through the existing transcription session payload, maps `language` to plural `languages` for `gpt-transcribe` and `gpt-live-transcribe`, and retains singular `language` for existing transcription models. Unset values remain omitted, preserving the existing model-only default payload.