### PR TITLE
fix: preserve annotated_types constraints in function schemas

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -434,6 +434,15 @@ def function_schema(
             metadata = param_metadata.get(name, ())
             field_info_from_annotated = _extract_field_info_from_metadata(metadata)
 
+            # Preserve constraint metadata (for example `annotated_types.Gt`) by re-wrapping it
+            # into the annotation; Pydantic applies `Annotated` constraints natively on model
+            # fields, so dropping them would silently weaken both the schema and validation.
+            constraint_metadata = tuple(
+                item for item in metadata if not isinstance(item, str | FieldInfo)
+            )
+            if constraint_metadata:
+                ann = Annotated[(ann, *constraint_metadata)]
+
             if field_info_from_annotated is not None:
                 merged = FieldInfo.merge_field_infos(
                     field_info_from_annotated,

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Annotated, Any, Literal
 
 import pytest
+from annotated_types import Gt, MinLen
 from pydantic import BaseModel, Field, ValidationError
 from pydantic.json_schema import PydanticJsonSchemaWarning
 from typing_extensions import TypedDict
@@ -710,6 +711,51 @@ def test_function_with_field_multiple_constraints():
 
 
 # --- Annotated + Field: same behavior as Field as default ---
+
+
+def test_function_with_annotated_types_constraints():
+    """annotated_types constraints in Annotated are preserved in schema and validation."""
+
+    def func_with_annotated_types_constraints(
+        count: Annotated[int, Gt(0)],
+        label: Annotated[str, MinLen(3)],
+    ) -> str:
+        return f"{label}: {count}"
+
+    fs = function_schema(func_with_annotated_types_constraints, use_docstring_info=False)
+
+    # Constraints must appear in the JSON schema, matching the equivalent Field spelling.
+    properties = fs.params_json_schema.get("properties", {})
+    assert properties["count"].get("exclusiveMinimum") == 0  # Gt(0)
+    assert properties["label"].get("minLength") == 3  # MinLen(3)
+
+    # Valid input works and reconstructs the call correctly.
+    parsed = fs.params_pydantic_model(**{"count": 2, "label": "abc"})
+    args, kwargs_dict = fs.to_call_args(parsed)
+    assert func_with_annotated_types_constraints(*args, **kwargs_dict) == "abc: 2"
+
+    # Constraint violations must be rejected at validation time.
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model(**{"count": -1, "label": "abc"})
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model(**{"count": 2, "label": "ab"})
+
+
+def test_function_with_annotated_types_constraints_combined_with_field():
+    """annotated_types constraints combine with a Field in the same Annotated."""
+
+    def func_with_mixed_constraints(
+        score: Annotated[float, Field(description="A score"), Gt(0.0)],
+    ) -> float:
+        return score * 2
+
+    fs = function_schema(func_with_mixed_constraints, use_docstring_info=False)
+    score_schema = fs.params_json_schema["properties"]["score"]
+    assert score_schema.get("description") == "A score"
+    assert score_schema.get("exclusiveMinimum") == 0.0
+
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model(**{"score": -1.0})
 
 
 def test_function_with_annotated_field_required_constraints():


### PR DESCRIPTION
### Summary

`annotated_types` constraints declared via `typing.Annotated` (for example `Annotated[int, Gt(0)]`, `Annotated[str, MinLen(3)]`, or `StringConstraints`) are currently **silently dropped**: they appear neither in the advertised tool JSON schema nor in the runtime Pydantic validation of tool arguments. The equivalent `Field(gt=0)` spelling works, so behavior differs between two forms users reasonably expect to be identical.

### Problem & impact

Repro on current `main`:

```python
@function_tool
def half(x: Annotated[int, Gt(0)]) -> int:
    return x // 2
```

- `half.params_json_schema["properties"]["x"]` is just `{"type": "integer"}` - no `exclusiveMinimum`
- Validation accepts out-of-contract input: the args model happily validates `x=-5`

The model is shown an unconstrained parameter and invalid values reach the user's function body unvalidated - a silent contract violation rather than a loud failure.

### Root cause

`_strip_annotated()` removes all `Annotated` metadata up front. When rebuilding the arguments model with `create_model()`, only string descriptions and `FieldInfo` instances from that metadata are re-applied; every other metadata item (`annotated_types.Gt`, `Ge`, `MinLen`, `StringConstraints`, ...) is discarded entirely.

### Solution

In the normal-parameter branch of `function_schema()`, re-wrap any non-`str`/non-`FieldInfo` metadata back into the annotation (`Annotated[ann, *constraint_metadata]`) before building the field. Pydantic v2 applies `Annotated` constraint metadata natively on model fields, so both the schema and validation now honor it. All existing merging behavior for `FieldInfo`, defaults, and docstring descriptions is untouched.

This also matches the documented contract in `.agents/references/function-and-output-schema.md`: "Preserve `Field` constraints, aliases, and defaults when merging `Annotated` metadata."

### Test plan

- [x] New test: `Annotated[int, Gt(0)]` / `Annotated[str, MinLen(3)]` produce `exclusiveMinimum`/`minLength` in the schema and reject violating inputs at validation time; valid calls still reconstruct correctly
- [x] New test: `annotated_types` constraints combined with a `Field` in the same `Annotated` keep both description and constraint
- [x] Full focused suites pass (`test_function_schema.py`, `test_function_tool.py`, `test_strict_schema.py`, converter/output tests)
- [x] `ruff format`, `ruff check`, `mypy src/agents`, and `pyright` all clean