### PR TITLE
fix: enforce public type alias contract coverage

### DIFF
--- a/.github/scripts/update_released_api_contract.py
+++ b/.github/scripts/update_released_api_contract.py
@@ -126,8 +126,8 @@ def main() -> int:
     print(f"Removed exports: {sorted(previous_exports - current_exports)!r}")
     print(
         "Review shipped example imports and update released_api_contract_policy.json when "
-        "the release adds canonical imports, public properties, public TypedDict fields, or "
-        "public modules."
+        "the release adds canonical imports, public properties, public type aliases, public "
+        "TypedDict fields, or public modules."
     )
     return 0
 

--- a/integration_tests/_contract_support.py
+++ b/integration_tests/_contract_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import dataclasses
 import enum
 import importlib
@@ -8,12 +9,23 @@ import json
 import logging
 import sys
 import traceback
+import typing
 from collections.abc import Callable, Iterable, Mapping
 from copy import deepcopy
 from importlib.util import find_spec
 from pathlib import Path
-from types import FunctionType, TracebackType, UnionType
-from typing import Any, ForwardRef, Literal, Union, cast, get_args, get_origin, get_type_hints
+from types import FunctionType, ModuleType, TracebackType, UnionType
+from typing import (
+    Any,
+    ForwardRef,
+    Literal,
+    TypeAlias,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 import typing_extensions
 from pydantic import BaseModel
@@ -888,7 +900,261 @@ def _sorted_type_alias_members(members: Iterable[dict[str, object]]) -> list[dic
     )
 
 
-def _type_alias_definition(value: object) -> dict[str, object]:
+def _is_type_alias_type(value: object) -> bool:
+    native_type_alias_type = getattr(typing, "TypeAliasType", typing_extensions.TypeAliasType)
+    return isinstance(value, typing_extensions.TypeAliasType | native_type_alias_type)
+
+
+def _is_type_alias_annotation(annotation: object, module: object) -> bool:
+    if annotation is TypeAlias or annotation is typing_extensions.TypeAlias:
+        return True
+    if not isinstance(annotation, str):
+        return False
+    reference_parts = annotation.split(".")
+    if not reference_parts or not all(part.isidentifier() for part in reference_parts):
+        return False
+    missing = object()
+    resolved = getattr(module, reference_parts[0], missing)
+    for part in reference_parts[1:]:
+        if resolved is missing:
+            break
+        resolved = getattr(resolved, part, missing)
+    return resolved is TypeAlias or resolved is typing_extensions.TypeAlias
+
+
+def _module_declares_type_alias(module: object, alias_name: str, value: object) -> bool:
+    annotations = getattr(module, "__annotations__", {})
+    if not isinstance(annotations, Mapping) or alias_name not in annotations:
+        return False
+    missing = object()
+    return (
+        _is_type_alias_annotation(annotations[alias_name], module)
+        and getattr(module, alias_name, missing) is value
+    )
+
+
+class _ModuleBindingVisitor(ast.NodeVisitor):
+    def __init__(self, name: str):
+        self.name = name
+        self.count = 0
+        self.has_wildcard_import = False
+        self.from_imports: list[tuple[ast.ImportFrom, str]] = []
+        self._bindings_target_module = True
+
+    def _count(self, name: str | None) -> None:
+        if self._bindings_target_module:
+            self.count += name == self.name
+
+    def _visit_nested_scope(self, body: list[ast.stmt]) -> None:
+        bindings_target_module = _scope_declares_global(body, self.name)
+        previous_bindings_target_module = self._bindings_target_module
+        self._bindings_target_module = bindings_target_module
+        for statement in body:
+            self.visit(statement)
+        self._bindings_target_module = previous_bindings_target_module
+
+    def _visit_arguments(self, arguments: ast.arguments) -> None:
+        all_arguments = [
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ]
+        if arguments.vararg is not None:
+            all_arguments.append(arguments.vararg)
+        if arguments.kwarg is not None:
+            all_arguments.append(arguments.kwarg)
+        for argument in all_arguments:
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        for default in [*arguments.defaults, *arguments.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+
+    def _visit_function_definition(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._count(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_arguments(node.args)
+        if node.returns is not None:
+            self.visit(node.returns)
+
+    def _visit_comprehension(
+        self, generators: list[ast.comprehension], values: list[ast.expr]
+    ) -> None:
+        for generator in generators:
+            self.visit(generator.iter)
+            for condition in generator.ifs:
+                self.visit(condition)
+        for value in values:
+            self.visit(value)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Store | ast.Del):
+            self._count(node.id)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function_definition(node)
+        self._visit_nested_scope(node.body)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function_definition(node)
+        self._visit_nested_scope(node.body)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._count(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        self._visit_nested_scope(node.body)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_arguments(node.args)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node.generators, [node.key, node.value])
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        self._count(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node: ast.MatchAs) -> None:
+        self._count(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchStar(self, node: ast.MatchStar) -> None:
+        self._count(node.name)
+
+    def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+        self._count(node.rest)
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for imported in node.names:
+            self._count(imported.asname or imported.name.split(".", 1)[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if not self._bindings_target_module:
+            return
+        for imported in node.names:
+            if imported.name == "*":
+                self.has_wildcard_import = True
+                continue
+            binding_name = imported.asname or imported.name
+            self._count(binding_name)
+            if binding_name == self.name:
+                self.from_imports.append((node, imported.name))
+
+
+def _scope_declares_global(nodes: Iterable[ast.AST], name: str) -> bool:
+    for node in nodes:
+        if isinstance(node, ast.Global):
+            if name in node.names:
+                return True
+            continue
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Lambda):
+            continue
+        if _scope_declares_global(ast.iter_child_nodes(node), name):
+            return True
+    return False
+
+
+def _direct_import_source(
+    module: object, export_name: str, *, package_root: str
+) -> tuple[ModuleType, str] | None:
+    module_name = getattr(module, "__name__", None)
+    package_name = getattr(module, "__package__", None)
+    if not isinstance(module_name, str) or not isinstance(package_name, str):
+        return None
+    try:
+        module_tree = ast.parse(inspect.getsource(module))
+    except (OSError, SyntaxError, TypeError):
+        return None
+
+    bindings = _ModuleBindingVisitor(export_name)
+    bindings.visit(module_tree)
+    if bindings.count != 1 or bindings.has_wildcard_import or len(bindings.from_imports) != 1:
+        return None
+    statement, source_name = bindings.from_imports[0]
+    if statement.level:
+        relative_name = "." * statement.level + (statement.module or "")
+        try:
+            source_module_name = importlib.util.resolve_name(relative_name, package_name)
+        except ImportError:
+            return None
+    else:
+        source_module_name = statement.module
+    if source_module_name is None or not (
+        source_module_name == package_root or source_module_name.startswith(f"{package_root}.")
+    ):
+        return None
+    source_module = sys.modules.get(source_module_name)
+    if not isinstance(source_module, ModuleType):
+        return None
+    return source_module, source_name
+
+
+def _has_explicit_type_alias_declaration(
+    agents_module: object, export_name: str, value: object
+) -> bool:
+    package_root = getattr(agents_module, "__name__", None)
+    module, alias_name = agents_module, export_name
+    visited_bindings: set[tuple[int, str]] = set()
+    missing = object()
+    while (id(module), alias_name) not in visited_bindings:
+        visited_bindings.add((id(module), alias_name))
+        if getattr(module, alias_name, missing) is not value:
+            return False
+        if _module_declares_type_alias(module, alias_name, value):
+            return True
+        if not isinstance(package_root, str):
+            return False
+        import_source = _direct_import_source(module, alias_name, package_root=package_root)
+        if import_source is None:
+            return False
+        module, alias_name = import_source
+    return False
+
+
+def _is_public_type_alias(agents_module: object, export_name: str, value: object) -> bool:
+    return (
+        get_origin(value) is not None
+        or _is_type_alias_type(value)
+        or _has_explicit_type_alias_declaration(agents_module, export_name, value)
+    )
+
+
+def _type_alias_definition(
+    value: object, *, visited_alias_ids: frozenset[int] = frozenset()
+) -> dict[str, object]:
+    if value is Any:
+        return {"kind": "any"}
+    if _is_type_alias_type(value):
+        if value.__type_params__:
+            raise TypeError(f"generic public type alias is unsupported: {value.__name__}")
+        alias_id = id(value)
+        if alias_id in visited_alias_ids:
+            alias_name = getattr(value, "__name__", repr(value))
+            raise TypeError(f"recursive public type alias is unsupported: {alias_name}")
+        try:
+            alias_value = value.__value__
+        except Exception as error:
+            raise TypeError(
+                f"cannot resolve public type alias {value.__name__} at runtime: "
+                f"{type(error).__name__}: {error}"
+            ) from None
+        return _type_alias_definition(alias_value, visited_alias_ids=visited_alias_ids | {alias_id})
     origin = get_origin(value)
     if origin is Literal:
         literal_values: list[dict[str, object]] = []
@@ -904,13 +1170,48 @@ def _type_alias_definition(value: object) -> dict[str, object]:
             "values": _sorted_type_alias_members(literal_values),
         }
     if origin in {Union, UnionType}:
-        members = [_type_alias_definition(member) for member in get_args(value)]
+        members = [
+            _type_alias_definition(member, visited_alias_ids=visited_alias_ids)
+            for member in get_args(value)
+        ]
         return {
             "kind": "union",
             "members": _sorted_type_alias_members(members),
         }
+    if origin is Callable:
+        callable_args = get_args(value)
+        if len(callable_args) != 2:
+            raise TypeError(
+                "public Callable type aliases must declare parameters and a return type"
+            )
+        parameter_types, return_type = callable_args
+        if parameter_types is Ellipsis or not isinstance(parameter_types, list | tuple):
+            raise TypeError("public Callable type aliases must declare explicit parameter types")
+        return {
+            "kind": "callable",
+            "parameters": [
+                _type_alias_definition(parameter_type, visited_alias_ids=visited_alias_ids)
+                for parameter_type in parameter_types
+            ],
+            "return": _type_alias_definition(return_type, visited_alias_ids=visited_alias_ids),
+        }
+    if origin is not None:
+        if not isinstance(origin, type) or not (
+            origin.__module__ == "agents" or origin.__module__.startswith("agents.")
+        ):
+            raise TypeError(f"unsupported public generic type alias origin: {origin!r}")
+        return {
+            "kind": "generic",
+            "origin": f"{origin.__module__}.{origin.__qualname__}",
+            "arguments": [
+                _type_alias_definition(argument, visited_alias_ids=visited_alias_ids)
+                for argument in get_args(value)
+            ],
+        }
     if isinstance(value, type) and (
-        value.__module__ == "agents" or value.__module__.startswith("agents.")
+        value.__module__ == "builtins"
+        or value.__module__ == "agents"
+        or value.__module__.startswith("agents.")
     ):
         return {
             "kind": "type",
@@ -1210,6 +1511,24 @@ def build_released_api_contract(
     released_export_order = list(contract["required_top_level_exports"])
     released_exports = set(released_export_order)
     current_export_names = set(current_exports)
+    if release_policy is not None:
+        promoted_top_level_type_aliases = {
+            entry["name"]
+            for entry in release_policy.public_type_aliases
+            if entry["module"] == "agents"
+        }
+        missing_top_level_type_aliases = sorted(
+            name
+            for name in current_export_names - released_exports
+            if _is_public_type_alias(agents, name, getattr(agents, name))
+            and name not in promoted_top_level_type_aliases
+        )
+        if missing_top_level_type_aliases:
+            raise ValueError(
+                "Cannot promote new top-level type aliases without public_type_aliases policy "
+                "entries for module 'agents': "
+                f"{missing_top_level_type_aliases!r}"
+            )
     ordered_exports = [name for name in released_export_order if name in current_export_names]
     ordered_exports.extend(name for name in current_exports if name not in released_exports)
     tracked_callables = set(contract["callables"])

--- a/tests/fixtures/released_api_contract_policy.json
+++ b/tests/fixtures/released_api_contract_policy.json
@@ -775,6 +775,10 @@
     {
       "module": "agents.voice.events",
       "name": "VoiceStreamEvent"
+    },
+    {
+      "module": "agents",
+      "name": "OutputGuardrailBlockedMessageFormatter"
     }
   ],
   "public_typed_dicts": [

--- a/tests/test_released_api_contract.py
+++ b/tests/test_released_api_contract.py
@@ -1,4 +1,5 @@
 import abc
+import ast
 import builtins
 import importlib
 import inspect
@@ -11,12 +12,13 @@ from enum import Enum
 from importlib.metadata import version
 from inspect import Parameter, Signature
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Any, Literal, cast
+from textwrap import indent
+from types import ModuleType, SimpleNamespace
+from typing import Any, Literal, TypeAlias, TypeVar, cast
 
 import pytest
 from pydantic import BaseModel, Field
-from typing_extensions import Required, TypedDict
+from typing_extensions import Required, TypeAliasType, TypedDict
 
 import integration_tests._contract_support as contract_support
 from integration_tests._contract_support import (
@@ -594,6 +596,583 @@ def test_curated_public_type_alias_contract_records_and_validates_members(
                 ),
             ),
         )
+
+
+def test_new_top_level_type_alias_requires_explicit_policy() -> None:
+    existing_alias = Literal["existing"]
+    new_alias = Callable[[str], str | None]
+    agents_module = SimpleNamespace(
+        __all__=["ExistingAlias", "NewAlias"],
+        ExistingAlias=existing_alias,
+        NewAlias=new_alias,
+    )
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": ["ExistingAlias"],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "public_class_contracts": [],
+        "public_properties": [],
+        "public_type_aliases": [],
+        "public_typed_dicts": [],
+        "callables": {},
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            release_policy=_release_policy({}),
+        )
+
+    assert str(exc_info.value) == (
+        "Cannot promote new top-level type aliases without public_type_aliases policy entries "
+        "for module 'agents': ['NewAlias']"
+    )
+
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        release_policy=_release_policy(
+            {},
+            public_type_aliases=({"module": "agents", "name": "NewAlias"},),
+        ),
+    )
+
+    assert updated["public_type_aliases"] == [
+        {
+            "definition": {
+                "kind": "callable",
+                "parameters": [{"identity": "builtins.str", "kind": "type"}],
+                "return": {
+                    "kind": "union",
+                    "members": [
+                        {"identity": "builtins.NoneType", "kind": "type"},
+                        {"identity": "builtins.str", "kind": "type"},
+                    ],
+                },
+            },
+            "module": "agents",
+            "name": "NewAlias",
+        }
+    ]
+
+    agents_module.NewAlias = Callable[[bytes], str | None]
+    errors = _validate_public_type_alias_contract(updated, agents_module)
+    assert len(errors) == 1
+    assert errors[0].startswith("agents.NewAlias changed its released public type alias")
+
+
+def test_new_originless_explicit_type_alias_requires_policy() -> None:
+    class ExistingClass:
+        pass
+
+    class NewClass:
+        pass
+
+    agents_module = ModuleType("synthetic_agents")
+    agents_module.TypeAlias = TypeAlias
+    agents_module.__annotations__ = {"NewAlias": "TypeAlias"}
+    agents_module.__all__ = [
+        "ExistingClass",
+        "NewAlias",
+        "NewClass",
+        "UnannotatedBinding",
+    ]
+    agents_module.ExistingClass = ExistingClass
+    agents_module.NewAlias = str
+    agents_module.NewClass = NewClass
+    agents_module.UnannotatedBinding = str
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": ["ExistingClass"],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "public_class_contracts": [],
+        "public_properties": [],
+        "public_type_aliases": [],
+        "public_typed_dicts": [],
+        "callables": {},
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            release_policy=_release_policy({}),
+        )
+
+    assert str(exc_info.value) == (
+        "Cannot promote new top-level type aliases without public_type_aliases policy entries "
+        "for module 'agents': ['NewAlias']"
+    )
+
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        release_policy=_release_policy(
+            {},
+            public_type_aliases=({"module": "agents", "name": "NewAlias"},),
+        ),
+    )
+    assert updated["public_type_aliases"] == [
+        {
+            "definition": {"identity": "builtins.str", "kind": "type"},
+            "module": "agents",
+            "name": "NewAlias",
+        }
+    ]
+
+    agents_module.NewAlias = bytes
+    errors = _validate_public_type_alias_contract(updated, agents_module)
+    assert len(errors) == 1
+    assert errors[0].startswith("agents.NewAlias changed its released public type alias")
+
+
+@pytest.mark.parametrize(
+    ("facade_count", "control_flow"), [(0, False), (1, False), (3, False), (1, True)]
+)
+def test_new_renamed_originless_type_alias_reexport_requires_policy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, facade_count: int, control_flow: bool
+) -> None:
+    package_name = f"contract_alias_reexport_package_{facade_count}_{control_flow}"
+    package_dir = tmp_path / package_name
+    package_dir.mkdir()
+    (package_dir / "aliases.py").write_text(
+        "from typing import TypeAlias\nInternalAlias: TypeAlias = str\n",
+        encoding="utf-8",
+    )
+    import_module, import_name = "aliases", "InternalAlias"
+    for index in range(facade_count):
+        facade_module, facade_name = f"facade{index}", f"ForwardedAlias{index}"
+        facade_import = f"from .{import_module} import {import_name} as {facade_name}\n"
+        if control_flow:
+            facade_import = (
+                "try:\n" + indent(facade_import, "    ") + "except ImportError:\n    raise\n"
+            )
+        (package_dir / f"{facade_module}.py").write_text(
+            facade_import,
+            encoding="utf-8",
+        )
+        import_module, import_name = facade_module, facade_name
+    export_import = (
+        f"from .{import_module} import (\n"
+        f"    {import_name} as PublicAlias,\n"
+        f"    {import_name} as ShadowedAlias,\n"
+        f"    {import_name} as WalrusShadowedAlias,\n"
+        f"    {import_name} as ControlFlowShadowedAlias,\n"
+        f"    {import_name} as FunctionGlobalShadowedAlias,\n"
+        f"    {import_name} as ClassGlobalShadowedAlias,\n"
+        ")\n"
+    )
+    if control_flow:
+        export_import = "import sys\nif sys.version_info >= (3, 10):\n" + indent(
+            export_import, "    "
+        )
+    (package_dir / "__init__.py").write_text(
+        export_import + "ShadowedAlias = str\n"
+        "UnrelatedBinding = (WalrusShadowedAlias := str)\n"
+        "if True:\n"
+        "    ControlFlowShadowedAlias = str\n"
+        "def capture(PublicAlias):\n"
+        "    from .aliases import InternalAlias as PublicAlias\n"
+        "    PublicAlias = str\n"
+        "    match PublicAlias:\n"
+        "        case {**PublicAlias}:\n"
+        "            return PublicAlias\n"
+        "class Container:\n"
+        "    from .aliases import InternalAlias as PublicAlias\n"
+        "    PublicAlias = str\n"
+        "def mutate_global():\n"
+        "    global FunctionGlobalShadowedAlias\n"
+        "    FunctionGlobalShadowedAlias = str\n"
+        "class GlobalMutator:\n"
+        "    global ClassGlobalShadowedAlias\n"
+        "    ClassGlobalShadowedAlias = str\n"
+        "UnannotatedBinding = str\n"
+        "__all__ = [\n"
+        '    "PublicAlias",\n'
+        '    "ShadowedAlias",\n'
+        '    "WalrusShadowedAlias",\n'
+        '    "ControlFlowShadowedAlias",\n'
+        '    "FunctionGlobalShadowedAlias",\n'
+        '    "ClassGlobalShadowedAlias",\n'
+        '    "UnannotatedBinding",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    agents_module = importlib.import_module(package_name)
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "public_class_contracts": [],
+        "public_properties": [],
+        "public_type_aliases": [],
+        "public_typed_dicts": [],
+        "callables": {},
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            release_policy=_release_policy({}),
+        )
+
+    assert str(exc_info.value) == (
+        "Cannot promote new top-level type aliases without public_type_aliases policy entries "
+        "for module 'agents': ['PublicAlias']"
+    )
+
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        release_policy=_release_policy(
+            {},
+            public_type_aliases=({"module": "agents", "name": "PublicAlias"},),
+        ),
+    )
+    assert updated["public_type_aliases"] == [
+        {
+            "definition": {"identity": "builtins.str", "kind": "type"},
+            "module": "agents",
+            "name": "PublicAlias",
+        }
+    ]
+
+    agents_module.PublicAlias = bytes
+    errors = _validate_public_type_alias_contract(updated, agents_module)
+    assert len(errors) == 1
+    assert errors[0].startswith("agents.PublicAlias changed its released public type alias")
+
+
+@pytest.mark.parametrize(
+    "invalid_edge", ["rebound", "mismatched_value", "outside_package", "cycle"]
+)
+def test_originless_alias_facade_requires_unambiguous_package_provenance(
+    monkeypatch: pytest.MonkeyPatch, invalid_edge: str
+) -> None:
+    package_name = "contract_alias_chain_package"
+    agents_module = ModuleType(package_name)
+    facade = ModuleType(f"{package_name}.facade")
+    definitions = ModuleType(f"{package_name}.definitions")
+    external = ModuleType(f"{package_name}_external")
+    agents_module.__all__ = ["PublicAlias"]
+    agents_module.PublicAlias = str
+    facade.ForwardedAlias = str
+    definitions.InternalAlias = str
+    definitions.__annotations__ = {"InternalAlias": TypeAlias}
+    external.InternalAlias = str
+    external.__annotations__ = {"InternalAlias": TypeAlias}
+    sources = {
+        package_name: "from .facade import ForwardedAlias as PublicAlias\n",
+        facade.__name__: "from .definitions import InternalAlias as ForwardedAlias\n",
+    }
+    if invalid_edge == "rebound":
+        sources[facade.__name__] += "ForwardedAlias = str\n"
+    elif invalid_edge == "mismatched_value":
+        facade.ForwardedAlias = bytes
+    elif invalid_edge == "outside_package":
+        sources[facade.__name__] = (
+            f"from {external.__name__} import InternalAlias as ForwardedAlias\n"
+        )
+    else:
+        sources[facade.__name__] = "from . import PublicAlias as ForwardedAlias\n"
+
+    # Use already-loaded modules to exercise cyclic provenance without executing circular imports.
+    for module in (agents_module, facade, definitions, external):
+        module.__package__ = package_name
+        monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(
+        contract_support.inspect,
+        "getsource",
+        lambda module: sources[module.__name__],
+    )
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "public_class_contracts": [],
+        "public_properties": [],
+        "public_type_aliases": [],
+        "public_typed_dicts": [],
+        "callables": {},
+    }
+
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        release_policy=_release_policy({}),
+    )
+
+    assert updated["required_top_level_exports"] == ["PublicAlias"]
+    assert updated["public_type_aliases"] == []
+
+
+def test_module_binding_visitor_ignores_type_parameter_bindings() -> None:
+    if not hasattr(ast, "TypeVar"):
+        pytest.skip("PEP 695 AST nodes require Python 3.12 or newer")
+
+    module_tree = ast.parse(
+        "from .aliases import InternalAlias as PublicAlias\n"
+        "def capture[PublicAlias](value):\n"
+        "    return value\n"
+    )
+
+    bindings = contract_support._ModuleBindingVisitor("PublicAlias")
+    bindings.visit(module_tree)
+
+    assert bindings.count == 1
+    assert not bindings.has_wildcard_import
+    assert len(bindings.from_imports) == 1
+    assert bindings.from_imports[0][1] == "InternalAlias"
+
+
+def test_new_type_alias_type_requires_policy() -> None:
+    new_alias = TypeAliasType("NewAlias", str)
+    agents_module = SimpleNamespace(__all__=["NewAlias"], NewAlias=new_alias)
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "public_class_contracts": [],
+        "public_properties": [],
+        "public_type_aliases": [],
+        "public_typed_dicts": [],
+        "callables": {},
+    }
+
+    with pytest.raises(ValueError, match="for module 'agents': \\['NewAlias'\\]"):
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            release_policy=_release_policy({}),
+        )
+
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        release_policy=_release_policy(
+            {},
+            public_type_aliases=({"module": "agents", "name": "NewAlias"},),
+        ),
+    )
+    assert updated["public_type_aliases"][0]["definition"] == {
+        "identity": "builtins.str",
+        "kind": "type",
+    }
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        "backport",
+        "type Public[T] = str",
+        "type Public[T, U] = str",
+        "type Public[T] = UndefinedType",
+    ],
+)
+def test_generic_type_alias_type_is_rejected_before_unwrapping(declaration: str) -> None:
+    if declaration == "backport":
+        alias = TypeAliasType("Public", str, type_params=(TypeVar("T"),))
+    else:
+        if sys.version_info < (3, 12):
+            pytest.skip("PEP 695 requires Python 3.12+")
+        namespace: dict[str, Any] = {}
+        exec(declaration, namespace)
+        alias = namespace["Public"]
+    agents_module = SimpleNamespace(__all__=["Public"], Public=alias)
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "public_type_aliases": [],
+        "callables": {},
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            release_policy=_release_policy(
+                {}, public_type_aliases=({"module": "agents", "name": "Public"},)
+            ),
+        )
+
+    assert str(exc_info.value) == (
+        "Cannot promote public type alias agents.Public: "
+        "generic public type alias is unsupported: Public"
+    )
+
+    contract["public_type_aliases"] = [
+        {
+            "module": "agents",
+            "name": "Public",
+            "definition": {"kind": "type", "identity": "builtins.str"},
+        }
+    ]
+    assert _validate_public_type_alias_contract(contract, agents_module) == [
+        "agents.Public no longer has a supported released public type alias definition: "
+        "generic public type alias is unsupported: Public"
+    ]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12+")
+def test_unresolved_type_alias_is_validation_error() -> None:
+    namespace: dict[str, Any] = {}
+    exec(
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    TypeOnlyName = str\n"
+        "type Public = TypeOnlyName\n",
+        namespace,
+    )
+    agents_module = SimpleNamespace(__all__=["Public"], Public=namespace["Public"])
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "public_type_aliases": [],
+        "callables": {},
+    }
+    policy = _release_policy({}, public_type_aliases=({"module": "agents", "name": "Public"},))
+
+    with pytest.raises(ValueError) as exc_info:
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            release_policy=policy,
+        )
+
+    assert str(exc_info.value) == (
+        "Cannot promote public type alias agents.Public: "
+        "cannot resolve public type alias Public at runtime: "
+        "NameError: name 'TypeOnlyName' is not defined"
+    )
+    contract["public_type_aliases"] = [
+        {
+            "module": "agents",
+            "name": "Public",
+            "definition": {"kind": "type", "identity": "builtins.str"},
+        }
+    ]
+    assert _validate_public_type_alias_contract(contract, agents_module) == [
+        "agents.Public no longer has a supported released public type alias definition: "
+        "cannot resolve public type alias Public at runtime: "
+        "NameError: name 'TypeOnlyName' is not defined"
+    ]
+
+    namespace["TypeOnlyName"] = str
+    contract["public_type_aliases"] = []
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        release_policy=policy,
+    )
+    assert updated["public_type_aliases"][0]["definition"] == {
+        "kind": "type",
+        "identity": "builtins.str",
+    }
+    assert _validate_public_type_alias_contract(updated, agents_module) == []
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12+")
+@pytest.mark.parametrize("error_type", [RuntimeError, KeyboardInterrupt, SystemExit])
+def test_lazy_type_alias_evaluation_exception_boundary(error_type: type[BaseException]) -> None:
+    class AliasTarget:
+        def __class_getitem__(cls, parameter: object) -> object:
+            raise error_type("alias evaluation failed")
+
+    namespace: dict[str, Any] = {"AliasTarget": AliasTarget}
+    exec("type Public = AliasTarget[str]", namespace)
+    agents_module = SimpleNamespace(Public=namespace["Public"])
+    policy_entries = ({"module": "agents", "name": "Public"},)
+
+    if error_type is RuntimeError:
+        with pytest.raises(ValueError) as exc_info:
+            contract_support._public_type_alias_contract(policy_entries, agents_module)
+        assert str(exc_info.value) == (
+            "Cannot promote public type alias agents.Public: "
+            "cannot resolve public type alias Public at runtime: "
+            "RuntimeError: alias evaluation failed"
+        )
+    else:
+        with pytest.raises(error_type, match="alias evaluation failed"):
+            contract_support._public_type_alias_contract(policy_entries, agents_module)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12+")
+def test_recursive_type_alias_type_is_rejected() -> None:
+    namespace: dict[str, Any] = {}
+    exec("type Recursive = Recursive | None", namespace)
+    agents_module = SimpleNamespace(__all__=["Recursive"], Recursive=namespace["Recursive"])
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "public_class_contracts": [],
+        "public_properties": [],
+        "public_type_aliases": [],
+        "public_typed_dicts": [],
+        "callables": {},
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            release_policy=_release_policy(
+                {},
+                public_type_aliases=({"module": "agents", "name": "Recursive"},),
+            ),
+        )
+
+    assert str(exc_info.value) == (
+        "Cannot promote public type alias agents.Recursive: "
+        "recursive public type alias is unsupported: Recursive"
+    )
 
 
 def test_curated_public_typed_dict_contract_detects_field_shape_drift(
@@ -3088,6 +3667,10 @@ def test_repository_release_policy_declares_public_state_surfaces() -> None:
             "module": "agents.voice.events",
             "name": "VoiceStreamEvent",
         },
