### PR TITLE
fix(mcp): drop cleaned-up servers from active_servers when keeping failed servers

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -388,7 +388,12 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
                     )
                     self._errors[server] = exc
         finally:
-            self._refresh_active_servers()
+            # Cleanup discards every processed server from the connected set, so no cleaned
+            # server may remain advertised as active regardless of `drop_failed_servers`:
+            # that flag only governs whether connect-phase failures stay listed.
+            self._active_servers = [
+                server for server in self._all_servers if server in self._connected_servers
+            ]
 
     async def _run_with_timeout(
         self, func: Callable[[], Awaitable[Any]], timeout_seconds: float | None

--- a/tests/mcp/test_mcp_server_manager_cleanup_state.py
+++ b/tests/mcp/test_mcp_server_manager_cleanup_state.py
@@ -30,6 +30,25 @@ async def test_cleanup_all_removes_cleaned_servers_from_active_servers() -> None
 
 
 @pytest.mark.asyncio
+async def test_cleanup_all_removes_cleaned_servers_from_active_servers_when_keeping_failed() -> (
+    None
+):
+    """`drop_failed_servers=False` keeps connect-phase failures listed, but a server that was
+    cleaned up is disconnected and must not remain advertised as active."""
+    server = cast(MCPServer, Mock(spec=MCPServer))
+    server.connect = AsyncMock()
+    server.cleanup = AsyncMock()
+
+    manager = MCPServerManager([server], drop_failed_servers=False)
+    assert await manager.connect_all() == [server]
+
+    await manager.cleanup_all()
+
+    assert manager.active_servers == []
+    assert manager._connected_servers == set()
+
+
+@pytest.mark.asyncio
 async def test_manager_owns_repeated_server_instance_once() -> None:
     server = cast(MCPServer, Mock(spec=MCPServer))
     server.connect = AsyncMock()


### PR DESCRIPTION
### Summary

`MCPServerManager.cleanup_all()` (and therefore `async with` exit) leaves cleaned-up servers listed in `active_servers` whenever `drop_failed_servers=False`. This completes the post-cleanup contract established by #4586 for the non-default flag path.

### Problem

Repro on current `main`:

```python
manager = MCPServerManager([server], drop_failed_servers=False)
await manager.connect_all()   # active_servers == [server], _connected_servers == {server}
await manager.cleanup_all()   # _connected_servers == set()
print(manager.active_servers) # still [server] - a disconnected server advertised as active
```

Callers following the documented pattern (`agent.mcp_servers = manager.active_servers`, including after cleanup within a lifespan) observe stale state: every server remains "active" even though the manager no longer owns any live connection.

### Root cause

`_cleanup_all()` refreshes `active_servers` via `_refresh_active_servers()` in its guaranteed `finally`. With `drop_failed_servers=True` that derives the list from the connected set (emptying it), but the `else` branch returns *all* servers unconditionally - so the disconnect performed by `_cleanup_server()` (which always discards from `_connected_servers`) is never reflected.

### Solution

Derive the post-cleanup active list from `_connected_servers` directly in `_cleanup_all()`'s `finally`. Behavior is unchanged for `drop_failed_servers=True`; for `False`, that flag continues to govern only connect-phase failures (the `_connect_all()` failure path is untouched), while servers whose lifecycle the manager has torn down are no longer advertised as active.

This matches #4586's stated intent ("consistently derives the active list from the canonical connected-server set") and the class docstring's guarantee that `active_servers` reflects successfully connected servers after connection attempts and cleanup.

### Test plan

- [x] New regression test: with `drop_failed_servers=False`, `cleanup_all()` empties `active_servers` and `_connected_servers`
- [x] Full MCP suite passes (463 passed, 24 skipped) including all existing `drop_failed_servers=False` coverage
- [x] Broader suite, `ruff format`/`check`, `mypy src/agents`, and `pyright` all clean