### PR TITLE
docs: fix links to untranslated pages in ja/ko/zh docs

### DIFF
--- a/docs/ja/agents.md
+++ b/docs/ja/agents.md
@@ -300,7 +300,7 @@ result = await Runner.run(agent, "Explain quines", hooks=LoggingHooks())
 print(result.final_output)
 ```
 
-コールバックの全機能については、[Lifecycle API リファレンス](ref/lifecycle.md)を参照してください。
+コールバックの全機能については、[Lifecycle API リファレンス](../ref/lifecycle.md)を参照してください。
 
 ## ガードレール {#guardrails}
 

--- a/docs/ja/mcp.md
+++ b/docs/ja/mcp.md
@@ -367,7 +367,7 @@ async with MCPServerStdio(
 
 ## 5. MCP サーバーマネージャー {#5-mcp-server-manager}
 
-複数の MCP サーバーがある場合は、`MCPServerManager` を使用して事前に接続し、正常に接続されたサーバーのみをエージェントに公開します。コンストラクターのオプションと再接続の動作については、[MCPServerManager API リファレンス](ref/mcp/manager.md)を参照してください。
+複数の MCP サーバーがある場合は、`MCPServerManager` を使用して事前に接続し、正常に接続されたサーバーのみをエージェントに公開します。コンストラクターのオプションと再接続の動作については、[MCPServerManager API リファレンス](../ref/mcp/manager.md)を参照してください。
 
 ```python
 from agents import Agent, Runner

--- a/docs/ja/sandbox/guide.md
+++ b/docs/ja/sandbox/guide.md
@@ -14,7 +14,7 @@ search:
 
 <div class="sandbox-harness-image" markdown="1">
 
-![コンピュートを備えたサンドボックスエージェントハーネス](../assets/images/harness_with_compute.png)
+![コンピュートを備えたサンドボックスエージェントハーネス](../../assets/images/harness_with_compute.png)
 
 </div>
 

--- a/docs/ja/sessions.md
+++ b/docs/ja/sessions.md
@@ -454,6 +454,6 @@ if __name__ == "__main__":
 
 - [`Session`][agents.memory.Session] - プロトコルインターフェース
 - [`SQLiteSession`][agents.memory.SQLiteSession] - SQLite 実装
-- [`OpenAIConversationsSession`](ref/memory/openai_conversations_session.md) - OpenAI Conversations API 実装
+- [`OpenAIConversationsSession`](../ref/memory/openai_conversations_session.md) - OpenAI Conversations API 実装
 - [`SQLAlchemySession`][agents.extensions.memory.sqlalchemy_session.SQLAlchemySession] - SQLAlchemy ベースの実装
 - [`EncryptedSession`][agents.extensions.memory.encrypt_session.EncryptedSession] - TTL 付き暗号化セッションラッパー

--- a/docs/ja/testing.md
+++ b/docs/ja/testing.md
@@ -570,6 +570,6 @@ Responses API または Chat Completions のリクエストシリアライズ、
 
 ## API リファレンス {#api-reference}
 
-- [`agents.testing`](ref/testing.md)
-- [`agents.realtime.testing`](ref/realtime/testing.md)
-- [`agents.voice.testing`](ref/voice/testing.md)
+- [`agents.testing`](../ref/testing.md)
+- [`agents.realtime.testing`](../ref/realtime/testing.md)
+- [`agents.voice.testing`](../ref/voice/testing.md)

