### PR TITLE
fix(items): preserve replayable shell output status

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -462,9 +462,8 @@ class ToolCallOutputItem(RunItemBase[Any]):
     def to_input_item(self) -> TResponseInputItem:
         """Converts the tool output into an input item for the next model turn.
 
-        Hosted tool outputs (e.g. shell/apply_patch) carry a `status` field for the SDK's
-        book-keeping, but the Responses API does not yet accept that parameter. Strip it from the
-        payload we send back to the model while keeping the original raw item intact.
+        Hosted tool outputs can carry SDK-only metadata that the Responses API does not accept.
+        Strip that metadata while keeping input-supported fields and the original raw item intact.
         """
 
         if isinstance(self.raw_item, dict):
@@ -472,7 +471,8 @@ class ToolCallOutputItem(RunItemBase[Any]):
             payload_type = payload.get("type")
             if payload_type == "shell_call_output":
                 payload = dict(payload)
-                payload.pop("status", None)
+                if payload.get("status") not in ("in_progress", "completed", "incomplete"):
+                    payload.pop("status", None)
                 payload.pop("shell_output", None)
                 payload.pop("provider_data", None)
                 outputs = payload.get("output")

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -661,12 +661,13 @@ def test_tool_call_output_item_to_input_item_strips_created_by() -> None:
     assert item.raw_item["created_by"] == "server"
 
 
-def test_dict_shell_call_output_item_to_input_item_sanitizes_without_mutation() -> None:
+@pytest.mark.parametrize("status", ["in_progress", "completed", "incomplete"])
+def test_dict_shell_call_output_item_to_input_item_sanitizes_without_mutation(status: str) -> None:
     agent = Agent(name="A")
     raw_item = {
         "type": "shell_call_output",
         "call_id": "call_1",
-        "status": "completed",
+        "status": status,
         "shell_output": "legacy",
         "provider_data": {"provider": "value"},
         "created_by": "server",
@@ -687,6 +688,7 @@ def test_dict_shell_call_output_item_to_input_item_sanitizes_without_mutation() 
     assert replayed == {
         "type": "shell_call_output",
         "call_id": "call_1",
+        "status": status,
         "output": [
             {
                 "stdout": "ok",

--- a/tests/test_process_model_response.py
+++ b/tests/test_process_model_response.py
@@ -312,7 +312,7 @@ def test_process_model_response_sanitizes_shell_call_output_model_object() -> No
     next_input = item.to_input_item()
     assert isinstance(next_input, dict)
     assert next_input["type"] == "shell_call_output"
-    assert "status" not in next_input
+    assert next_input["status"] == "completed"
     assert "created_by" not in next_input
     next_outputs = next_input.get("output")
     assert isinstance(next_outputs, list)

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -281,7 +281,7 @@ async def test_shell_tool_structured_output_is_rendered() -> None:
     assert isinstance(input_payload, dict)
     payload_dict = cast(dict[str, Any], input_payload)
     assert payload_dict["type"] == "shell_call_output"
-    assert "status" not in payload_dict
+    assert payload_dict["status"] == "completed"
     assert "shell_output" not in payload_dict
     assert "provider_data" not in payload_dict
 


### PR DESCRIPTION
### Summary

Preserve API-supported `shell_call_output.status` values when a dict-backed `ToolCallOutputItem` is replayed as model input.

The input schema now accepts `in_progress`, `completed`, and `incomplete`, and `ModelResponse.to_input_items()` already preserves those values. `ToolCallOutputItem.to_input_item()` still unconditionally removed the field, so replay behavior differed depending on which item representation reached the runner. Local-only values such as the shell executor's `failed` status remain stripped, along with `shell_output`, `provider_data`, and `created_by` metadata.

### Test plan

- Added regression coverage for all three input-supported statuses and retained coverage that strips the local-only `failed` status.
- Focused item/model/shell tests: 139 passed, then 6 targeted regression cases passed after the final assertion update.
- Verification wrapper: formatting and lint passed; mypy and Pyright passed; parallel tests passed (9,060 passed, 55 skipped).
- Non-review-optional serial tests passed (76 passed, 4 skipped, 63 deselected).
- The wrapper's Docker-backed Dapr/Redis review-optional phase stalled while starting its testcontainers and was terminated after more than six minutes. This integration path does not exercise item replay or shell output conversion.
- `git diff --check` passed.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
