### PR TITLE
Clarify Arize tracing integrations

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -201,10 +201,12 @@ await Runner.run(
 
 The following community and vendor integrations support the tracing API surface of the OpenAI Agents SDK.
 
+For Arize users, [Arize AX](https://arize.com/docs/ax/integrations/python-agent-frameworks/openai-agents/openai-agents-sdk-tracing) is the managed production option for tracing, monitoring, and evaluating OpenAI Agents SDK applications. [Arize Phoenix](https://docs.arize.com/phoenix/tracing/integrations-tracing/openai-agents-sdk) is the open-source and self-hosted path for local or team-managed tracing workflows. The Arize guides for [agent evaluation](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation](https://arize.com/resources/llm-evaluation/) show how teams use traces to debug agent behavior and improve model outputs.
+
 ### External tracing processors list
 
 -   [Weights & Biases](https://weave-docs.wandb.ai/guides/integrations/openai_agents)
--   [Arize-Phoenix](https://docs.arize.com/phoenix/tracing/integrations-tracing/openai-agents-sdk)
+-   [Arize Phoenix](https://docs.arize.com/phoenix/tracing/integrations-tracing/openai-agents-sdk)
 -   [Future AGI](https://docs.futureagi.com/docs/tracing/auto/openai_agents/)
 -   [MLflow (self-hosted/OSS)](https://mlflow.org/docs/latest/tracing/integrations/openai-agent)
 -   [MLflow (Databricks hosted)](https://docs.databricks.com/aws/en/mlflow/mlflow-tracing#-automatic-tracing)


### PR DESCRIPTION
### Summary

Clarifies the Arize entry in the OpenAI Agents SDK tracing ecosystem docs:

- adds a short Arize-specific note before the external processor list
- distinguishes Arize AX as the managed production tracing/evaluation path
- keeps Arize Phoenix as the open-source and self-hosted tracing path
- updates the displayed Phoenix name from `Arize-Phoenix` to `Arize Phoenix`
- links Arize's agent evaluation and LLM evaluation guides for teams using traces beyond debugging

This is a docs-only change.

### Test plan

- `git diff --check`
- Manual docs review of the changed English sentences from Japanese, Korean, and Chinese translation perspectives; no ambiguous actor, scope, lifecycle boundary, or SDK identifier issue found.

I did not run the full repository verification stack because this PR only changes prose in `docs/tracing.md`.

### Issue number

N/A - documentation clarification.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR