### PR TITLE
request_usage_entries: two paths disagree on whether a zero-token request gets an entry

### DIFF
--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -315,16 +315,6 @@ async def _await_model_attempt(
     raise timeout_error from None
 
 
-def _build_zero_request_usage_entry() -> RequestUsage:
-    return RequestUsage(
-        input_tokens=0,
-        output_tokens=0,
-        total_tokens=0,
-        input_tokens_details=Usage().input_tokens_details,
-        output_tokens_details=Usage().output_tokens_details,
-    )
-
-
 def _build_request_usage_entry_from_usage(usage: Usage) -> RequestUsage:
     return RequestUsage(
         input_tokens=usage.input_tokens,
@@ -336,17 +326,22 @@ def _build_request_usage_entry_from_usage(usage: Usage) -> RequestUsage:
 
 
 def apply_retry_attempt_usage(usage: Usage, failed_attempts: int) -> Usage:
+    """Fold failed attempts into a retried request's usage totals.
+
+    Failed attempts never receive a `request_usage_entries` entry: the SDK has no usage
+    payload for them, and `Usage.add()` applies the same "no entry without known tokens"
+    rule to every other request it has no usage for. Callers must read `requests` for the
+    full attempt count; `request_usage_entries` only ever covers requests with known usage.
+    """
     if failed_attempts <= 0:
         return usage
 
     successful_request_entries = list(usage.request_usage_entries)
-    if not successful_request_entries:
+    if not successful_request_entries and usage.total_tokens > 0:
         successful_request_entries.append(_build_request_usage_entry_from_usage(usage))
 
     usage.requests = max(usage.requests, 1) + failed_attempts
-    usage.request_usage_entries = [
-        _build_zero_request_usage_entry() for _ in range(failed_attempts)
-    ] + successful_request_entries
+    usage.request_usage_entries = successful_request_entries
     return usage
 
 

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -219,7 +219,10 @@ class Usage:
     """List of RequestUsage entries for accurate per-request cost calculation.
 
     Each call to `add()` automatically creates an entry in this list if the added usage
-    represents a new request (i.e., has non-zero tokens).
+    represents a new request (i.e., has non-zero tokens). Requests with no known usage
+    (for example a provider that reports no usage, or a failed attempt that is retried)
+    are still counted in `requests` but do not get an entry here, so this list is a
+    subset of the requests the run made, not a 1:1 breakdown of `requests`.
 
     Example:
         For a run that makes 3 API calls with 100K, 150K, and 80K input tokens each,

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -921,17 +921,23 @@ async def test_get_response_with_retry_preserves_successful_request_usage_entry(
     )
 
     assert result.usage.requests == 2
-    assert len(result.usage.request_usage_entries) == 2
-    assert result.usage.request_usage_entries[0].total_tokens == 0
-    assert result.usage.request_usage_entries[1].input_tokens == 11
-    assert result.usage.request_usage_entries[1].output_tokens == 7
-    assert result.usage.request_usage_entries[1].total_tokens == 18
+    # The failed attempt has no known usage, so it does not get an entry.
+    assert len(result.usage.request_usage_entries) == 1
+    assert result.usage.request_usage_entries[0].input_tokens == 11
+    assert result.usage.request_usage_entries[0].output_tokens == 7
+    assert result.usage.request_usage_entries[0].total_tokens == 18
 
 
 @pytest.mark.asyncio
-async def test_get_response_with_retry_preserves_zero_token_successful_request_usage_entry(
+async def test_get_response_with_retry_omits_zero_token_request_usage_entries(
     monkeypatch,
 ) -> None:
+    """Requests with no known usage never get a request_usage_entries entry.
+
+    This holds for both the failed attempt and a "successful" final attempt whose usage is
+    all zero (e.g. a provider that reports no usage), matching Usage.add()'s rule that an
+    entry is only created for a request with known (non-zero) tokens.
+    """
     calls = 0
 
     async def fake_sleep(_delay: float) -> None:
@@ -967,9 +973,7 @@ async def test_get_response_with_retry_preserves_zero_token_successful_request_u
     )
 
     assert result.usage.requests == 2
-    assert len(result.usage.request_usage_entries) == 2
-    assert result.usage.request_usage_entries[0].total_tokens == 0
-    assert result.usage.request_usage_entries[1].total_tokens == 0
+    assert result.usage.request_usage_entries == []
 
 
 @pytest.mark.asyncio
@@ -1126,9 +1130,9 @@ async def test_get_response_with_retry_preserves_conversation_locked_compatibili
     assert rewinds == 1
     assert sleeps == [1.0]
     assert result.usage.requests == 2
-    assert len(result.usage.request_usage_entries) == 2
-    assert result.usage.request_usage_entries[0].total_tokens == 0
-    assert result.usage.request_usage_entries[1].total_tokens == 5
+    # The conversation-locked attempt has no known usage, so it does not get an entry.
+    assert len(result.usage.request_usage_entries) == 1
+    assert result.usage.request_usage_entries[0].total_tokens == 5
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -431,11 +431,12 @@ async def test_streamed_run_preserves_request_usage_entries_after_retry() -> Non
 
     usage = result.context_wrapper.usage
     assert usage.requests == 2
-    assert len(usage.request_usage_entries) == 2
-    assert usage.request_usage_entries[0].total_tokens == 0
-    assert usage.request_usage_entries[1].input_tokens == 10
-    assert usage.request_usage_entries[1].output_tokens == 5
-    assert usage.request_usage_entries[1].total_tokens == 15
+    # The failed attempt has no known usage, so it does not get an entry -- consistent with
+    # Usage.add(), which never creates an entry for a request it has no tokens for.
+    assert len(usage.request_usage_entries) == 1
+    assert usage.request_usage_entries[0].input_tokens == 10
+    assert usage.request_usage_entries[0].output_tokens == 5
+    assert usage.request_usage_entries[0].total_tokens == 15
 
 
 @pytest.mark.asyncio
@@ -483,9 +484,9 @@ async def test_streamed_run_counts_retry_attempts_when_terminal_usage_missing() 
     usage = result.context_wrapper.usage
     assert len(model.calls) == 2
     assert usage.requests == 2
-    assert len(usage.request_usage_entries) == 2
-    assert usage.request_usage_entries[0].total_tokens == 0
-    assert usage.request_usage_entries[1].total_tokens == 0
+    # Neither attempt has known usage (one failed outright, the other completed without a
+    # usage payload), so neither gets a request_usage_entries entry.
+    assert usage.request_usage_entries == []
 
 
 @pytest.mark.asyncio
@@ -557,11 +558,11 @@ async def test_streamed_run_preserves_request_usage_entries_after_conversation_l
 
     usage = result.context_wrapper.usage
     assert usage.requests == 2
-    assert len(usage.request_usage_entries) == 2
-    assert usage.request_usage_entries[0].total_tokens == 0
-    assert usage.request_usage_entries[1].input_tokens == 10
-    assert usage.request_usage_entries[1].output_tokens == 5
-    assert usage.request_usage_entries[1].total_tokens == 15
+    # The conversation-locked attempt has no known usage, so it does not get an entry.
+    assert len(usage.request_usage_entries) == 1
+    assert usage.request_usage_entries[0].input_tokens == 10
+    assert usage.request_usage_entries[0].output_tokens == 5
+    assert usage.request_usage_entries[0].total_tokens == 15
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
Fixes #4563.

## What changed
- `src/agents/run_internal/model_retry.py`
- `src/agents/usage.py`
- `tests/models/test_model_retry.py`
- `tests/test_agent_runner_streamed.py`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.