### PR TITLE
fix: strip non-null defaults from strict JSON schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import copy
 from typing import Any, TypeGuard, cast
 
-from openai import NOT_GIVEN
-
 from .exceptions import UserError
 
 _EMPTY_SCHEMA = {
@@ -361,11 +359,11 @@ def _ensure_strict_json_schema(
                 for i, entry in enumerate(all_of)
             ]
 
-    # strip `None` defaults as there's no meaningful distinction here
-    # the schema will still be `nullable` and the model will default
-    # to using `None` anyway
-    if json_schema.get("default", NOT_GIVEN) is None:
-        json_schema.pop("default")
+    # Strip all defaults, not just `None`: every property is already forced into
+    # `required` above, so the model must always supply an explicit value regardless of
+    # any Python-level default. The API also rejects non-null `default` values within
+    # property definitions in strict mode.
+    json_schema.pop("default", None)
 
     # we can't use `$ref`s if there are also other properties defined, e.g.
     # `{"$ref": "...", "description": "my description"}`

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -501,7 +501,9 @@ def test_function_with_field_optional_with_default():
     optional_schema = properties.get("optional_param", {})
     assert optional_schema.get("type") == "number"
     assert optional_schema.get("minimum") == 0.0  # ge=0.0
-    assert optional_schema.get("default") == 5.0
+    # Defaults are stripped from strict schemas: the field stays required, so the
+    # default is never used by the API, and non-null defaults are rejected outright.
+    assert "default" not in optional_schema
 
     # Valid input with default
     valid_input = {"required_param": "test"}
@@ -675,13 +677,13 @@ def test_function_with_field_multiple_constraints():
     assert name_schema.get("type") == "string"
     assert name_schema.get("minLength") == 1
     assert name_schema.get("maxLength") == 50
-    assert name_schema.get("default") == "Unknown"
+    assert "default" not in name_schema
 
     # Check factor field
     factor_schema = properties.get("factor", {})
     assert factor_schema.get("type") == "number"
     assert factor_schema.get("exclusiveMinimum") == 0.0
-    assert factor_schema.get("default") == 1.0
+    assert "default" not in factor_schema
     assert factor_schema.get("description") == "Positive multiplier"
 
     # Valid input with defaults
@@ -761,7 +763,9 @@ def test_function_with_annotated_field_optional_with_default():
     optional_schema = properties.get("optional_param", {})
     assert optional_schema.get("type") == "number"
     assert optional_schema.get("minimum") == 0.0  # ge=0.0
-    assert optional_schema.get("default") == 5.0
+    # Defaults are stripped from strict schemas: the field stays required, so the
+    # default is never used by the API, and non-null defaults are rejected outright.
+    assert "default" not in optional_schema
 
     # Valid input with default
     valid_input = {"required_param": "test"}
@@ -854,13 +858,13 @@ def test_function_with_annotated_field_multiple_constraints():
     assert name_schema.get("type") == "string"
     assert name_schema.get("minLength") == 1
     assert name_schema.get("maxLength") == 50
-    assert name_schema.get("default") == "Unknown"
+    assert "default" not in name_schema
 
     # Check factor field
     factor_schema = properties.get("factor", {})
     assert factor_schema.get("type") == "number"
     assert factor_schema.get("exclusiveMinimum") == 0.0
-    assert factor_schema.get("default") == 1.0
+    assert "default" not in factor_schema
     assert factor_schema.get("description") == "Positive multiplier"
 
     # Valid input with defaults

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -709,6 +709,25 @@ def test_default_removal_on_non_object():
     assert "default" not in result
 
 
+def test_non_null_default_removal():
+    # Non-null defaults must also be stripped: every property is forced into `required`
+    # in strict mode, so the default is never used, and the API rejects non-null
+    # `default` values within property definitions.
+    schema = {
+        "type": "object",
+        "properties": {
+            "currency": {"type": "string", "enum": ["EUR", "USD"], "default": "EUR"},
+            "count": {"type": "integer", "default": 0},
+        },
+        "required": [],
+        "additionalProperties": False,
+    }
+    result = ensure_strict_json_schema(schema)
+    assert "default" not in result["properties"]["currency"]
+    assert "default" not in result["properties"]["count"]
+    assert set(result["required"]) == {"currency", "count"}
+
+
 def test_ref_expansion():
     # Construct a schema with a definitions section and a property with a $ref.
     schema = {


### PR DESCRIPTION
### Summary

Tools and output models built from Pydantic models with non-null field defaults currently produce strict schemas containing `"default"`. The OpenAI/Azure Structured Outputs API rejects these at call time:

```
'default' is not permitted within a property definition
```

This forces users to disable `strict_mode` entirely for any tool whose parameters include a non-null default (enum member, int, string, etc.), losing structured-output schema guarantees.

### Problem & root cause

`_ensure_strict_json_schema()` only stripped `"default"` when its value was exactly `None`. However, strict mode already forces every property into `required` (simulating optionality via nullability), so any remaining default is unreachable by construction — the model must always supply an explicit value. The `is None` check was an arbitrary distinction that left dead-weight keys in the schema that the API then rejects outright.

### Solution

Strip `default` unconditionally at each schema node (`json_schema.pop("default", None)`), and remove the now-unused `NOT_GIVEN` import. Python-side behavior is unchanged: defaults still apply locally via `to_call_args` / Pydantic validation; they are simply no longer emitted into wire schemas where the API forbids them.

### Test plan

- [x] New regression test `test_non_null_default_removal` verifying string/integer defaults are stripped while all properties stay required
- [x] Updated four function-schema tests that asserted the previous preservation behavior
- [x] Verified Python-side defaults still apply through `to_call_args`
- [x] Focused suites pass (`test_strict_schema.py`, `test_function_schema.py`, `test_strict_schema_oneof.py`, tool tests)
- [x] Full suite, `ruff format`/`ruff check`, `mypy src/agents`, and `pyright` all pass

Fixes #4390