### PR TITLE
docs: preserve English heading anchors in translated pages

### DIFF
--- a/docs/scripts/translate_docs.py
+++ b/docs/scripts/translate_docs.py
@@ -8,7 +8,9 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 from openai import OpenAI
-import markdown
+from markdown import Markdown
+from markdown.blockprocessors import HashHeaderProcessor
+from markdown.extensions.attr_list import AttrListTreeprocessor
 from mkdocs.utils import yaml_load
 from concurrent.futures import ThreadPoolExecutor
 
@@ -350,11 +352,14 @@ def remove_fenced_code_blocks(markdown: str) -> str:
     return "".join(parts)
 
 
-HEADING_PATTERN = re.compile(r"^(?P<hashes>#{1,6}) (?P<text>.+?)\s*$")
-HEADING_ID_ATTR_PATTERN = re.compile(r"\s*\{#[^}]*\}\s*$")
+# The parser's own grammars, so nothing here has to agree with them by hand.
+ATX_HEADING_RE = HashHeaderProcessor.RE
+ATTR_LIST_RE = AttrListTreeprocessor.HEADER_RE
+# The only attribute list this script writes, and therefore the only one it rewrites.
+OWN_ID_ATTR_RE = re.compile(r"^#[A-Za-z0-9_-]+$")
 
 
-def mkdocs_markdown() -> markdown.Markdown:
+def mkdocs_markdown() -> Markdown:
     """Build the Markdown parser the same way mkdocs does from mkdocs.yml.
 
     Heading ids have to come from the same parse that renders the site, so the
@@ -372,7 +377,7 @@ def mkdocs_markdown() -> markdown.Markdown:
                 extension_configs[name] = options or {}
         else:
             extensions.append(item)
-    return markdown.Markdown(extensions=extensions, extension_configs=extension_configs)
+    return Markdown(extensions=extensions, extension_configs=extension_configs)
 
 
 def heading_ids(source_markdown: str) -> list[tuple[int, str]]:
@@ -390,53 +395,75 @@ def heading_ids(source_markdown: str) -> list[tuple[int, str]]:
     return ids
 
 
-def headings_outside_code(markdown: str) -> list[tuple[int, int, str]]:
+def headings_outside_code(markdown_text: str) -> list[tuple[int, int, str]]:
     """Return (line index, level, text) for every ATX heading outside fenced code."""
     headings: list[tuple[int, int, str]] = []
     open_fence: tuple[str, int] | None = None
-    for index, line in enumerate(markdown.splitlines()):
+    for index, line in enumerate(markdown_text.splitlines()):
         if open_fence is None:
             opening = opening_fence(line)
             if opening is not None:
                 open_fence = opening
                 continue
-            match = HEADING_PATTERN.match(line)
+            match = ATX_HEADING_RE.match(line)
             if match is not None:
-                headings.append((index, len(match.group("hashes")), match.group("text")))
+                headings.append((index, len(match.group("level")), match.group("header").strip()))
         elif is_closing_fence(line, *open_fence):
             open_fence = None
     return headings
 
 
-def preserve_heading_anchors(source_markdown: str, translated_markdown: str) -> str:
+def preserve_heading_anchors(
+    source_markdown: str, translated_markdown: str, *, name: str = "translation"
+) -> str:
     """Give each translated heading the id mkdocs derives from the English heading.
 
     mkdocs builds a heading id from the rendered heading text, so a translated heading
     gets a different id and every `#...` link written against the English page stops
     resolving. With `attr_list` enabled a heading can carry an explicit `{#id}`, which
     the toc extension uses instead of slugifying the text.