--- a/docs/ja/tools.md
+++ b/docs/ja/tools.md
@@ -901,7 +901,7 @@ agent = Agent(
 
 リファレンス:
 
--   [Codex ツール API リファレンス](ref/extensions/experimental/codex/codex_tool.md)
--   [ThreadOptions リファレンス](ref/extensions/experimental/codex/thread_options.md)
--   [TurnOptions リファレンス](ref/extensions/experimental/codex/turn_options.md)
+-   [Codex ツール API リファレンス](../ref/extensions/experimental/codex/codex_tool.md)
+-   [ThreadOptions リファレンス](../ref/extensions/experimental/codex/thread_options.md)
+-   [TurnOptions リファレンス](../ref/extensions/experimental/codex/turn_options.md)
 -   完全に実行可能なサンプルについては、`examples/tools/codex.py` と `examples/tools/codex_same_thread.py` を参照してください。

--- a/docs/ko/agents.md
+++ b/docs/ko/agents.md
@@ -300,7 +300,7 @@ result = await Runner.run(agent, "Explain quines", hooks=LoggingHooks())
 print(result.final_output)
 ```
 
-전체 콜백 인터페이스는 [수명 주기 API 레퍼런스](ref/lifecycle.md)를 참조하세요.
+전체 콜백 인터페이스는 [수명 주기 API 레퍼런스](../ref/lifecycle.md)를 참조하세요.
 
 ## 가드레일 {#guardrails}
 

--- a/docs/ko/mcp.md
+++ b/docs/ko/mcp.md
@@ -368,7 +368,7 @@ async with MCPServerStdio(
 
 ## 5. MCP 서버 관리자 {#5-mcp-server-manager}
 
-MCP 서버가 여러 개라면 `MCPServerManager`을 사용하여 미리 연결하고, 연결에 성공한 서버만 에이전트에 노출하세요. 생성자 옵션과 재연결 동작은 [MCPServerManager API 레퍼런스](ref/mcp/manager.md)를 참고하세요.
+MCP 서버가 여러 개라면 `MCPServerManager`을 사용하여 미리 연결하고, 연결에 성공한 서버만 에이전트에 노출하세요. 생성자 옵션과 재연결 동작은 [MCPServerManager API 레퍼런스](../ref/mcp/manager.md)를 참고하세요.
 
 ```python
 from agents import Agent, Runner

--- a/docs/ko/sandbox/guide.md
+++ b/docs/ko/sandbox/guide.md
@@ -14,7 +14,7 @@ search:
 
 <div class="sandbox-harness-image" markdown="1">
 
-![컴퓨팅을 포함한 샌드박스 에이전트 하네스](../assets/images/harness_with_compute.png)
+![컴퓨팅을 포함한 샌드박스 에이전트 하네스](../../assets/images/harness_with_compute.png)
 
 </div>
 

--- a/docs/ko/sessions.md
+++ b/docs/ko/sessions.md
@@ -455,6 +455,6 @@ if __name__ == "__main__":
 
 -   [`Session`][agents.memory.Session] - 프로토콜 인터페이스
 -   [`SQLiteSession`][agents.memory.SQLiteSession] - SQLite 구현
--   [`OpenAIConversationsSession`](ref/memory/openai_conversations_session.md) - OpenAI Conversations API 구현
+-   [`OpenAIConversationsSession`](../ref/memory/openai_conversations_session.md) - OpenAI Conversations API 구현
 -   [`SQLAlchemySession`][agents.extensions.memory.sqlalchemy_session.SQLAlchemySession] - SQLAlchemy 기반 구현
 -   [`EncryptedSession`][agents.extensions.memory.encrypt_session.EncryptedSession] - TTL이 포함된 암호화 세션 래퍼

--- a/docs/ko/testing.md
+++ b/docs/ko/testing.md
@@ -570,6 +570,6 @@ WebSocket 연결을 열지 않고 `RealtimeSession` 동작 또는 `RealtimeAgent
 
 ## API 레퍼런스 {#api-reference}
 
-- [`agents.testing`](ref/testing.md)
-- [`agents.realtime.testing`](ref/realtime/testing.md)
-- [`agents.voice.testing`](ref/voice/testing.md)
+- [`agents.testing`](../ref/testing.md)
+- [`agents.realtime.testing`](../ref/realtime/testing.md)
+- [`agents.voice.testing`](../ref/voice/testing.md)

--- a/docs/ko/tools.md
+++ b/docs/ko/tools.md
@@ -901,7 +901,7 @@ agent = Agent(
 
 참조:
 
--   [Codex 도구 API 레퍼런스](ref/extensions/experimental/codex/codex_tool.md)
--   [ThreadOptions 레퍼런스](ref/extensions/experimental/codex/thread_options.md)
--   [TurnOptions 레퍼런스](ref/extensions/experimental/codex/turn_options.md)
+-   [Codex 도구 API 레퍼런스](../ref/extensions/experimental/codex/codex_tool.md)
+-   [ThreadOptions 레퍼런스](../ref/extensions/experimental/codex/thread_options.md)
+-   [TurnOptions 레퍼런스](../ref/extensions/experimental/codex/turn_options.md)
 -   완전한 실행 가능 샘플은 `examples/tools/codex.py` 및 `examples/tools/codex_same_thread.py`을 참고하세요.

--- a/docs/zh/agents.md
+++ b/docs/zh/agents.md
@@ -300,7 +300,7 @@ result = await Runner.run(agent, "Explain quines", hooks=LoggingHooks())
 print(result.final_output)
 ```
 
-有关完整的回调接口，请参阅[生命周期 API 参考](ref/lifecycle.md)。
+有关完整的回调接口，请参阅[生命周期 API 参考](../ref/lifecycle.md)。
 
 ## 安全防护措施 {#guardrails}
 

--- a/docs/zh/mcp.md
+++ b/docs/zh/mcp.md
@@ -367,7 +367,7 @@ async with MCPServerStdio(
 
 ## 5. MCP 服务器管理器 {#5-mcp-server-manager}
 
-如果有多个 MCP 服务器，请使用 `MCPServerManager` 预先连接它们，并向智能体公开其中成功连接的服务器子集。有关构造函数选项和重新连接行为，请参阅 [MCPServerManager API 参考](ref/mcp/manager.md)。
+如果有多个 MCP 服务器，请使用 `MCPServerManager` 预先连接它们，并向智能体公开其中成功连接的服务器子集。有关构造函数选项和重新连接行为，请参阅 [MCPServerManager API 参考](../ref/mcp/manager.md)。
 
 ```python
 from agents import Agent, Runner

--- a/docs/zh/sandbox/guide.md
+++ b/docs/zh/sandbox/guide.md
@@ -14,7 +14,7 @@ search:
 
 <div class="sandbox-harness-image" markdown="1">
 
-![带计算环境的沙箱智能体运行框架](../assets/images/harness_with_compute.png)
+![带计算环境的沙箱智能体运行框架](../../assets/images/harness_with_compute.png)
 
 </div>
 

--- a/docs/zh/sessions.md
+++ b/docs/zh/sessions.md
@@ -455,6 +455,6 @@ if __name__ == "__main__":
 
 -   [`Session`][agents.memory.Session] - 协议接口
 -   [`SQLiteSession`][agents.memory.SQLiteSession] - SQLite 实现
--   [`OpenAIConversationsSession`](ref/memory/openai_conversations_session.md) - OpenAI Conversations API 实现
+-   [`OpenAIConversationsSession`](../ref/memory/openai_conversations_session.md) - OpenAI Conversations API 实现
 -   [`SQLAlchemySession`][agents.extensions.memory.sqlalchemy_session.SQLAlchemySession] - 由 SQLAlchemy 驱动的实现
 -   [`EncryptedSession`][agents.extensions.memory.encrypt_session.EncryptedSession] - 具有 TTL 的加密会话封装器

--- a/docs/zh/testing.md
+++ b/docs/zh/testing.md
@@ -570,6 +570,6 @@ stt = ScriptedSTTModel(sessions=[session])
 
 ## API 参考 {#api-reference}
 
-- [`agents.testing`](ref/testing.md)
-- [`agents.realtime.testing`](ref/realtime/testing.md)
-- [`agents.voice.testing`](ref/voice/testing.md)
+- [`agents.testing`](../ref/testing.md)
+- [`agents.realtime.testing`](../ref/realtime/testing.md)
+- [`agents.voice.testing`](../ref/voice/testing.md)

--- a/docs/zh/tools.md
+++ b/docs/zh/tools.md
@@ -901,7 +901,7 @@ agent = Agent(
 
 参考资料：
 
--   [Codex 工具 API 参考](ref/extensions/experimental/codex/codex_tool.md)
--   [ThreadOptions 参考](ref/extensions/experimental/codex/thread_options.md)
--   [TurnOptions 参考](ref/extensions/experimental/codex/turn_options.md)
+-   [Codex 工具 API 参考](../ref/extensions/experimental/codex/codex_tool.md)
+-   [ThreadOptions 参考](../ref/extensions/experimental/codex/thread_options.md)
+-   [TurnOptions 参考](../ref/extensions/experimental/codex/turn_options.md)
 -   有关完整的可运行代码示例，请参阅 `examples/tools/codex.py` 和 `examples/tools/codex_same_thread.py`。


### PR DESCRIPTION
## Summary
The docs build uses the mkdocs-material i18n plugin with `docs_structure: folder`, so each locale is built from its own folder. Relative links like `ref/lifecycle.md` inside `docs/ja/agents.md` resolve to `docs/ja/ref/lifecycle.md`, which doesn't exist (reference pages are English-only) — every such link 404s on the built site for ja/ko/zh, and mkdocs warns about them at build time.

This points those links at the English pages (`../ref/…`), so localized pages fall back to English for untranslated sections. 30 links fixed across:
- `agents.md` (`ref/lifecycle.md`)
- `mcp.md` (`ref/mcp/manager.md`)
- `sessions.md` (`ref/memory/openai_conversations_session.md`)
- `testing.md` (`ref/testing.md`, `ref/realtime/testing.md`, `ref/voice/testing.md`)
- `tools.md` (3x `ref/extensions/experimental/codex/*`)
- `sandbox/guide.md` (image `../assets/…` -> `../../assets/…`)

Same fix applied identically in `ja/`, `ko/`, `zh/`. Text content untouched.