+        {
+            "module": "agents",
+            "name": "OutputGuardrailBlockedMessageFormatter",
+        },
     )
     type_aliases: dict[tuple[str, str], dict[str, Any]] = {
         (cast(str, entry["module"]), cast(str, entry["name"])): cast(
@@ -3126,6 +3709,24 @@ def test_repository_release_policy_declares_public_state_surfaces() -> None:
         "agents.voice.events.VoiceStreamEventAudio",
         "agents.voice.events.VoiceStreamEventError",
         "agents.voice.events.VoiceStreamEventLifecycle",
+    }
+    blocked_message_formatter = type_aliases[("agents", "OutputGuardrailBlockedMessageFormatter")]
+    assert blocked_message_formatter == {
+        "kind": "callable",
+        "parameters": [
+            {
+                "arguments": [{"kind": "any"}],
+                "kind": "generic",
+                "origin": "agents.run_config.OutputGuardrailBlockedMessageArgs",
+            }
+        ],
+        "return": {
+            "kind": "union",
+            "members": [
+                {"identity": "builtins.NoneType", "kind": "type"},
+                {"identity": "builtins.str", "kind": "type"},
+            ],
+        },
     }
     assert policy.public_typed_dicts == (
         {


### PR DESCRIPTION
This pull request fixes a gap in prospective released API contract generation where a new top-level typing alias could be frozen only by its exported name.

It requires newly exported top-level runtime typing aliases to have an explicit `public_type_aliases` policy entry while grandfathering exports already present in the released contract. It also promotes `OutputGuardrailBlockedMessageFormatter` and records its synchronous `Callable[[OutputGuardrailBlockedMessageArgs[Any]], str | None]` definition.

Future incompatible parameter, return-type, or async-shape changes will therefore fail the released API compatibility gate. This change does not modify SDK runtime behavior.