### PR TITLE
fix: fail fast when STT websocket closes during setup

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -83,7 +83,7 @@ def _prepare_websocket_headers(client: AsyncOpenAI) -> dict[str, str]:
 
 
 async def _wait_for_event(
-    event_queue: asyncio.Queue[dict[str, Any] | ErrorSentinel],
+    event_queue: asyncio.Queue[dict[str, Any] | ErrorSentinel | WebsocketDoneSentinel],
     expected_types: list[str],
     timeout: float,
 ):
@@ -98,6 +98,8 @@ async def _wait_for_event(
         evt = await asyncio.wait_for(event_queue.get(), timeout=remaining)
         if isinstance(evt, ErrorSentinel):
             raise _ListenerError("Websocket listener failed") from evt.error
+        if isinstance(evt, WebsocketDoneSentinel):
+            raise _ListenerError("Websocket listener closed before the expected setup event")
         evt_type = evt.get("type", "")
         if evt_type in expected_types:
             return evt
@@ -133,7 +135,9 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
         self._event_queue: asyncio.Queue[dict[str, Any] | ErrorSentinel | WebsocketDoneSentinel] = (
             asyncio.Queue()
         )
-        self._state_queue: asyncio.Queue[dict[str, Any] | ErrorSentinel] = asyncio.Queue()
+        self._state_queue: asyncio.Queue[
+            dict[str, Any] | ErrorSentinel | WebsocketDoneSentinel
+        ] = asyncio.Queue()
         self._turn_audio_buffer: list[npt.NDArray[np.int16 | np.float32]] = []
         self._tracing_span: Span[TranscriptionSpanData] | None = None
 
@@ -195,7 +199,9 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             await self._event_queue.put(error)
             await self._state_queue.put(error)
         finally:
-            await self._event_queue.put(WebsocketDoneSentinel())
+            done = WebsocketDoneSentinel()
+            await self._event_queue.put(done)
+            await self._state_queue.put(done)
 
     async def _configure_session(self) -> None:
         assert self._websocket is not None, "Websocket not initialized"

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -358,10 +358,12 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                     logger.error("Listener task not initialized")
                     raise AgentsException("Listener task not initialized")
         except _ListenerError as e:
+            wrapped_err = STTWebsocketConnectionError("Error parsing events")
+            self._stored_exception = wrapped_err
             if self._process_events_task is None:
                 self._process_events_task = asyncio.create_task(self._handle_events())
             await self._process_events_task
-            raise STTWebsocketConnectionError("Error parsing events") from e.__cause__
+            raise wrapped_err from e.__cause__
         except Exception as e:
             await self._output_queue.put(ErrorSentinel(e))
             raise

--- a/tests/voice/test_openai_stt_setup_close.py
+++ b/tests/voice/test_openai_stt_setup_close.py
@@ -1,0 +1,47 @@
+import asyncio
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+
+from agents.voice import OpenAISTTTranscriptionSession, StreamedAudioInput, STTModelSettings
+from agents.voice.exceptions import STTWebsocketConnectionError
+
+
+def create_mock_openai_client(api_key: str = "FAKE_KEY") -> AsyncOpenAI:
+    client = AsyncMock(api_key=api_key)
+    client.websocket_base_url = None
+    client.base_url = httpx2.URL("https://api.openai.com/v1/")
+    client.default_query = {}
+    client.auth_headers = {"Authorization": f"Bearer {api_key}"}
+    client.default_headers = {}
+    client._refresh_api_key = AsyncMock()
+    return cast(AsyncOpenAI, client)
+
+
+@pytest.mark.asyncio
+async def test_clean_websocket_close_during_setup_fails_without_waiting_for_timeout() -> None:
+    mock_ws = AsyncMock()
+    mock_ws.__aenter__.return_value = mock_ws
+    mock_ws.__aiter__.return_value = iter([])
+
+    with patch("websockets.connect", return_value=mock_ws):
+        session = OpenAISTTTranscriptionSession(
+            input=StreamedAudioInput(),
+            client=create_mock_openai_client(),
+            model="whisper-1",
+            settings=STTModelSettings(),
+            trace_include_sensitive_data=False,
+            trace_include_sensitive_audio_data=False,
+        )
+
+        async def consume_turns() -> None:
+            async for _ in session.transcribe_turns():
+                pass
+
+        with pytest.raises(STTWebsocketConnectionError):
+            await asyncio.wait_for(consume_turns(), timeout=1)
+
+        await session.close()


### PR DESCRIPTION
## Summary

A streamed STT WebSocket that closes cleanly before `session.created` or `session.updated` currently leaves `_setup_connection()` waiting on `_state_queue` until the 10-second setup timeout, because the listener completion sentinel is only sent to `_event_queue`.

This change sends the listener-completion sentinel to the setup state queue as well and makes `_wait_for_event()` treat it as an immediate listener failure. Clean connection closure during setup now fails promptly instead of waiting for a timeout.

## Regression coverage

Added a focused test with a WebSocket that closes without emitting setup events. The test requires the session to raise `STTWebsocketConnectionError` within one second, so the previous timeout-based behavior fails the regression.

Full repository tests were not run locally because this environment does not contain the Agents SDK development checkout/dependencies; CI should run the voice test suite.