### PR TITLE
fix(voice): use monotonic STT event deadlines

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from time import monotonic
 from typing import Any, cast
 
 from openai import AsyncOpenAI
@@ -90,9 +90,11 @@ async def _wait_for_event(
     """
     Wait for an event from event_queue whose type is in expected_types within the specified timeout.
     """
-    start_time = time.time()
+    # Wall-clock adjustments can move a deadline forwards or backwards. Timeout
+    # accounting must use a monotonic clock instead.
+    start_time = monotonic()
     while True:
-        remaining = timeout - (time.time() - start_time)
+        remaining = timeout - (monotonic() - start_time)
         if remaining <= 0:
             raise TimeoutError(f"Timeout waiting for event(s): {expected_types}")
         evt = await asyncio.wait_for(event_queue.get(), timeout=remaining)

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -4,7 +4,6 @@ import asyncio
 import base64
 import json
 import logging
-import time
 from collections.abc import AsyncGenerator
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -30,10 +29,10 @@ try:
     )
     from agents.voice.exceptions import STTWebsocketConnectionError
     from agents.voice.models.openai_stt import (
-        EVENT_INACTIVITY_TIMEOUT,
         ErrorSentinel,
         WebsocketDoneSentinel,
         _audio_buffer_to_base64,
+        _wait_for_event,
     )
 
     from .pipeline_test_models import StreamedAudioInputFactory
@@ -55,6 +54,31 @@ def create_mock_websocket(messages: list[str]) -> AsyncMock:
     # The incoming_messages are strings that we pretend come from the server
     mock_ws.__aiter__.return_value = iter(messages)
     return mock_ws
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_returns_matching_event() -> None:
+    queue: asyncio.Queue[dict[str, str]] = asyncio.Queue()
+    await queue.put({"type": "session.created"})
+
+    event = await _wait_for_event(queue, ["session.created"], timeout=1)
+
+    assert event == {"type": "session.created"}
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_uses_one_deadline_across_unrelated_events() -> None:
+    queue: asyncio.Queue[dict[str, str]] = asyncio.Queue()
+    await queue.put({"type": "unrelated"})
+
+    with patch(
+        "agents.voice.models.openai_stt.monotonic",
+        side_effect=[1000.0, 1000.0, 1011.0],
+    ):
+        with pytest.raises(TimeoutError, match="Timeout waiting for event"):
+            await _wait_for_event(queue, ["session.created"], timeout=10)
+
+    assert queue.empty()
 
 
 def create_mock_openai_client(api_key: str = "FAKE_KEY") -> AsyncOpenAI:
@@ -593,8 +617,8 @@ async def test_timeout_waiting_for_created_event(monkeypatch):
     def fake_time_func():
         return next(time_gen)
 
-    # Monkey-patch time.time with our fake_time_func
-    monkeypatch.setattr(time, "time", fake_time_func)
+    # Patch only the STT deadline clock so the asyncio event-loop clock remains real.
+    monkeypatch.setattr("agents.voice.models.openai_stt.monotonic", fake_time_func)
 
     mock_ws = create_mock_websocket(
         [
@@ -755,60 +779,43 @@ async def test_listener_timeout_drains_buffered_transcript_before_setup():
 
 
 @pytest.mark.asyncio
-async def test_inactivity_timeout():
+async def test_inactivity_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     """
-    Test that if no events arrive in EVENT_INACTIVITY_TIMEOUT ms,
+    Test that if no events arrive in EVENT_INACTIVITY_TIMEOUT seconds,
     _handle_events breaks out and a SessionCompleteSentinel is placed in the output queue.
     """
-    # We'll feed only the creation + updated events. Then do nothing.
-    # The handle_events loop should eventually time out.
-    mock_ws = create_mock_websocket(
-        [
-            json.dumps({"type": "unknown"}),
-            json.dumps({"type": "unknown"}),
-            json.dumps({"type": "transcription_session.created"}),
-            json.dumps({"type": "transcription_session.updated"}),
-        ]
-    )
 
-    # We'll artificially manipulate the "time" to simulate inactivity quickly.
-    # The code checks time.time() for inactivity over EVENT_INACTIVITY_TIMEOUT.
-    # We'll increment the return_value manually.
-    with (
-        patch("websockets.connect", return_value=mock_ws),
-        patch(
-            "time.time",
-            side_effect=[
-                1000.0,
-                1000.0 + EVENT_INACTIVITY_TIMEOUT + 1,
-                2000.0 + EVENT_INACTIVITY_TIMEOUT + 1,
-                3000.0 + EVENT_INACTIVITY_TIMEOUT + 1,
-                9999,
-            ],
-        ),
-    ):
+    async def messages_then_wait() -> AsyncGenerator[str, None]:
+        yield json.dumps({"type": "transcription_session.created"})
+        yield json.dumps({"type": "transcription_session.updated"})
+        await asyncio.Event().wait()
+
+    mock_ws = AsyncMock()
+    mock_ws.__aenter__.return_value = mock_ws
+    mock_ws.__aiter__.side_effect = messages_then_wait
+    monkeypatch.setattr("agents.voice.models.openai_stt.EVENT_INACTIVITY_TIMEOUT", 0.01)
+
+    with patch("websockets.connect", return_value=mock_ws):
         audio_input = await StreamedAudioInputFactory.get(count=2)
-        stt_settings = STTModelSettings()
-
         session = OpenAISTTTranscriptionSession(
             input=audio_input,
             client=create_mock_openai_client(),
             model="whisper-1",
-            settings=stt_settings,
+            settings=STTModelSettings(),
             trace_include_sensitive_data=False,
             trace_include_sensitive_audio_data=False,
         )
 
-        collected_turns: list[str] = []
-        with pytest.raises(STTWebsocketConnectionError) as exc_info:
-            async for turn in session.transcribe_turns():
-                collected_turns.append(turn)
+        async def collect_turns() -> list[str]:
+            return [turn async for turn in session.transcribe_turns()]
 
-        assert "Timeout waiting for transcription_session" in str(exc_info.value)
+        collected_turns = await asyncio.wait_for(collect_turns(), timeout=1)
 
-        assert len(collected_turns) == 0, "No transcripts expected, but we got something?"
-
-        await session.close()
+        assert collected_turns == []
+        assert session._process_events_task is not None
+        assert session._process_events_task.done()
+        assert not session._process_events_task.cancelled()
+        assert session._process_events_task.exception() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request supersedes #4571 and fixes streamed STT event timeout accounting so system wall-clock adjustments cannot move session setup deadlines forwards or backwards.

It uses a module-local monotonic clock for the cumulative deadline across unrelated events. The regression tests patch only that STT-local clock binding so the asyncio scheduler keeps its real clock, cover matching and unrelated events, and correct the inactivity test to reach `_handle_events` and finish normally after inactivity.