### PR TITLE
fix(extensions): bound string tool output summaries

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -98,8 +98,8 @@ class ToolOutputTrimmer:
             trimmed. Defaults to 2.
         max_output_chars: Tool outputs above this character count are candidates for
             trimming. Structured outputs count their model-facing string payloads without
-            Python or JSON representation overhead, and their replacements fit within this
-            budget. Defaults to 500.
+            Python or JSON representation overhead. String function-output summaries and
+            structured function-output replacements fit within this budget. Defaults to 500.
         preview_chars: Maximum number of characters of a string output, or the text parts of
             a structured output, to preserve as a preview when trimming. Structured previews
             may be shorter when needed to fit ``max_output_chars``. Defaults to 200.
@@ -258,12 +258,34 @@ class ToolOutputTrimmer:
         tool_name = tool_names[0] if tool_names else ""
         display_name = tool_name or "unknown_tool"
         preview = output_str[: self.preview_chars]
-        summary = (
+        detailed_summary = (
             f"[Trimmed: {display_name} output — {output_len} chars → "
             f"{self.preview_chars} char preview]\n{preview}..."
         )
-        if len(summary) >= output_len:
+        if len(detailed_summary) >= output_len:
             return None, 0
+        if len(detailed_summary) <= self.max_output_chars:
+            summary = detailed_summary
+        else:
+            minimal_header = "[Trimmed]"
+            if self.max_output_chars < len(minimal_header):
+                summary = minimal_header[: self.max_output_chars]
+            else:
+                preview_budget = self.max_output_chars - len(minimal_header) - 1
+                preview_len = min(len(output_str), self.preview_chars, max(0, preview_budget))
+                body = f"\n{output_str[:preview_len]}" if preview_len else ""
+                if (
+                    preview_len < len(output_str)
+                    and len(minimal_header) + len(body) + len("...") <= self.max_output_chars
+                ):
+                    body += "..."
+
+                headers = [f"[Trimmed: {display_name}]", minimal_header]
+                summary = next(
+                    header + body
+                    for header in headers
+                    if len(header) + len(body) <= self.max_output_chars
+                )
 
         trimmed_item = dict(item)
         trimmed_item["output"] = summary

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -206,6 +206,32 @@ class TestTrimming:
         assert "1000 chars" in trimmed
         assert len(trimmed) < len(large)
 
+    @pytest.mark.parametrize("max_output_chars", [1, len("[Trimmed]"), 40])
+    def test_string_output_respects_tight_budget(self, max_output_chars: int) -> None:
+        """String summaries should stay within the configured output budget."""
+        large = "x" * 1000
+        items = [
+            _user("q1"),
+            _func_call("c1", "search"),
+            _func_output("c1", large),
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+
+        trimmer = ToolOutputTrimmer(
+            max_output_chars=max_output_chars,
+            preview_chars=100,
+        )
+        result = trimmer(_make_data(items))
+        trimmed = _output(result, 2)
+
+        assert isinstance(trimmed, str)
+        assert len(trimmed) <= max_output_chars
+        assert trimmer(_make_data(result.input)).input == result.input
+
     def test_preserves_small_old_output(self) -> None:
         """Small outputs should never be trimmed."""
         small = "x" * 100


### PR DESCRIPTION
### Summary

- Keep string function-call output summaries within `max_output_chars` when the rich summary is useful but exceeds the configured budget.
- Preserve rich summaries when they fit, skip trimming when the rich summary is not shorter than the original, and leave structured and legacy tool-search paths unchanged.
- Add regression coverage for very tight budgets and repeated trimming.

Fixes #4622

### Test plan

- [x] `pytest tests/extensions/test_tool_output_trimmer.py -q` (63 passed)
- [x] Ruff format and lint checks on the changed files
- [x] Pyright on the changed source file
- [x] Mypy on the changed source file with the locked SDK environment
- [x] Optional truthiness check
- [x] Independent final review completed

Full repository format, lint, and typecheck commands still report pre-existing findings in unrelated files and optional integrations; the focused checks above are clean.
