### PR TITLE
fix(sandbox): finish dependency cleanup on cancellation

### DIFF
--- a/src/agents/sandbox/session/dependencies.py
+++ b/src/agents/sandbox/session/dependencies.py
@@ -268,14 +268,22 @@ class Dependencies:
             await asyncio.gather(*active_tasks, return_exceptions=True)
 
         seen_ids: set[int] = set()
+        cancellation: asyncio.CancelledError | None = None
         for value in reversed(self._owned_results):
             value_id = id(value)
             if value_id in seen_ids:
                 continue
             seen_ids.add(value_id)
-            await _close_best_effort(value)
+            try:
+                await _close_best_effort(value)
+            except asyncio.CancelledError as exc:
+                if cancellation is None:
+                    cancellation = exc
 
         self._pending.clear()
         self._active_tasks.clear()
         self._cache.clear()
         self._owned_results.clear()
+
+        if cancellation is not None:
+            raise cancellation

--- a/tests/sandbox/test_dependencies.py
+++ b/tests/sandbox/test_dependencies.py
@@ -44,6 +44,15 @@ class _AsyncCloseMethod:
         self.calls += 1
 
 
+class _CancellingAsyncClosable:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def aclose(self) -> None:
+        self.calls += 1
+        raise asyncio.CancelledError("dependency close cancelled")
+
+
 class _SyncClosable:
     def __init__(self) -> None:
         self.calls = 0
@@ -433,6 +442,34 @@ async def test_dependencies_aclose_continues_after_waiter_cancellation() -> None
     await dependencies.aclose()
     assert value.calls == 1
     assert value.completed
+
+
+@pytest.mark.asyncio
+async def test_dependencies_aclose_finishes_owned_cleanup_before_propagating_cancellation() -> None:
+    dependencies = Dependencies()
+    earlier = _AsyncClosable()
+    cancelling = _CancellingAsyncClosable()
+    dependencies.bind_factory(
+        "tests.earlier_owned", lambda _dependencies: earlier, owns_result=True
+    )
+    dependencies.bind_factory(
+        "tests.cancelling_owned", lambda _dependencies: cancelling, owns_result=True
+    )
+
+    _ = await dependencies.require("tests.earlier_owned")
+    _ = await dependencies.require("tests.cancelling_owned")
+
+    with pytest.raises(asyncio.CancelledError):
+        await dependencies.aclose()
+
+    assert cancelling.calls == 1
+    assert earlier.calls == 1
+
+    with pytest.raises(asyncio.CancelledError):
+        await dependencies.aclose()
+
+    assert cancelling.calls == 1
+    assert earlier.calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`Dependencies.aclose()` stopped reverse-order cleanup as soon as an owned dependency raised `CancelledError`. That left earlier owned resources open and cached a cancelled close task, so subsequent close attempts could not complete the skipped cleanup.

This change records the first child cancellation, finishes exactly-once cleanup for the remaining owned dependencies, clears the container's internal state, and then propagates cancellation. Normal cleanup and non-cancellation best-effort behavior are unchanged.

### Test plan

- Added a regression with two owned dependencies proving that a later dependency's cancellation does not skip the earlier resource, cancellation still propagates, and a repeated `aclose()` does not close either resource twice.
- `uv run pytest tests/sandbox/test_dependencies.py::test_dependencies_aclose_finishes_owned_cleanup_before_propagating_cancellation -q` — 1 passed; repeated 10 times with the same result.
- `uv run pytest tests/sandbox/test_dependencies.py -q` — 20 passed.
- `make typecheck` — mypy passed for 307 source files; Pyright reported 0 errors.
- `.agents/skills/code-change-verification/scripts/run.sh` — format and lint passed; the broad suite completed with 9085 passed, 28 skipped, and 1 pre-existing failure. `tests/sandbox/test_run_cwd.py::test_python_skill_uses_absolute_root_from_nested_workdir` fails with the same missing output file on clean upstream `23346799` and is unrelated to this two-file cleanup change.
- `git diff --check` — passed.

No public API, serialization format, or documentation changes.

### Issue number

None filed; reproduced deterministically with local owned-resource fakes.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
