### PR TITLE
fix(extensions): forward empty extra_query and metadata in LiteLLM path

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -614,9 +614,9 @@ class LitellmModel(Model):
             stream_options = {"include_usage": model_settings.include_usage}
 
         extra_kwargs: dict[str, Any] = {}
-        if model_settings.extra_query:
+        if model_settings.extra_query is not None:
             extra_kwargs["extra_query"] = copy(model_settings.extra_query)
-        if model_settings.metadata:
+        if model_settings.metadata is not None:
             extra_kwargs["metadata"] = copy(model_settings.metadata)
         if model_settings.extra_body is not None:
             extra_body = copy(model_settings.extra_body)

--- a/tests/models/test_litellm_extra_body.py
+++ b/tests/models/test_litellm_extra_body.py
@@ -24,6 +24,43 @@ def test_falsy_reasoning_effort_is_preserved() -> None:
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_empty_extra_query_and_metadata_are_forwarded(monkeypatch):
+    """
+    Forward empty `extra_query` and `metadata` dicts instead of dropping them.
+
+    The OpenAI and AnyLLM model paths forward these settings whenever they are
+    not `None`; the falsy check here dropped `{}`, silently discarding an
+    explicitly configured value and diverging from those paths.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        captured.update(kwargs)
+        msg = Message(role="assistant", content="ok")
+        choice = Choices(index=0, message=msg)
+        return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    settings = ModelSettings(extra_query={}, metadata={})
+    model = LitellmModel(model="test-model")
+
+    await model.get_response(
+        system_instructions=None,
+        input=[],
+        model_settings=settings,
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+
+    assert captured["extra_query"] == {}
+    assert captured["metadata"] == {}
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_extra_body_is_forwarded(monkeypatch):
     """
     Forward `extra_body` via LiteLLM's dedicated kwarg.


### PR DESCRIPTION
## Summary

`LitellmModel` drops an explicitly-configured empty `extra_query` / `metadata` dict before calling `litellm.acompletion`, because it uses falsy checks (`if model_settings.extra_query:`) instead of `is not None` checks. This diverges from the other two model paths:

- **OpenAI** (`openai_chatcompletions.py`): passes `extra_query` through as-is and forwards `metadata` unless it is `None` (`_non_null_or_omit`).
- **AnyLLM** (`any_llm_model.py`): switched to `is not None` checks in #4544.
- **LiteLLM** (`litellm_model.py`): still drops `{}`.

## Change

Use `is not None` checks for `extra_query` and `metadata` in the LiteLLM chat path, matching #4544's handling in the AnyLLM path. Empty dicts are now forwarded instead of silently discarded.

## Verification

- Added a regression test (`test_empty_extra_query_and_metadata_are_forwarded`) that mocks `litellm.acompletion` and asserts `extra_query={}` and `metadata={}` reach the provider. Confirmed it fails (`KeyError: 'extra_query'`) before the fix and passes after.
- `ruff check` / `ruff format --check` clean on both touched files.
- Related LiteLLM tests pass (`test_litellm_extra_body.py`, `test_litellm_content_filter.py`, `test_litellm_usage_requests.py` — 16 passed).