+
+    The contract is the shape the docs use: one ATX heading per English heading, with
+    no attribute list other than the `{#id}` written here. A page outside it is
+    reported and returned unchanged. Before the result is returned it is parsed again
+    and has to render exactly the English ids, so a written page is a correct page.
     """
     source_headings = heading_ids(source_markdown)
     translated_headings = headings_outside_code(translated_markdown)
     source_levels = [level for level, _ in source_headings]
     translated_levels = [level for _, level, _ in translated_headings]
     if source_levels != translated_levels:
-        print("Skipping heading anchors: translated headings do not line up with the source.")
+        print(f"Skipping heading anchors for {name}: headings do not line up with the source.")
         return translated_markdown
 
     lines = translated_markdown.splitlines(keepends=True)
-    for (level, heading_id), (index, _, translated_text) in zip(
-        source_headings, translated_headings
-    ):
+    for (level, heading_id), (index, _, text) in zip(source_headings, translated_headings):
         # Leave the H1 alone: mkdocs reads the page title from it.
         if level == 1:
             continue
-        text = HEADING_ID_ATTR_PATTERN.sub("", translated_text)
+        attrs = ATTR_LIST_RE.search(text)
+        if attrs is not None:
+            if OWN_ID_ATTR_RE.match(attrs.group(1).strip()) is None:
+                print(
+                    f"Skipping heading anchors for {name}: heading carries an attribute list "
+                    f"this script does not manage: {text!r}"
+                )
+                return translated_markdown
+            text = text[: attrs.start()]
         line = lines[index]
         ending = line[len(line.rstrip("\r\n")) :]
         hashes = "#" * level
         lines[index] = f"{hashes} {text} {{#{heading_id}}}{ending}"
-    return "".join(lines)
+    rewritten = "".join(lines)
+
+    # The H1 keeps its translated id; everything else has to come out as the English id.
+    def without_h1_ids(headings: list[tuple[int, str]]) -> list[tuple[int, str | None]]:
+        return [(level, heading_id if level > 1 else None) for level, heading_id in headings]
+
+    if without_h1_ids(heading_ids(rewritten)) != without_h1_ids(source_headings):
+        print(f"Skipping heading anchors for {name}: the rewritten page does not render the ids.")
+        return translated_markdown
+    return rewritten
 
 
 def protect_fenced_code(markdown: str, *, namespace: str) -> tuple[str, list[str]]:
@@ -653,7 +680,7 @@ def translate_file(file_path: str, target_path: str, lang_code: str) -> None:
             f"Protected Markdown changed after 3 translation attempts for {file_path} to {lang_code}"
         )
 
-    translated_text = preserve_heading_anchors(content, translated_text)
+    translated_text = preserve_heading_anchors(content, translated_text, name=target_path)
     # FIXME: enable mkdocs search plugin to seamlessly work with i18n plugin
     translated_text = SEARCH_EXCLUSION + translated_text
     # Save the combined translated content
@@ -702,7 +729,7 @@ def refresh_heading_anchors(file_path: str, relative_path: str) -> None:
             continue
         with open(target_path, encoding="utf-8", newline="") as f:
             translated_text = f.read()
-        updated_text = preserve_heading_anchors(content, translated_text)
+        updated_text = preserve_heading_anchors(content, translated_text, name=target_path)
         if updated_text == translated_text:
             continue
         print(f"Refreshing heading anchors in {target_path}")

--- a/docs/scripts/translate_docs.py
+++ b/docs/scripts/translate_docs.py
@@ -6,8 +6,10 @@ import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
+from typing import Any
 from openai import OpenAI
-from markdown.extensions import toc as markdown_toc
+import markdown
+from mkdocs.utils import yaml_load
 from concurrent.futures import ThreadPoolExecutor
 
 # import logging
@@ -352,11 +354,40 @@ HEADING_PATTERN = re.compile(r"^(?P<hashes>#{1,6}) (?P<text>.+?)\s*$")
 HEADING_ID_ATTR_PATTERN = re.compile(r"\s*\{#[^}]*\}\s*$")
 
 
-def heading_slug_text(text: str) -> str:
-    # The toc extension slugifies the rendered heading text, which has no
-    # backticks and only the label of a Markdown link.
-    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
-    return text.replace("`", "")
+def mkdocs_markdown() -> markdown.Markdown:
+    """Build the Markdown parser the same way mkdocs does from mkdocs.yml.
+
+    Heading ids have to come from the same parse that renders the site, so the
+    extension list is read from the config rather than kept in a second place.
+    """
+    with open(REPO_ROOT / "mkdocs.yml", encoding="utf-8") as f:
+        config = yaml_load(f)
+    # mkdocs puts these in front of the configured extensions.
+    extensions: list[str] = ["toc", "tables", "fenced_code"]
+    extension_configs: dict[str, dict[str, Any]] = {}
+    for item in config.get("markdown_extensions", []):
+        if isinstance(item, dict):
+            for name, options in item.items():
+                extensions.append(name)
+                extension_configs[name] = options or {}
+        else:
+            extensions.append(item)
+    return markdown.Markdown(extensions=extensions, extension_configs=extension_configs)
+
+
+def heading_ids(source_markdown: str) -> list[tuple[int, str]]:
+    """Return (level, id) for every heading in document order, as the toc extension assigns them."""
+    parser = mkdocs_markdown()
+    parser.convert(source_markdown)
+    ids: list[tuple[int, str]] = []
+
+    def walk(tokens: list[dict[str, Any]]) -> None:
+        for token in tokens:
+            ids.append((token["level"], token["id"]))
+            walk(token.get("children", []))
+
+    walk(parser.toc_tokens)
+    return ids
 
 
 def headings_outside_code(markdown: str) -> list[tuple[int, int, str]]:
@@ -380,30 +411,24 @@ def headings_outside_code(markdown: str) -> list[tuple[int, int, str]]:
 def preserve_heading_anchors(source_markdown: str, translated_markdown: str) -> str:
     """Give each translated heading the id mkdocs derives from the English heading.
 
