### PR TITLE
Fix missing httpx2 dep due to unconditional import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,14 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "OpenAI", email = "support@openai.com" }]
 dependencies = [
+    "griffelib>=2, <3",
+    "httpx2",
+    "mcp>=1.19.0, <3; python_version >= '3.10'",
     "openai>=3.0.0,<4",
     "pydantic>=2.12.2, <3",
-    "griffelib>=2, <3",
-    "typing-extensions>=4.12.2, <5",
     "requests>=2.0, <3",
+    "typing-extensions>=4.12.2, <5",
     "websockets>=15.0, <17",
-    "mcp>=1.19.0, <3; python_version >= '3.10'",
 ]
 classifiers = [
     "Typing :: Typed",


### PR DESCRIPTION
You have an unconditional import hoisted to the top level `agents` import here: https://github.com/openai/openai-agents-python/blob/233467994fac7e7dbd868931573cc9a4302c0a16/src/agents/tracing/processors.py#L14

xref:
https://github.com/conda-forge/openai-agents-feedstock/actions/runs/32274620397/job/96138993962#step:4:1314


added the dep and alphabetized your deps.