### PR TITLE
fix(realtime): keep the server's status when converting a conversation item

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -2011,7 +2011,9 @@ class _ConversionHelper:
                 "type": item.type,
                 "role": item.role,
                 "content": content,
-                "status": "in_progress",
+                # Keep the server's status: hardcoding "in_progress" regressed
+                # completed items every time one was retrieved (#4597).
+                "status": item.status or "in_progress",
             },
         )
 

--- a/tests/realtime/test_item_parsing.py
+++ b/tests/realtime/test_item_parsing.py
@@ -78,3 +78,33 @@ def test_system_message_conversion() -> None:
     )
 
     assert isinstance(converted, SystemMessageItem)
+
+
+def test_status_is_taken_from_the_server_item() -> None:
+    """A retrieved item reports its real status; overriding it regressed history (#4597)."""
+    item = RealtimeConversationItemAssistantMessage(
+        id="123",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[AssistantMessageContent(type="output_text", text="hi")],
+    )
+
+    converted = _ConversionHelper.conversation_item_to_realtime_message_item(item, None)
+
+    assert isinstance(converted, AssistantMessageItem)
+    assert converted.status == "completed"
+
+
+def test_status_defaults_to_in_progress_when_the_server_omits_it() -> None:
+    item = RealtimeConversationItemAssistantMessage(
+        id="123",
+        type="message",
+        role="assistant",
+        content=[AssistantMessageContent(type="output_text", text="hi")],
+    )
+
+    converted = _ConversionHelper.conversation_item_to_realtime_message_item(item, None)
+
+    assert isinstance(converted, AssistantMessageItem)
+    assert converted.status == "in_progress"

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -554,6 +554,29 @@ class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
         assert item_updated_event.item.previous_item_id == ""
 
     @pytest.mark.asyncio
+    async def test_retrieved_item_keeps_the_status_the_server_reported(self, model):
+        """A retrieve of a finished item must not regress it to in_progress (#4597)."""
+        mock_listener = AsyncMock()
+        model.add_listener(mock_listener)
+        server_event = {
+            "type": "conversation.item.retrieved",
+            "event_id": "event_1",
+            "item": {
+                "id": "item_1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "hello there"}],
+            },
+        }
+
+        await model._handle_ws_event(server_event)
+
+        assert mock_listener.on_event.call_count == 2
+        item_updated_event = mock_listener.on_event.call_args_list[1][0][0]
+        assert item_updated_event.item.status == "completed"
+
+    @pytest.mark.asyncio
     async def test_handle_malformed_json_logs_error_continues(self, model):
         """Test that malformed JSON emits error event but doesn't crash."""
         mock_listener = AsyncMock()


### PR DESCRIPTION
This pull request fixes a realtime history regression where completed conversation items flip back to `in_progress`.

`_ConversionHelper.conversation_item_to_realtime_message_item` hardcoded `"status": "in_progress"`, discarding the status carried by the server payload.

This is reachable in a default voice session. After the assistant produces audio, `_current_item_id` points at the assistant's audio item. When the user's next utterance finishes transcription, the handler for `conversation.item.input_audio_transcription.completed` sends `conversation.item.retrieve` for that item, and the server replies with `conversation.item.retrieved` carrying the item's real status (`completed`). The conversion rewrote it to `in_progress`, and the session history merge keeps the incoming status, so a completed assistant item regressed on every user turn with nothing to restore it. `conversation.item.truncated` triggers the same retrieve.

The fix passes `item.status` through, falling back to `"in_progress"` only when the server omits it. The GA conversation item models (`RealtimeConversationItem{User,Assistant,System}Message`) all declare `status: Literal["in_progress", "completed", "incomplete"] | None`, so the value is already on the parsed item. This matches what `_handle_ws_event` already does for `response.output_item.added`/`.done`, which reads the payload's status and only synthesizes one when it is absent.

Behavior note: items whose status the server does report now surface that status instead of a fabricated `in_progress`. That also applies to user and system items, which do not declare `status` on the SDK model and carry it as an extra field.

Fixes #4597
