### PR TITLE
feat: customize output guardrail blocked messages

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -111,6 +111,8 @@ from .retry import (
     retry_policies,
 )
 from .run import (
+    OutputGuardrailBlockedMessageArgs,
+    OutputGuardrailBlockedMessageFormatter,
     ReasoningItemIdPolicy,
     RunConfig,
     Runner,
@@ -481,6 +483,8 @@ __all__ = [
     "RunResultStreaming",
     "ResponsesWebSocketSession",
     "RunConfig",
+    "OutputGuardrailBlockedMessageArgs",
+    "OutputGuardrailBlockedMessageFormatter",
     "ToolNameCollisionPolicy",
     "ReasoningItemIdPolicy",
     "ToolExecutionConfig",

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -45,6 +45,8 @@ from .run_config import (
     CallModelData,
     CallModelInputFilter,
     ModelInputData,
+    OutputGuardrailBlockedMessageArgs,
+    OutputGuardrailBlockedMessageFormatter,
     ReasoningItemIdPolicy,
     RunConfig,
     RunOptions,
@@ -82,12 +84,14 @@ from .run_internal.agent_runner_helpers import (
 )
 from .run_internal.approvals import approvals_from_step
 from .run_internal.blocked_output import (
+    OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
     _blocked_output_failure_items,
     _BlockedOutputOwnerStarts,
     _current_response_boundary,
     _final_turn_items_for_persistence,
     _has_output_guardrails,
     _is_terminal_tool_output_response,
+    _resolve_output_guardrail_blocked_message,
     _retained_items_for_blocked_response,
     _sanitize_blocked_output_guardrail_results,
     _should_defer_interrupted_session_items,
@@ -170,6 +174,8 @@ __all__ = [
     "ModelInputData",
     "CallModelData",
     "CallModelInputFilter",
+    "OutputGuardrailBlockedMessageArgs",
+    "OutputGuardrailBlockedMessageFormatter",
     "ToolNameCollisionPolicy",
     "ReasoningItemIdPolicy",
     "ToolExecutionConfig",
@@ -1262,12 +1268,30 @@ class AgentRunner:
                                         (),
                                         blocked_output_owner_starts,
                                     )
+                                    blocked_message = _resolve_output_guardrail_blocked_message(
+                                        exc,
+                                        agent=current_agent,
+                                        run_config=run_config,
+                                        context_wrapper=context_wrapper,
+                                    )
+                                    if blocked_message != OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT:
+                                        sanitized_results = (
+                                            _sanitize_blocked_output_guardrail_results(
+                                                sanitized_results,
+                                                exc,
+                                                blocked_message,
+                                            )
+                                        )
+                                        output_guardrail_results[output_guardrail_result_start:] = (
+                                            sanitized_results
+                                        )
                                     retained_items = _retained_items_for_blocked_response(
                                         turn_session_items,
                                         turn_result.model_response,
                                         run_state,
                                         current_processed_response,
                                         owner_starts=blocked_output_owner_starts,
+                                        blocked_message=blocked_message,
                                     )
                                     list.extend(session_items, retained_items)
                                     try:
@@ -1865,8 +1889,7 @@ class AgentRunner:
                                 ):
                                     raise
                                 sanitized_results = _sanitize_blocked_output_guardrail_results(
-                                    output_guardrail_results[output_guardrail_result_start:],
-                                    exc,
+                                    output_guardrail_results[output_guardrail_result_start:], exc
                                 )
                                 output_guardrail_results[output_guardrail_result_start:] = (
                                     sanitized_results
@@ -1876,12 +1899,28 @@ class AgentRunner:
                                     (),
                                     blocked_output_owner_starts,
                                 )
+                                blocked_message = _resolve_output_guardrail_blocked_message(
+                                    exc,
+                                    agent=current_agent,
+                                    run_config=run_config,
+                                    context_wrapper=context_wrapper,
+                                )
+                                if blocked_message != OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT:
+                                    sanitized_results = _sanitize_blocked_output_guardrail_results(
+                                        sanitized_results,
+                                        exc,
+                                        blocked_message,
+                                    )
+                                    output_guardrail_results[output_guardrail_result_start:] = (
+                                        sanitized_results
+                                    )
                                 retained_items = _retained_items_for_blocked_response(
                                     turn_session_items,
                                     turn_result.model_response,
                                     run_state,
                                     turn_result.processed_response,
                                     owner_starts=blocked_output_owner_starts,
+                                    blocked_message=blocked_message,
                                 )
                                 list.extend(session_items, retained_items)
                                 try:

--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -102,6 +103,33 @@ class ToolErrorFormatterArgs(Generic[TContext]):
 
 
 ToolErrorFormatter = Callable[[ToolErrorFormatterArgs[Any]], MaybeAwaitable[str | None]]
+
+
+@dataclass
+class OutputGuardrailBlockedMessageArgs(Generic[TContext]):
+    """Data passed to output guardrail blocked-message formatters."""
+
+    default_message: str
+    """The SDK default data-free placeholder."""
+
+    guardrail_name: str
+    """The name of the output guardrail that triggered the tripwire."""
+
+    agent: Agent[Any]
+    """The agent whose final output was rejected."""
+
+    run_context: RunContextWrapper[TContext]
+    """The active run context wrapper."""
+
+
+# Keep this formatter synchronous. It runs after a terminal tool output is rejected but before
+# every replay and persistence owner is rebuilt with the data-free replacement. Awaiting
+# application code at that boundary can leave the rejected output reachable through cancellation
+# traceback locals or partially sanitized state. Async support therefore requires a redesign of
+# the redaction boundary, not merely awaiting the formatter result here.
+OutputGuardrailBlockedMessageFormatter = Callable[
+    [OutputGuardrailBlockedMessageArgs[Any]], str | None
+]
 
 
 @dataclass
@@ -458,6 +486,15 @@ class RunConfig:
     Existing strict validation for namespaced and deferred-loading tools is unchanged.
     """
 
+    output_guardrail_blocked_message: str | OutputGuardrailBlockedMessageFormatter | None = None
+    """Customize the data-free placeholder retained for terminal tool output rejected by an
+    output guardrail.
+
+    Pass a non-empty string or a synchronous formatter that receives safe run metadata. Returning
+    ``None`` or an invalid value, or raising from the formatter, uses the SDK default. The rejected
+    output and guardrail ``output_info`` are never passed to the formatter.
+    """
+
     if TYPE_CHECKING:
 
         def __init__(
@@ -486,11 +523,26 @@ class RunConfig:
             tool_execution: ToolExecutionConfig | dict[str, Any] | None = None,
             tool_not_found_behavior: ToolNotFoundBehavior = "raise_error",
             tool_name_collision_policy: ToolNameCollisionPolicy = "warn",
+            output_guardrail_blocked_message: (
+                str | OutputGuardrailBlockedMessageFormatter | None
+            ) = None,
         ) -> None: ...
 
     def __post_init__(self) -> None:
         if self.tool_name_collision_policy not in ("warn", "error"):
             raise ValueError("tool_name_collision_policy must be either 'warn' or 'error'")
+        blocked_message = self.output_guardrail_blocked_message
+        if type(blocked_message) is str:
+            if not blocked_message:
+                raise ValueError("output_guardrail_blocked_message must be non-empty")
+        elif isinstance(blocked_message, str):
+            raise TypeError(
+                "output_guardrail_blocked_message must be a built-in string, callable, or None"
+            )
+        elif blocked_message is not None and not callable(blocked_message):
+            raise TypeError("output_guardrail_blocked_message must be a string, callable, or None")
+        elif inspect.iscoroutinefunction(blocked_message):
+            raise TypeError("output_guardrail_blocked_message formatter must be synchronous")
         if self.model_settings is not None:
             self.model_settings = _coerce_model_settings(
                 self.model_settings,
@@ -562,6 +614,8 @@ __all__ = [
     "CallModelData",
     "CallModelInputFilter",
     "ModelInputData",
+    "OutputGuardrailBlockedMessageArgs",
+    "OutputGuardrailBlockedMessageFormatter",
     "ReasoningItemIdPolicy",
     "RunConfig",
     "RunOptions",

--- a/src/agents/run_internal/blocked_output.py
+++ b/src/agents/run_internal/blocked_output.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses as _dc
+import inspect
 from collections.abc import Sequence
 from typing import Any, TypeVar, cast
 
@@ -22,7 +23,12 @@ from ..guardrail import GuardrailFunctionOutput, OutputGuardrailResult
 from ..items import ModelResponse, RunItem, ToolCallItem, ToolCallOutputItem
 from ..memory import Session
 from ..result import RunResultStreaming
-from ..run_config import RunConfig
+from ..run_config import (
+    OutputGuardrailBlockedMessageArgs,
+    OutputGuardrailBlockedMessageFormatter,
+    RunConfig,
+)
+from ..run_context import RunContextWrapper
 from ..run_state import RunState
 from ..tool_guardrails import (
     ToolGuardrailFunctionOutput,
@@ -158,6 +164,7 @@ _SIDE_EFFECT_ITEM_TYPES = frozenset({"tool_call_item", "tool_call_output_item"})
 def _sanitize_blocked_output_guardrail_results(
     results: Sequence[OutputGuardrailResult],
     tripwire: OutputGuardrailTripwireTriggered,
+    blocked_message: str = OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
 ) -> list[OutputGuardrailResult]:
     """Build data-free guardrail results and detach the tripwire from raw output."""
     sanitized_by_id: dict[int, OutputGuardrailResult] = {}
@@ -168,7 +175,7 @@ def _sanitize_blocked_output_guardrail_results(
             return existing
         sanitized = OutputGuardrailResult(
             guardrail=result.guardrail,
-            agent_output=OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+            agent_output=blocked_message,
             agent=result.agent,
             output=GuardrailFunctionOutput(
                 output_info=None,
@@ -183,6 +190,44 @@ def _sanitize_blocked_output_guardrail_results(
     _mark_error_data_redacted(tripwire)
     _detach_data_redacted_error_traceback(tripwire)
     return sanitized_results
+
+
+def _resolve_output_guardrail_blocked_message(
+    tripwire: OutputGuardrailTripwireTriggered,
+    *,
+    agent: Agent[Any],
+    run_config: RunConfig,
+    context_wrapper: RunContextWrapper[Any],
+) -> str:
+    """Resolve a custom placeholder without suspending the redaction pipeline."""
+    blocked_message = OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT
+    configured = run_config.output_guardrail_blocked_message
+    if configured is None:
+        return blocked_message
+    if type(configured) is str:
+        resolved: Any = configured
+    else:
+        try:
+            formatter = cast(OutputGuardrailBlockedMessageFormatter, configured)
+            resolved = formatter(
+                OutputGuardrailBlockedMessageArgs(
+                    default_message=blocked_message,
+                    guardrail_name=tripwire.guardrail_result.guardrail.get_name(),
+                    agent=agent,
+                    run_context=context_wrapper,
+                )
+            )
+        except BaseException:
+            return blocked_message
+    if inspect.iscoroutine(resolved):
+        try:
+            resolved.close()
+        except BaseException:
+            pass
+        return blocked_message
+    if type(resolved) is not str or not resolved:
+        return blocked_message
+    return resolved
 
 
 @_dc.dataclass(frozen=True)
@@ -419,6 +464,7 @@ def _is_terminal_tool_output_response(
 def _prepare_blocked_output_snapshot(
     boundary: _CurrentResponseBoundary,
     model_response: ModelResponse | None,
+    blocked_message: str,
 ) -> _BlockedOutputSnapshot:
     """Build an allowlist-only function call/output snapshot before changing live state."""
     current_items = list(boundary.items)
@@ -448,6 +494,7 @@ def _prepare_blocked_output_snapshot(
             )
         elif isinstance(item, ToolCallOutputItem):
             payload = blocked_function_output_payload(item.raw_item)
+            payload["output"] = blocked_message
             call_id = cast(str, payload["call_id"])
             if call_id in outputs_by_id:
                 raise AgentsException("Cannot sanitize duplicate function outputs.")
@@ -455,7 +502,7 @@ def _prepare_blocked_output_snapshot(
             replacements[index] = ToolCallOutputItem(
                 agent=item.agent,
                 raw_item=cast(Any, payload),
-                output=OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+                output=blocked_message,
                 tool_origin=item.tool_origin,
                 custom_data=None,
             )
@@ -640,6 +687,7 @@ def _sever_blocked_output_replay_graph(cleanup_plan: _BlockedOutputOwnerPlan) ->
 
 def _data_free_tool_output_guardrail_results(
     results: Sequence[ToolOutputGuardrailResult],
+    blocked_message: str,
 ) -> tuple[ToolOutputGuardrailResult, ...]:
     """Rebuild current-turn tool guardrail results without retaining caller output data."""
     replacements: list[ToolOutputGuardrailResult] = []
@@ -656,16 +704,16 @@ def _data_free_tool_output_guardrail_results(
                 return ()
             if str.__eq__(behavior_type, "allow") is True:
                 sanitized_output = ToolGuardrailFunctionOutput.allow(
-                    output_info=OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+                    output_info=blocked_message,
                 )
             elif str.__eq__(behavior_type, "reject_content") is True:
                 sanitized_output = ToolGuardrailFunctionOutput.reject_content(
-                    message=OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
-                    output_info=OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+                    message=blocked_message,
+                    output_info=blocked_message,
                 )
             elif str.__eq__(behavior_type, "raise_exception") is True:
                 sanitized_output = ToolGuardrailFunctionOutput.raise_exception(
-                    output_info=OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+                    output_info=blocked_message,
                 )
             else:
                 return ()
@@ -688,6 +736,7 @@ def _prepare_blocked_output_owner_plan(
     streamed_result: RunResultStreaming | None,
     prefixes: _BlockedOutputOwnerPrefixes,
     cleanup_plan: _BlockedOutputOwnerPlan,
+    blocked_message: str,
 ) -> _BlockedOutputOwnerPlan:
     """Build every owner replacement before applying any of them."""
     safe_items = list(snapshot.items) if snapshot is not None else []
@@ -706,7 +755,10 @@ def _prepare_blocked_output_owner_plan(
         )
     else:
         current_results = []
-    safe_tool_output_guardrail_results = _data_free_tool_output_guardrail_results(current_results)
+    safe_tool_output_guardrail_results = _data_free_tool_output_guardrail_results(
+        current_results,
+        blocked_message,
+    )
     if streamed_result is not None:
         public_safe_results = [
             *prefixes.streamed_tool_output_guardrail_results,
@@ -793,6 +845,7 @@ def _retained_items_for_blocked_response(
     processed_response: ProcessedResponse | None = None,
     streamed_result: RunResultStreaming | None = None,
     owner_starts: _BlockedOutputOwnerStarts | None = None,
+    blocked_message: str = OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
 ) -> list[RunItem]:
     """Return a complete data-free response or discard the entire unsupported suffix."""
     boundary = _current_response_boundary(items, processed_response, run_state)
@@ -805,7 +858,11 @@ def _retained_items_for_blocked_response(
     snapshot: _BlockedOutputSnapshot | None = None
     try:
         if boundary.proven:
-            snapshot = _prepare_blocked_output_snapshot(boundary, model_response)
+            snapshot = _prepare_blocked_output_snapshot(
+                boundary,
+                model_response,
+                blocked_message,
+            )
     except Exception:
         snapshot = None
     except BaseException:
@@ -820,6 +877,7 @@ def _retained_items_for_blocked_response(
             streamed_result,
             prefixes,
             cleanup_plan,
+            blocked_message,
         )
         _apply_blocked_output_owner_plan(owner_plan)
     except Exception as error:

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -114,6 +114,7 @@ from .blocked_output import (
     _final_turn_items_for_persistence,
     _has_output_guardrails,
     _is_terminal_tool_output_response,
+    _resolve_output_guardrail_blocked_message,
     _retained_items_for_blocked_response,
     _sanitize_blocked_output_guardrail_results,
     _should_defer_interrupted_session_items,
@@ -530,13 +531,30 @@ async def _finalize_streamed_final_output(
             *streamed_result.output_guardrail_results[:output_guardrail_result_start],
             *sanitized_results,
         ]
+        blocked_message = _resolve_output_guardrail_blocked_message(
+            exc,
+            agent=agent,
+            run_config=run_config,
+            context_wrapper=context_wrapper,
+        )
+        if blocked_message != OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT:
+            sanitized_results = _sanitize_blocked_output_guardrail_results(
+                sanitized_results,
+                exc,
+                blocked_message,
+            )
+            streamed_result.output_guardrail_results = [
+                *streamed_result.output_guardrail_results[:output_guardrail_result_start],
+                *sanitized_results,
+            ]
         retained_items = _retained_items_for_blocked_response(
             items,
             model_response,
             streamed_result._state,
             processed_response,
-            streamed_result,
-            owner_starts,
+            streamed_result=streamed_result,
+            owner_starts=owner_starts,
+            blocked_message=blocked_message,
         )
         if retained_items:
             try:

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -35,6 +35,7 @@ from agents import (
     OpenAIChatCompletionsModel,
     OpenAIResponsesWSModel,
     OutputGuardrail,
+    OutputGuardrailBlockedMessageArgs,
     OutputGuardrailTripwireTriggered,
     RunContextWrapper,
     Runner,
@@ -48,7 +49,13 @@ from agents import (
     handoff,
     retry_policies,
 )
-from agents.items import RunItem, ToolApprovalItem, TResponseInputItem, TResponseStreamEvent
+from agents.items import (
+    RunItem,
+    ToolApprovalItem,
+    ToolCallOutputItem,
+    TResponseInputItem,
+    TResponseStreamEvent,
+)
 from agents.memory.openai_conversations_session import OpenAIConversationsSession
 from agents.models.interface import Model
 from agents.run import RunConfig
@@ -2902,6 +2909,275 @@ async def test_stop_on_first_tool_final_persists_committed_tool_items_on_tripwir
     )
     assert replayed_output == run_loop._OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT
     assert "committed-result" not in json.dumps(model_input)
+
+
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
+@pytest.mark.parametrize("customizer_kind", ["fixed", "sync"])
+@pytest.mark.asyncio
+async def test_terminal_tool_trip_uses_custom_blocked_message_everywhere(
+    mode: str,
+    customizer_kind: str,
+) -> None:
+    blocked_message = "出力ガードレールにより非表示になりました。"
+    formatter_args: list[OutputGuardrailBlockedMessageArgs[dict[str, str]]] = []
+    context = {"locale": "ja"}
+
+    def sync_formatter(
+        args: OutputGuardrailBlockedMessageArgs[dict[str, str]],
+    ) -> str:
+        formatter_args.append(args)
+        return blocked_message
+
+    customizer: Any
+    if customizer_kind == "fixed":
+        customizer = blocked_message
+    else:
+        customizer = sync_formatter
+
+    @tool_output_guardrail
+    def retain_tool_output(data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info=data.output)
+
+    @function_tool(
+        name_override="secret_tool",
+        tool_output_guardrails=[retain_tool_output],
+    )
+    def secret_tool() -> str:
+        return "blocked-secret"
+
+    def reject_output(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(
+            output_info={"secret": "blocked-output-info"},
+            tripwire_triggered=True,
+        )
+
+    model = ScriptedModel([[get_function_tool_call("secret_tool", "{}", call_id="call-secret")]])
+    guardrail = OutputGuardrail(
+        guardrail_function=reject_output,
+        name="localized_guardrail",
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[secret_tool],
+        tool_use_behavior="stop_on_first_tool",
+        output_guardrails=[guardrail],
+    )
+    session = SimpleListSession()
+    run_config = RunConfig(output_guardrail_blocked_message=customizer)
+    streamed_result = None
+
+    with pytest.raises(OutputGuardrailTripwireTriggered) as exc_info:
+        if mode == "non_streamed":
+            await Runner.run(
+                agent,
+                "run",
+                context=context,
+                session=session,
+                run_config=run_config,
+            )
+        else:
+            streamed_result = Runner.run_streamed(
+                agent,
+                "run",
+                context=context,
+                session=session,
+                run_config=run_config,
+            )
+            await consume_stream(streamed_result)
+
+    assert exc_info.value.guardrail_result.agent_output == blocked_message
+    assert exc_info.value.guardrail_result.output.output_info is None
+    saved_items = await session.get_items()
+    assert cast(dict[str, Any], saved_items[-1])["output"] == blocked_message
+    assert "blocked-secret" not in json.dumps(saved_items)
+    assert "blocked-output-info" not in json.dumps(saved_items)
+
+    if customizer_kind == "fixed":
+        assert formatter_args == []
+    else:
+        assert len(formatter_args) == 1
+        args = formatter_args[0]
+        assert vars(args).keys() == {
+            "default_message",
+            "guardrail_name",
+            "agent",
+            "run_context",
+        }
+        assert args.default_message == run_loop._OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT
+        assert args.guardrail_name == "localized_guardrail"
+        assert args.agent is agent
+        assert args.run_context.context is context
+
+    if streamed_result is not None:
+        streamed_outputs = [
+            item for item in streamed_result.new_items if isinstance(item, ToolCallOutputItem)
+        ]
+        assert [item.output for item in streamed_outputs] == [blocked_message]
+        assert (
+            streamed_result.tool_output_guardrail_results[0].output.output_info == blocked_message
+        )
+        serialized_state = streamed_result.to_state().to_json()
+        assert blocked_message in json.dumps(serialized_state, ensure_ascii=False)
+        assert "blocked-secret" not in json.dumps(serialized_state)
+        assert "blocked-output-info" not in json.dumps(serialized_state)
+
+    agent.output_guardrails = []
+    model.enqueue([get_text_message("done")])
+    if mode == "non_streamed":
+        followup: Any = await Runner.run(
+            agent,
+            "continue",
+            context=context,
+            session=session,
+            run_config=run_config,
+        )
+    else:
+        followup = Runner.run_streamed(
+            agent,
+            "continue",
+            context=context,
+            session=session,
+            run_config=run_config,
+        )
+        await consume_stream(followup)
+    assert followup.final_output == "done"
+    assert blocked_message in json.dumps(model.calls[-1].input, ensure_ascii=False)
+
+
+@pytest.mark.parametrize(
+    "formatter_outcome",
+    [
+        "none",
+        "empty",
+        "non_string",
+        "string_subclass",
+        "awaitable",
+        "awaitable_close_error",
+        "error",
+        "cancel",
+    ],
+)
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
+@pytest.mark.asyncio
+async def test_terminal_tool_trip_falls_back_when_blocked_message_formatter_fails(
+    formatter_outcome: str,
+    mode: str,
+) -> None:
+    formatter_calls = 0
+
+    class FormatterStringSubclass(str):
+        def __len__(self) -> int:
+            raise RuntimeError("formatter-subclass-secret")
+
+        def __str__(self) -> str:
+            raise RuntimeError("formatter-subclass-secret")
+
+    def formatter(_args: OutputGuardrailBlockedMessageArgs[Any]) -> Any:
+        nonlocal formatter_calls
+        formatter_calls += 1
+        if formatter_outcome == "none":
+            return None
+        if formatter_outcome == "empty":
+            return ""
+        if formatter_outcome == "non_string":
+            return 123
+        if formatter_outcome == "string_subclass":
+            return FormatterStringSubclass("formatter-subclass-secret")
+        if formatter_outcome == "awaitable":
+
+            async def async_value() -> str:
+                return "formatter-awaitable-secret"
+
+            return async_value()
+        if formatter_outcome == "awaitable_close_error":
+
+            async def async_value_with_failing_close() -> str:
+                try:
+                    await asyncio.sleep(0)
+                finally:
+                    raise RuntimeError("formatter-close-secret")
+
+            coroutine = async_value_with_failing_close()
+            coroutine.send(None)
+            return coroutine
+        if formatter_outcome == "error":
+            raise RuntimeError("formatter-secret")
+        raise asyncio.CancelledError("formatter-cancel-secret")
+
+    @function_tool(name_override="secret_tool")
+    def secret_tool() -> str:
+        return "blocked-secret"
+
+    def reject_output(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(
+            output_info="blocked-output-info",
+            tripwire_triggered=True,
+        )
+
+    model = ScriptedModel([[get_function_tool_call("secret_tool", "{}", call_id="call-secret")]])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[secret_tool],
+        tool_use_behavior="stop_on_first_tool",
+        output_guardrails=[OutputGuardrail(guardrail_function=reject_output)],
+    )
+    session = SimpleListSession()
+    streamed_result = None
+
+    with pytest.raises(OutputGuardrailTripwireTriggered) as exc_info:
+        if mode == "non_streamed":
+            await Runner.run(
+                agent,
+                "run",
+                session=session,
+                run_config=RunConfig(output_guardrail_blocked_message=formatter),
+            )
+        else:
+            streamed_result = Runner.run_streamed(
+                agent,
+                "run",
+                session=session,
+                run_config=RunConfig(output_guardrail_blocked_message=formatter),
+            )
+            await consume_stream(streamed_result)
+
+    default_message = run_loop._OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT
+    assert formatter_calls == 1
+    assert exc_info.value.guardrail_result.agent_output == default_message
+    assert exc_info.value.guardrail_result.output.output_info is None
+    saved_items = await session.get_items()
+    assert cast(dict[str, Any], saved_items[-1])["output"] == default_message
+    serialized = json.dumps(saved_items)
+    assert "blocked-secret" not in serialized
+    assert "blocked-output-info" not in serialized
+    assert "formatter-secret" not in serialized
+    assert "formatter-cancel-secret" not in serialized
+    assert "formatter-subclass-secret" not in serialized
+    assert "formatter-awaitable-secret" not in serialized
+    assert "formatter-close-secret" not in serialized
+
+    if streamed_result is not None:
+        streamed_views = [
+            repr(streamed_result.new_items),
+            repr(streamed_result._model_input_items),
+            repr(streamed_result.raw_responses),
+            repr(streamed_result.tool_output_guardrail_results),
+            json.dumps(streamed_result.to_state().to_json()),
+        ]
+        assert all("blocked-secret" not in view for view in streamed_views)
+        assert all("blocked-output-info" not in view for view in streamed_views)
+        assert all("formatter-close-secret" not in view for view in streamed_views)
+        assert default_message in streamed_views[-1]
 
 
 @pytest.mark.parametrize("mode", ["non_streamed", "streamed"])

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -7,6 +7,7 @@ import pytest
 
 from agents import (
     Agent,
+    OutputGuardrailBlockedMessageArgs,
     RunConfig,
     Runner,
     SessionSettings,
@@ -96,6 +97,43 @@ def test_run_config_preserves_typed_configuration_instances() -> None:
 
     assert config.model_settings is settings
     assert config.session_settings is session_settings
+
+
+def test_run_config_accepts_output_guardrail_blocked_message_customizers() -> None:
+    def formatter(_args: OutputGuardrailBlockedMessageArgs[Any]) -> str:
+        return "custom"
+
+    assert RunConfig(
+        output_guardrail_blocked_message="custom"
+    ).output_guardrail_blocked_message == ("custom")
+    assert RunConfig(
+        output_guardrail_blocked_message=formatter
+    ).output_guardrail_blocked_message is (formatter)
+
+
+def test_run_config_rejects_async_output_guardrail_blocked_message_formatter() -> None:
+    async def formatter(_args: OutputGuardrailBlockedMessageArgs[Any]) -> str:
+        return "custom"
+
+    with pytest.raises(
+        TypeError,
+        match="output_guardrail_blocked_message formatter must be synchronous",
+    ):
+        RunConfig(output_guardrail_blocked_message=cast(Any, formatter))
+
+
+class _BlockedMessageStringSubclass(str):
+    def __len__(self) -> int:
+        raise RuntimeError("string-subclass-hook")
+
+
+@pytest.mark.parametrize("value", ["", 123, _BlockedMessageStringSubclass("custom")])
+def test_run_config_rejects_invalid_output_guardrail_blocked_message(value: object) -> None:
+    with pytest.raises(
+        (TypeError, ValueError),
+        match="output_guardrail_blocked_message",
+    ):
+        RunConfig(output_guardrail_blocked_message=cast(Any, value))
 
 
 def test_run_config_rejects_untrusted_manifest_path_grants() -> None:


### PR DESCRIPTION
This pull request adds configurable, data-free placeholder messages for terminal tool output rejected by an output guardrail.

`RunConfig.output_guardrail_blocked_message` accepts either a non-empty fixed string or a synchronous formatter receiving the default message, guardrail name, current agent, and run context. This allows applications to localize or otherwise adjust the retained message based on context.

The selected placeholder is applied consistently to the caller-visible tripwire, Session history, serialized `RunState`, streamed results, tool-output guardrail metadata, and subsequent model replay. Formatter failures and invalid return values fail closed to the existing SDK default, and rejected output or guardrail `output_info` is never passed to the formatter.

Async formatters are intentionally rejected. Awaiting application code between the terminal tripwire and retained-owner redaction can leave rejected output reachable through cancellation traceback locals or partially sanitized state, so async support requires a redesign of that redaction boundary rather than simply awaiting the formatter result.