### PR TITLE
fix(core): strict_schema error message, REPL whitespace input, debug docstrings

### DIFF
--- a/src/agents/_debug.py
+++ b/src/agents/_debug.py
@@ -18,11 +18,11 @@ def _load_dont_log_tool_data() -> bool:
 
 
 DONT_LOG_MODEL_DATA = _load_dont_log_model_data()
-"""By default we don't log LLM inputs/outputs, to prevent exposing sensitive information. Set this
-flag to enable logging them.
+"""By default we don't log LLM inputs/outputs, to prevent exposing sensitive information. Set the
+`OPENAI_AGENTS_DONT_LOG_MODEL_DATA` environment variable to `0`/`false` to enable logging them.
 """
 
 DONT_LOG_TOOL_DATA = _load_dont_log_tool_data()
 """By default we don't log tool call inputs/outputs, to prevent exposing sensitive information. Set
-this flag to enable logging them.
+the `OPENAI_AGENTS_DONT_LOG_TOOL_DATA` environment variable to `0`/`false` to enable logging them.
 """

--- a/src/agents/repl.py
+++ b/src/agents/repl.py
@@ -43,7 +43,7 @@ async def run_demo_loop(
             break
         if user_input.strip().lower() in {"exit", "quit"}:
             break
-        if not user_input:
+        if not user_input.strip():
             continue
 
         input_items.append({"role": "user", "content": user_input})

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -379,7 +379,7 @@ def _ensure_strict_json_schema(
         resolved = resolve_ref(root=root, ref=ref)
         if not is_dict(resolved):
             raise ValueError(
-                f"Expected `$ref: {ref}` to resolved to a dictionary but got {resolved}"
+                f"Expected `$ref: {ref}` to resolve to a dictionary but got {resolved}"
             )
 
         # Pop the current `$ref` first so that if the resolved schema is itself a `$ref`
@@ -456,7 +456,7 @@ def _resolve_non_constraining_ref_chain(
         budget.spend()
         target = resolve_ref(root=root, ref=ref)
         if not is_dict(target):
-            raise ValueError(f"Expected `$ref: {ref}` to resolved to a dictionary but got {target}")
+            raise ValueError(f"Expected `$ref: {ref}` to resolve to a dictionary but got {target}")
         resolved = target
     return {**resolved, **carried_siblings}
 


### PR DESCRIPTION
## Summary

Three small, independent fixes:

1. **`strict_schema.py`**: two `ValueError` messages say "Expected `$ref: …` **to resolved to** a dictionary" — fixed to "to resolve to". No tests assert on this text.
2. **`repl.py`**: the exit check strips input but the emptiness check doesn't, so a whitespace-only line was appended as a blank user message and sent to the model. `tests/test_repl.py::test_run_demo_loop_skips_empty_input` only feeds `""`, so intent is to skip blank lines generally. Now skips whitespace-only input.
3. **`_debug.py`**: `DONT_LOG_MODEL_DATA` / `DONT_LOG_TOOL_DATA` docstrings said "Set this flag to enable logging them" — inverted. These flags are opt-out and default to `True`; logging is enabled by setting the env var to `0`/`false` before startup, which is what `docs/config.md` ("Sensitive data in logs") documents.