### PR TITLE
fix(mcp): deduplicate managed servers

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -200,7 +200,7 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
         suppress_cancelled_error: bool = True,
         connect_in_parallel: bool = False,
     ) -> None:
-        self._all_servers = list(servers)
+        self._all_servers = self._unique_servers(servers)
         self._active_servers = list(self._all_servers)
         self.connect_timeout_seconds = connect_timeout_seconds
         self.cleanup_timeout_seconds = cleanup_timeout_seconds

--- a/tests/mcp/test_mcp_server_manager_cleanup_state.py
+++ b/tests/mcp/test_mcp_server_manager_cleanup_state.py
@@ -30,6 +30,22 @@ async def test_cleanup_all_removes_cleaned_servers_from_active_servers() -> None
 
 
 @pytest.mark.asyncio
+async def test_manager_owns_repeated_server_instance_once() -> None:
+    server = cast(MCPServer, Mock(spec=MCPServer))
+    server.connect = AsyncMock()
+    server.cleanup = AsyncMock()
+
+    manager = MCPServerManager([server, server])
+
+    assert manager.all_servers == [server]
+    assert await manager.connect_all() == [server]
+    await manager.cleanup_all()
+
+    server.connect.assert_awaited_once()
+    server.cleanup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_cleanup_all_refreshes_active_servers_when_cancellation_propagates() -> None:
     server = cast(MCPServer, Mock(spec=MCPServer))
     server.connect = AsyncMock()


### PR DESCRIPTION
### Summary

`MCPServerManager` already deduplicated its connection attempt list by server identity, but retained repeated instances in its configured and active lists. Passing the same server object twice therefore connected it once while exposing it twice and cleaning it up twice.

Normalize the constructor iterable with the manager's existing identity-based deduplication helper. First-occurrence ordering is preserved, and distinct server objects remain distinct. This changes no transport, retry, timeout, failure, or parallel-worker behavior.

### Test plan

- Added a lifecycle regression showing that a repeated server instance appears once in `all_servers`, connects once, appears once in the active result, and cleans up once.
- `uv run pytest tests/mcp/test_mcp_server_manager_cleanup_state.py tests/mcp/test_mcp_server_manager.py tests/mcp/test_connect_disconnect.py -q` — `85 passed`
- `make typecheck` — mypy passed for 307 source files; Pyright reported 0 errors
- `.agents/skills/code-change-verification/scripts/run.sh` — format and lint passed; the broad suite completed with `9029 passed, 28 skipped, 3 failed`. The failures were unrelated native-sandbox and timing-sensitive tests. The timing-sensitive failures passed when rerun individually; `test_python_skill_uses_absolute_root_from_nested_workdir` remains unavailable on this host because its native sandbox command does not create the expected output file.
- `git diff --check` — passed

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
