### PR TITLE
Preserve server status when converting realtime message items

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -2011,7 +2011,7 @@ class _ConversionHelper:
                 "type": item.type,
                 "role": item.role,
                 "content": content,
-                "status": "in_progress",
+                "status": item.status,
             },
         )
 

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -523,6 +523,14 @@ class RealtimeSession(RealtimeModelListener):
                 and existing_item.type == "message"
                 and incoming_item.type == "message"
             ):
+                if (
+                    isinstance(existing_item, AssistantMessageItem)
+                    and isinstance(incoming_item, AssistantMessageItem)
+                    and incoming_item.status is None
+                ):
+                    incoming_item = incoming_item.model_copy(
+                        update={"status": existing_item.status}
+                    )
                 try:
                     # Merge transcripts for matching content indices
                     existing_content = existing_item.content

--- a/tests/realtime/test_item_parsing.py
+++ b/tests/realtime/test_item_parsing.py
@@ -50,11 +50,12 @@ def test_user_message_conversion() -> None:
     assert isinstance(converted, UserMessageItem)
 
 
-def test_assistant_message_conversion() -> None:
+def test_assistant_message_conversion_preserves_status() -> None:
     item = RealtimeConversationItemAssistantMessage(
         id="123",
         type="message",
         role="assistant",
+        status="completed",
         content=[AssistantMessageContent(type="output_text", text=None)],
     )
 
@@ -63,6 +64,22 @@ def test_assistant_message_conversion() -> None:
     )
 
     assert isinstance(converted, AssistantMessageItem)
+    assert converted.status == "completed"
+
+
+def test_assistant_message_conversion_preserves_missing_status() -> None:
+    item = RealtimeConversationItemAssistantMessage(
+        id="123",
+        type="message",
+        role="assistant",
+        status=None,
+        content=[AssistantMessageContent(type="output_text", text=None)],
+    )
+
+    converted = _ConversionHelper.conversation_item_to_realtime_message_item(item, None)
+
+    assert isinstance(converted, AssistantMessageItem)
+    assert converted.status is None
 
 
 def test_system_message_conversion() -> None:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -6182,6 +6182,36 @@ class TestTranscriptPreservation:
     """Tests ensuring assistant transcripts are preserved across updates."""
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("incoming_status", ["completed", "incomplete", None])
+    async def test_assistant_status_preserved_or_updated_on_item_update(
+        self, mock_model, mock_agent, incoming_status
+    ):
+        session = RealtimeSession(mock_model, mock_agent, None)
+        session._history = [
+            AssistantMessageItem(
+                item_id="assist_status",
+                status="completed",
+                role="assistant",
+                content=[AssistantAudio(audio=None, transcript="Hello there")],
+            )
+        ]
+
+        await session.on_event(
+            RealtimeModelItemUpdatedEvent(
+                item=AssistantMessageItem(
+                    item_id="assist_status",
+                    status=incoming_status,
+                    role="assistant",
+                    content=[AssistantAudio(audio=None, transcript=None)],
+                )
+            )
+        )
+
+        updated_item = cast(AssistantMessageItem, session._history[0])
+        assert updated_item.status == (incoming_status or "completed")
+        assert updated_item.content[0].transcript == "Hello there"
+
+    @pytest.mark.asyncio
     async def test_assistant_transcript_preserved_on_item_update(self, mock_model, mock_agent):
         session = RealtimeSession(mock_model, mock_agent, None)
 


### PR DESCRIPTION
## Summary

Fixes #4597.

The Realtime conversation item converter previously replaced the server-provided status with `in_progress`. Retrieved completed or incomplete assistant items therefore regressed in `RealtimeSession` history after reconciliation.

This update:
- preserves the server-provided completed and incomplete statuses;
- preserves an existing assistant history status when a retrieved item omits status;
- preserves an existing assistant transcript when the retrieved item omits it;
- tests the converter and the actual `RealtimeSession` item-update path.

## Validation

- `uv run --frozen pytest tests/realtime/test_item_parsing.py tests/realtime/test_session.py -q` — 205 passed
- `uv run --frozen ruff format --check src/agents/realtime/session.py src/agents/realtime/openai_realtime.py tests/realtime/test_item_parsing.py tests/realtime/test_session.py` — passed
- `uv run --frozen ruff check src/agents/realtime/session.py src/agents/realtime/openai_realtime.py tests/realtime/test_item_parsing.py tests/realtime/test_session.py` — passed
- `git diff --check` — passed
- `uv run --frozen mypy src` — blocked by the local environment missing `numpy` and `numpy.typing` stubs

### Agent review

GPT-5 via Codex, one fresh review pass after the formatting fix. Verified that the converter preserves server status, the session fallback only applies when the incoming status is absent, transcript preservation remains intact, and the regression tests cover completed, incomplete, and missing-status cases. No additional findings.