### PR TITLE
fix(realtime): advance crossed guardrail thresholds

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -1774,7 +1774,10 @@ class RealtimeSession(RealtimeModelListener):
         next_run_threshold = (self._item_guardrail_run_counts[item_id] + 1) * threshold
 
         if current_length >= next_run_threshold:
-            self._item_guardrail_run_counts[item_id] += 1
+            crossed_thresholds = current_length // threshold if threshold > 0 else 1
+            self._item_guardrail_run_counts[item_id] = max(
+                self._item_guardrail_run_counts[item_id] + 1, crossed_thresholds
+            )
             self._enqueue_guardrail_task(
                 self._item_transcripts[item_id],
                 response_id,

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -5589,6 +5589,39 @@ class TestGuardrailFunctionality:
         assert len(mock_model.sent_messages) == 1
 
     @pytest.mark.asyncio
+    async def test_large_transcript_delta_advances_past_each_crossed_threshold(
+        self, mock_model, mock_agent
+    ):
+        calls = 0
+
+        async def guardrail_func(context, agent, output):
+            nonlocal calls
+            calls += 1
+            return GuardrailFunctionOutput(output_info={}, tripwire_triggered=False)
+
+        guardrail = OutputGuardrail(guardrail_function=guardrail_func)
+        run_config: RealtimeRunConfig = {
+            "output_guardrails": [guardrail],
+            "guardrails_settings": {"debounce_text_length": 5},
+        }
+        session = RealtimeSession(mock_model, mock_agent, None, run_config=run_config)
+
+        await session.on_event(
+            RealtimeModelTranscriptDeltaEvent(
+                item_id="item_1", delta="123456789012", response_id="resp_1"
+            )
+        )
+        await self._wait_for_guardrail_tasks(session)
+        assert calls == 1
+
+        await session.on_event(
+            RealtimeModelTranscriptDeltaEvent(item_id="item_1", delta="3", response_id="resp_1")
+        )
+        await self._wait_for_guardrail_tasks(session)
+
+        assert calls == 1
+
+    @pytest.mark.asyncio
     async def test_transcript_delta_different_items_tracked_separately(
         self, mock_model, mock_agent, safe_guardrail
     ):


### PR DESCRIPTION
### Summary

Realtime output guardrails run when accumulated text reaches each configured debounce threshold. A single large transcript delta could cross multiple thresholds, but the session advanced its threshold counter by only one. The next small delta could therefore schedule another guardrail check even though the accumulated text had not reached the next threshold.

Advance the counter to the highest threshold crossed by the current accumulated length while preserving the existing behavior for ordinary incremental deltas and legacy non-positive values. This changes no public API, event shape, guardrail result, interruption, or cleanup behavior.

### Test plan

- Added a regression through `RealtimeSession.on_event()` that sends 12 characters with a threshold of 5, then one additional character. Before the fix, the safe guardrail ran twice; after the fix, it runs once until the next threshold is reached.
- `uv run pytest tests/realtime/test_session.py -q` — `198 passed`
- `make typecheck` — mypy passed for 307 source files; Pyright reported 0 errors
- `.agents/skills/code-change-verification/scripts/run.sh` — format and lint passed; the broad suite completed with `9029 passed, 28 skipped, 3 failed`. The failures were unrelated native-sandbox, multiprocessing, and 0.2-second scheduling tests. The multiprocessing and scheduling failures passed when rerun individually; `test_python_skill_uses_absolute_root_from_nested_workdir` remains unavailable on this host because its native sandbox command does not create the expected output file.
- `git diff --check` — passed

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