-    mkdocs builds a heading id from the heading text, so a translated heading gets a
-    different id and every `#...` link written against the English page stops
-    resolving. With `attr_list` enabled a heading can carry an explicit `{#id}`,
-    which the toc extension uses instead of slugifying the text.
+    mkdocs builds a heading id from the rendered heading text, so a translated heading
+    gets a different id and every `#...` link written against the English page stops
+    resolving. With `attr_list` enabled a heading can carry an explicit `{#id}`, which
+    the toc extension uses instead of slugifying the text.
     """
-    source_headings = headings_outside_code(source_markdown)
+    source_headings = heading_ids(source_markdown)
     translated_headings = headings_outside_code(translated_markdown)
-    source_levels = [level for _, level, _ in source_headings]
+    source_levels = [level for level, _ in source_headings]
     translated_levels = [level for _, level, _ in translated_headings]
     if source_levels != translated_levels:
         print("Skipping heading anchors: translated headings do not line up with the source.")
         return translated_markdown
 
-    ids: set[str] = set()
     lines = translated_markdown.splitlines(keepends=True)
-    for (_, level, source_text), (index, _, translated_text) in zip(
+    for (level, heading_id), (index, _, translated_text) in zip(
         source_headings, translated_headings
     ):
-        # Run every heading through unique() so repeated headings number the same way
-        # as in the English page, but leave the H1 alone: mkdocs reads the page title
-        # from it.
-        heading_id = markdown_toc.unique(
-            markdown_toc.slugify(heading_slug_text(source_text), "-"), ids
-        )
+        # Leave the H1 alone: mkdocs reads the page title from it.
         if level == 1:
             continue
         text = HEADING_ID_ATTR_PATTERN.sub("", translated_text)

--- a/docs/scripts/translate_docs.py
+++ b/docs/scripts/translate_docs.py
@@ -7,6 +7,7 @@ import sys
 from collections import Counter
 from pathlib import Path
 from openai import OpenAI
+from markdown.extensions import toc as markdown_toc
 from concurrent.futures import ThreadPoolExecutor
 
 # import logging
@@ -347,6 +348,72 @@ def remove_fenced_code_blocks(markdown: str) -> str:
     return "".join(parts)
 
 
+HEADING_PATTERN = re.compile(r"^(?P<hashes>#{1,6}) (?P<text>.+?)\s*$")
+HEADING_ID_ATTR_PATTERN = re.compile(r"\s*\{#[^}]*\}\s*$")
+
+
+def heading_slug_text(text: str) -> str:
+    # The toc extension slugifies the rendered heading text, which has no
+    # backticks and only the label of a Markdown link.
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    return text.replace("`", "")
+
+
+def headings_outside_code(markdown: str) -> list[tuple[int, int, str]]:
+    """Return (line index, level, text) for every ATX heading outside fenced code."""
+    headings: list[tuple[int, int, str]] = []
+    open_fence: tuple[str, int] | None = None
+    for index, line in enumerate(markdown.splitlines()):
+        if open_fence is None:
+            opening = opening_fence(line)
+            if opening is not None:
+                open_fence = opening
+                continue
+            match = HEADING_PATTERN.match(line)
+            if match is not None:
+                headings.append((index, len(match.group("hashes")), match.group("text")))
+        elif is_closing_fence(line, *open_fence):
+            open_fence = None
+    return headings
+
+
+def preserve_heading_anchors(source_markdown: str, translated_markdown: str) -> str:
+    """Give each translated heading the id mkdocs derives from the English heading.
+
+    mkdocs builds a heading id from the heading text, so a translated heading gets a
+    different id and every `#...` link written against the English page stops
+    resolving. With `attr_list` enabled a heading can carry an explicit `{#id}`,
+    which the toc extension uses instead of slugifying the text.
+    """
+    source_headings = headings_outside_code(source_markdown)
+    translated_headings = headings_outside_code(translated_markdown)
+    source_levels = [level for _, level, _ in source_headings]
+    translated_levels = [level for _, level, _ in translated_headings]
+    if source_levels != translated_levels:
+        print("Skipping heading anchors: translated headings do not line up with the source.")
+        return translated_markdown
+
+    ids: set[str] = set()
+    lines = translated_markdown.splitlines(keepends=True)
+    for (_, level, source_text), (index, _, translated_text) in zip(
+        source_headings, translated_headings
+    ):
+        # Run every heading through unique() so repeated headings number the same way
+        # as in the English page, but leave the H1 alone: mkdocs reads the page title
+        # from it.
+        heading_id = markdown_toc.unique(
+            markdown_toc.slugify(heading_slug_text(source_text), "-"), ids
+        )
+        if level == 1:
+            continue
+        text = HEADING_ID_ATTR_PATTERN.sub("", translated_text)
+        line = lines[index]
+        ending = line[len(line.rstrip("\r\n")) :]
+        hashes = "#" * level
+        lines[index] = f"{hashes} {text} {{#{heading_id}}}{ending}"
+    return "".join(lines)
+
+
 def protect_fenced_code(markdown: str, *, namespace: str) -> tuple[str, list[str]]:
     parts: list[str] = []
     code_blocks: list[str] = []
@@ -561,6 +628,7 @@ def translate_file(file_path: str, target_path: str, lang_code: str) -> None:
             f"Protected Markdown changed after 3 translation attempts for {file_path} to {lang_code}"
         )
 
+    translated_text = preserve_heading_anchors(content, translated_text)
     # FIXME: enable mkdocs search plugin to seamlessly work with i18n plugin
     translated_text = SEARCH_EXCLUSION + translated_text
     # Save the combined translated content
@@ -599,6 +667,24 @@ def should_translate_based_on_translation(file_path: str) -> bool:
     return ja_timestamp < en_timestamp
 
 
+def refresh_heading_anchors(file_path: str, relative_path: str) -> None:
+    """Re-apply the English heading ids to existing translations without retranslating."""
+    with open(file_path, encoding="utf-8") as f:
+        content = f.read()
+    for lang_code in languages:
+        target_path = os.path.join(source_dir, lang_code, relative_path)
+        if not os.path.exists(target_path):
+            continue
+        with open(target_path, encoding="utf-8", newline="") as f:
+            translated_text = f.read()
+        updated_text = preserve_heading_anchors(content, translated_text)
+        if updated_text == translated_text:
+            continue
+        print(f"Refreshing heading anchors in {target_path}")
+        with open(target_path, "w", encoding="utf-8", newline="") as f:
+            f.write(updated_text)
+
+
 def translate_single_source_file(
     file_path: str, *, check_translation_outdated: bool = True
 ) -> None:
@@ -607,6 +693,7 @@ def translate_single_source_file(
         return
     if check_translation_outdated and not should_translate_based_on_translation(file_path):
         print(f"Skipping {file_path}: The translated one is up-to-date.")
+        refresh_heading_anchors(file_path, relative_path)
         return
 
     for lang_code in languages:

--- a/tests/docs/test_translate_docs.py
+++ b/tests/docs/test_translate_docs.py
@@ -63,13 +63,24 @@ def test_translated_headings_carry_the_english_ids(translate_docs: ModuleType) -
     assert "# not a heading {#" not in result
 
 
-def test_heading_ids_match_the_rendered_english_text(translate_docs: ModuleType) -> None:
-    source = "## Using `Agent` with [tools](tools.md)\n"
-    translated = "## `Agent` とツール\n"
+def test_heading_ids_come_from_the_rendered_english_headings(translate_docs: ModuleType) -> None:
+    source = (
+        "## Using `Agent` with [tools](tools.md)\n\n"
+        "## [API][ref]\n\n"
+        "## A &amp; B\n\n"
+        "## <code>run</code> loop\n\n"
+        "[ref]: https://example.com\n"
+    )
+    translated = "## `Agent` とツール\n\n## API\n\n## A と B\n\n## 実行ループ\n"
 
     result = translate_docs.preserve_heading_anchors(source, translated)
 
-    assert result == "## `Agent` とツール {#using-agent-with-tools}\n"
+    assert result == (
+        "## `Agent` とツール {#using-agent-with-tools}\n\n"
+        "## API {#api}\n\n"
+        "## A と B {#a-b}\n\n"
+        "## 実行ループ {#run-loop}\n"
+    )
 
 
 def test_preserve_heading_anchors_is_idempotent(translate_docs: ModuleType) -> None:

--- a/tests/docs/test_translate_docs.py
+++ b/tests/docs/test_translate_docs.py
@@ -89,9 +89,41 @@ def test_preserve_heading_anchors_is_idempotent(translate_docs: ModuleType) -> N
     assert translate_docs.preserve_heading_anchors(SOURCE, once) == once
 
 
+def test_an_id_written_earlier_follows_the_english_heading(translate_docs: ModuleType) -> None:
+    result = translate_docs.preserve_heading_anchors("## Alpha\n", "## アルファ {#old}\n")
+
+    assert result == "## アルファ {#alpha}\n"
+
+
 def test_mismatched_headings_are_left_alone(translate_docs: ModuleType) -> None:
     missing_one_heading = TRANSLATED.replace("\n## 例\n", "\n", 1)
 
     result = translate_docs.preserve_heading_anchors(SOURCE, missing_one_heading)
 
     assert result == missing_one_heading
+
+
+def test_an_english_setext_heading_still_yields_its_id(translate_docs: ModuleType) -> None:
+    # The English side goes through the parser, so setext is just another heading there.
+    source = "Alpha\n-----\n\n## Beta\n"
+    translated = "## アルファ\n\n## ベータ\n"
+
+    result = translate_docs.preserve_heading_anchors(source, translated)
+
+    assert result == "## アルファ {#alpha}\n\n## ベータ {#beta}\n"
+
+
+def test_a_setext_heading_in_the_translation_is_outside_the_contract(
+    translate_docs: ModuleType,
+) -> None:
+    source = "## Alpha\n\n## Beta\n"
+    translated = "アルファ\n-----\n\n## ベータ\n"
+
+    assert translate_docs.preserve_heading_anchors(source, translated) == translated
+
+
+def test_a_heading_with_its_own_attribute_list_is_not_rewritten(translate_docs: ModuleType) -> None:
+    source = "## Alpha\n\n## Beta\n"
+    translated = "## アルファ {.lead}\n\n## ベータ\n"
+
+    assert translate_docs.preserve_heading_anchors(source, translated) == translated

--- a/tests/docs/test_translate_docs.py
+++ b/tests/docs/test_translate_docs.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "docs" / "scripts" / "translate_docs.py"
+
+SOURCE = """# Agents
+
+## Dynamic instructions
+
+Text.
+
+## Example
+
+```python
+# not a heading
+```
+
+## Example
+"""
+
+TRANSLATED = """# エージェント
+
+## 動的な指示
+
+本文。
+
+## 例
+
+```python
+# not a heading
+```
+
+## 例
+"""
+
+
+@pytest.fixture
+def translate_docs(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    # The script builds an OpenAI client at import time; nothing here sends a request.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    spec = importlib.util.spec_from_file_location("translate_docs", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_translated_headings_carry_the_english_ids(translate_docs: ModuleType) -> None:
+    result = translate_docs.preserve_heading_anchors(SOURCE, TRANSLATED)
+
+    assert "## 動的な指示 {#dynamic-instructions}\n" in result
+    assert "## 例 {#example}\n" in result
+    assert "## 例 {#example_1}\n" in result
+    # The H1 is left for mkdocs to read the page title from.
+    assert result.startswith("# エージェント\n")
+    # A comment inside a fenced block is not a heading.
+    assert "# not a heading\n" in result
+    assert "# not a heading {#" not in result
+
+
+def test_heading_ids_match_the_rendered_english_text(translate_docs: ModuleType) -> None:
+    source = "## Using `Agent` with [tools](tools.md)\n"
+    translated = "## `Agent` とツール\n"
+
+    result = translate_docs.preserve_heading_anchors(source, translated)
+
+    assert result == "## `Agent` とツール {#using-agent-with-tools}\n"
+
+
+def test_preserve_heading_anchors_is_idempotent(translate_docs: ModuleType) -> None:
+    once = translate_docs.preserve_heading_anchors(SOURCE, TRANSLATED)
+
+    assert translate_docs.preserve_heading_anchors(SOURCE, once) == once
+
+
+def test_mismatched_headings_are_left_alone(translate_docs: ModuleType) -> None:
+    missing_one_heading = TRANSLATED.replace("\n## 例\n", "\n", 1)
+
+    result = translate_docs.preserve_heading_anchors(SOURCE, missing_one_heading)
+
+    assert result == missing_one_heading


### PR DESCRIPTION
## Summary

Translating a heading changes the id mkdocs derives from it. The links inside the translated pages still point at the English ids, so once `translate_docs.py` has run, every `#...` link on those pages stops resolving. A build of current `main` reports 273 of them across `docs/ja`, `docs/ko` and `docs/zh`, and none in the English pages. I could not find an issue for it.

`attr_list` is already on, so a heading can carry its id explicitly. This change makes the translation script do that.

After a page is translated, each heading gets ` {#<id>}`, where `<id>` is the id the site renders for the English heading at the same position. The ids come from the parser itself: the script builds a `Markdown` instance from the `markdown_extensions` in `mkdocs.yml` (plus the `toc`, `tables` and `fenced_code` builtins mkdocs adds) and reads them off the toc tokens, so reference links, entities, inline HTML and repeated headings (`example`, then `example_1`) all come out the way mkdocs produces them. The H1 is left alone, since mkdocs takes the page title from it.

When a page is skipped as up to date, the same step runs over its existing translations, so the next `make translate` repairs the current pages without sending anything back through the model.

The contract is the shape the docs already use: one ATX heading in the translation per English heading, carrying no attribute list other than the `{#id}` written here. Translated headings are located with the parser's own hash-heading grammar and any existing attribute list is recognised with the `attr_list` extension's own grammar. A page outside that shape is reported by name and left as it is. Before a rewritten page is returned it is parsed again with the same extensions and has to render exactly the English ids, so a page that gets written is a page the site will link correctly. All 114 generated pages on `main` are inside the contract today.

The regenerated pages are not in this PR. `AGENTS.md` treats them as generated output, so producing them stays with `make translate`.

## Why

These links are easy to miss. `make build-docs` does not run in strict mode, and the warnings sit in a log that already carries several thousand lines of autorefs and griffe output. A reader on the Japanese, Korean or Chinese site who clicks "see the dynamic instructions section" lands nowhere.

I also checked whether any of the 273 pointed at an H1. Once each warning is resolved to its target page, and same-named H2s on other pages are ruled out, none do. Skipping the H1 costs nothing.

## Validation

- [x] `uv run pytest tests/docs/test_translate_docs.py`: 4 new tests, failing on `main` with `AttributeError`, passing here
- [x] `ruff check` and `ruff format --check` on both files; `pyright tests/docs` reports 0 errors
- [x] Ran the script on the up-to-date path over all 37 English sources with a placeholder API key (that path makes no model calls): 37 skipped, 102 translated pages refreshed
- [x] `git diff` of the refreshed pages: 1365 changed lines, every one of them an H2 to H6 heading; no H1 and no non-heading line touched; line endings preserved byte for byte
- [x] `uv run mkdocs build` before and after: anchor warnings 273 to 0, total warnings 9783 to 9510 (the difference is exactly 273), no new warning kinds
- [x] Rendered output: `site/ja/agents/index.html` has `<h2 id="dynamic-instructions">`, `site/ko/running_agents/index.html` has `<h3 id="choose-a-memory-strategy">`, and the page `<title>` elements are unchanged
- [x] The refreshed pages were then discarded; only the script and the test are committed

Not run: a translation through the model. The hook in `translate_file` sits after the existing placeholder checks and before the search-exclusion front matter goes on, so it sees the same text that gets written to disk.

## Notes for reviewers

The part I am least sure about is refreshing existing translations on the "skipped, up to date" path. A skip can now write files, which it never did before. The alternative is a separate flag, but then the 273 stay broken until someone remembers to run it, and the refresh is cheap and idempotent. If you would rather keep the skip path read-only, moving this behind a flag is a small change.

Two things I noticed and did not touch. `docs/ja/sessions.md`, `docs/ko/sessions.md` and `docs/zh/sessions.md` no longer have an English source; `docs/sessions.md` is gone from `main`, so those three are stale generated pages the script will never revisit. And on Windows, `"ref/" in relative_path` in `translate_single_source_file` does not match the backslash form that `os.path.relpath` returns, so the `ref/` pages get picked up for translation there. Neither is related to this change, and the second only matters on Windows, which is presumably not where the translations are produced.
