### PR TITLE
fix: clear active MCP servers after cleanup

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -386,10 +386,7 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
                     exc,
                 )
                 self._errors[server] = exc
-        if self.drop_failed_servers:
-            self._active_servers = [
-                server for server in self._all_servers if server in self._connected_servers
-            ]
+        self._refresh_active_servers()
 
     async def _run_with_timeout(
         self, func: Callable[[], Awaitable[Any]], timeout_seconds: float | None
@@ -424,8 +421,9 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
 
     def _refresh_active_servers(self) -> None:
         if self.drop_failed_servers:
-            failed = set(self._failed_server_set)
-            self._active_servers = [server for server in self._all_servers if server not in failed]
+            self._active_servers = [
+                server for server in self._all_servers if server in self._connected_servers
+            ]
         else:
             self._active_servers = list(self._all_servers)
 

--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -367,26 +367,28 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
         return True
 
     async def _cleanup_all(self) -> None:
-        for server in reversed(self._all_servers):
-            try:
-                await self._cleanup_server(server)
-            except asyncio.CancelledError as exc:
-                if not self.suppress_cancelled_error:
-                    raise
-                log_tool_action_debug(
-                    logger,
-                    get_mcp_server_log_message("Cleanup cancelled for MCP server", server),
-                    exc,
-                )
-                self._errors[server] = exc
-            except Exception as exc:
-                log_tool_action_error(
-                    logger,
-                    get_mcp_server_log_message("Failed to cleanup MCP server", server),
-                    exc,
-                )
-                self._errors[server] = exc
-        self._refresh_active_servers()
+        try:
+            for server in reversed(self._all_servers):
+                try:
+                    await self._cleanup_server(server)
+                except asyncio.CancelledError as exc:
+                    if not self.suppress_cancelled_error:
+                        raise
+                    log_tool_action_debug(
+                        logger,
+                        get_mcp_server_log_message("Cleanup cancelled for MCP server", server),
+                        exc,
+                    )
+                    self._errors[server] = exc
+                except Exception as exc:
+                    log_tool_action_error(
+                        logger,
+                        get_mcp_server_log_message("Failed to cleanup MCP server", server),
+                        exc,
+                    )
+                    self._errors[server] = exc
+        finally:
+            self._refresh_active_servers()
 
     async def _run_with_timeout(
         self, func: Callable[[], Awaitable[Any]], timeout_seconds: float | None

--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -386,6 +386,10 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
                     exc,
                 )
                 self._errors[server] = exc
+        if self.drop_failed_servers:
+            self._active_servers = [
+                server for server in self._all_servers if server in self._connected_servers
+            ]
 
     async def _run_with_timeout(
         self, func: Callable[[], Awaitable[Any]], timeout_seconds: float | None

--- a/tests/mcp/test_mcp_server_manager_cleanup_state.py
+++ b/tests/mcp/test_mcp_server_manager_cleanup_state.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from typing import cast
 from unittest.mock import AsyncMock, Mock
 
@@ -26,3 +28,18 @@ async def test_cleanup_all_removes_cleaned_servers_from_active_servers() -> None
 
     assert await manager.connect_all() == [server]
     assert server.connect.await_count == 2
+
+@pytest.mark.asyncio
+async def test_cleanup_all_refreshes_active_servers_when_cancellation_propagates() -> None:
+    server = cast(MCPServer, Mock(spec=MCPServer))
+    server.connect = AsyncMock()
+    server.cleanup = AsyncMock(side_effect=asyncio.CancelledError)
+
+    manager = MCPServerManager([server], suppress_cancelled_error=False)
+    assert await manager.connect_all() == [server]
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager.cleanup_all()
+
+    assert manager.active_servers == []
+    assert manager._connected_servers == set()

--- a/tests/mcp/test_mcp_server_manager_cleanup_state.py
+++ b/tests/mcp/test_mcp_server_manager_cleanup_state.py
@@ -1,5 +1,4 @@
 import asyncio
-
 from typing import cast
 from unittest.mock import AsyncMock, Mock
 
@@ -28,6 +27,7 @@ async def test_cleanup_all_removes_cleaned_servers_from_active_servers() -> None
 
     assert await manager.connect_all() == [server]
     assert server.connect.await_count == 2
+
 
 @pytest.mark.asyncio
 async def test_cleanup_all_refreshes_active_servers_when_cancellation_propagates() -> None:

--- a/tests/mcp/test_mcp_server_manager_cleanup_state.py
+++ b/tests/mcp/test_mcp_server_manager_cleanup_state.py
@@ -1,0 +1,24 @@
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from agents.mcp import MCPServer, MCPServerManager
+
+
+@pytest.mark.asyncio
+async def test_cleanup_all_removes_cleaned_servers_from_active_servers() -> None:
+    server = cast(MCPServer, Mock(spec=MCPServer))
+    server.connect = AsyncMock()
+    server.cleanup = AsyncMock()
+
+    manager = MCPServerManager([server])
+    assert await manager.connect_all() == [server]
+
+    await manager.cleanup_all()
+
+    assert manager.active_servers == []
+    assert manager._connected_servers == set()
+
+    assert await manager.connect_all() == [server]
+    assert server.connect.await_count == 2

--- a/tests/mcp/test_mcp_server_manager_cleanup_state.py
+++ b/tests/mcp/test_mcp_server_manager_cleanup_state.py
@@ -20,5 +20,9 @@ async def test_cleanup_all_removes_cleaned_servers_from_active_servers() -> None
     assert manager.active_servers == []
     assert manager._connected_servers == set()
 
+    assert await manager.reconnect() == []
+    assert manager.active_servers == []
+    assert server.connect.await_count == 1
+
     assert await manager.connect_all() == [server]
     assert server.connect.await_count == 2


### PR DESCRIPTION
## Summary

`MCPServerManager.cleanup_all()` removes servers from the internal connected set, but previously left `active_servers` unchanged. With the default `drop_failed_servers=True`, callers could therefore receive cleaned or disconnected servers from `active_servers` even though the manager documents that property as the successfully connected subset.

This change consistently derives the active list from the canonical connected-server set and refreshes it in a guaranteed cleanup `finally` path. A subsequent `reconnect(failed_only=True)` cannot reintroduce a cleaned server without reconnecting it, and propagated cleanup cancellation cannot leave disconnected servers advertised as active.

## Regression coverage

Added focused tests covering:

- successful cleanup followed by a failed-only reconnect and then `connect_all()`;
- cleanup cancellation with `suppress_cancelled_error=False`, verifying the cancellation propagates while active and connected state remain consistent.

Full repository tests were not run locally in this environment; CI should run the MCP test suite.