### PR TITLE
Remove defaults from strict output schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 from typing import Any, TypeGuard, cast
 
-from openai import NOT_GIVEN
 
 from .exceptions import UserError
 
@@ -361,11 +360,10 @@ def _ensure_strict_json_schema(
                 for i, entry in enumerate(all_of)
             ]
 
-    # strip `None` defaults as there's no meaningful distinction here
-    # the schema will still be `nullable` and the model will default
-    # to using `None` anyway
-    if json_schema.get("default", NOT_GIVEN) is None:
-        json_schema.pop("default")
+    # Strict structured outputs require every property to be supplied, so
+    # Python-side defaults are neither used by the model nor valid in the
+    # provider schema. Remove them regardless of their value.
+    json_schema.pop("default", None)
 
     # we can't use `$ref`s if there are also other properties defined, e.g.
     # `{"$ref": "...", "description": "my description"}`

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -34,6 +34,18 @@ def test_empty_schema_has_additional_properties_false():
     assert strict_schema["additionalProperties"] is False
 
 
+def test_non_null_property_defaults_are_removed():
+    schema = {
+        "type": "object",
+        "properties": {"currency": {"type": "string", "default": "EUR"}},
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert "default" not in result["properties"]["currency"]
+    assert result["required"] == ["currency"]
+
+
 def test_empty_schema_returns_fresh_copy():
     first = ensure_strict_json_schema({})
     first["additionalProperties"] = True


### PR DESCRIPTION
Closes #4390

Summary:
- Remove property defaults from strict output schemas, including non-null defaults.
- Add regression coverage for the generated schema.

Tests:
- Python syntax compilation passed.