### PR TITLE
fix(extensions): bound trimmed string outputs to max_output_chars

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -97,12 +97,12 @@ class ToolOutputTrimmer:
         recent_turns: Number of recent user messages whose surrounding items are never
             trimmed. Defaults to 2.
         max_output_chars: Tool outputs above this character count are candidates for
-            trimming. Structured outputs count their model-facing string payloads without
-            Python or JSON representation overhead, and their replacements fit within this
-            budget. Defaults to 500.
+            trimming, and every replacement summary fits within this budget. Structured
+            outputs count their model-facing string payloads without Python or JSON
+            representation overhead. Defaults to 500.
         preview_chars: Maximum number of characters of a string output, or the text parts of
-            a structured output, to preserve as a preview when trimming. Structured previews
-            may be shorter when needed to fit ``max_output_chars``. Defaults to 200.
+            a structured output, to preserve as a preview when trimming. Previews may be
+            shorter when needed to fit ``max_output_chars``. Defaults to 200.
         trimmable_tools: Optional tool name or set of tool names whose outputs can be trimmed.
             For namespaced tools, both bare names and qualified ``namespace.name`` entries are
             supported. If ``None``, all tool outputs are eligible for trimming. Defaults
@@ -257,17 +257,58 @@ class ToolOutputTrimmer:
 
         tool_name = tool_names[0] if tool_names else ""
         display_name = tool_name or "unknown_tool"
-        preview = output_str[: self.preview_chars]
-        summary = (
-            f"[Trimmed: {display_name} output — {output_len} chars → "
-            f"{self.preview_chars} char preview]\n{preview}..."
-        )
-        if len(summary) >= output_len:
+        summary = self._string_output_summary(display_name, output_str)
+        if summary is None:
             return None, 0
 
         trimmed_item = dict(item)
         trimmed_item["output"] = summary
         return trimmed_item, output_len - len(summary)
+
+    def _string_output_summary(self, display_name: str, output_str: str) -> str | None:
+        """Summarize a string output within ``max_output_chars``, or ``None`` to keep it.
+
+        The full preview summary is kept verbatim when it fits. When it would exceed the
+        budget, the preview shrinks first and the header falls back to shorter forms,
+        matching the structured-output summaries.
+        """
+        output_len = len(output_str)
+        full_preview = output_str[: self.preview_chars]
+        summary = (
+            f"[Trimmed: {display_name} output — {output_len} chars → "
+            f"{self.preview_chars} char preview]\n{full_preview}..."
+        )
+        if len(summary) >= output_len:
+            return None
+        if len(summary) <= self.max_output_chars:
+            return summary
+
+        minimal_header = "[Trimmed]"
+        if self.max_output_chars < len(minimal_header):
+            return minimal_header[: self.max_output_chars]
+
+        preview_budget = self.max_output_chars - len(minimal_header) - 1
+        preview_len = min(output_len, self.preview_chars, max(0, preview_budget))
+        body = f"\n{output_str[:preview_len]}" if preview_len else ""
+        if preview_len and len(minimal_header) + len(body) + len("...") <= self.max_output_chars:
+            body += "..."
+
+        headers: list[str] = []
+        if preview_len:
+            headers.append(
+                f"[Trimmed: {display_name} output — {output_len} chars → "
+                f"{preview_len} char preview]"
+            )
+        headers.extend(
+            [
+                f"[Trimmed: {display_name} output — {output_len} chars]",
+                f"[Trimmed: {display_name}]",
+                minimal_header,
+            ]
+        )
+        return next(
+            header + body for header in headers if len(header) + len(body) <= self.max_output_chars
+        )
 
     def _trim_structured_function_call_output(
         self,
@@ -421,12 +462,8 @@ class ToolOutputTrimmer:
         if output_len <= self.max_output_chars:
             return None, 0
 
-        preview = serialized_results[: self.preview_chars]
-        summary = (
-            f"[Trimmed: tool_search output — {output_len} chars → "
-            f"{self.preview_chars} char preview]\n{preview}..."
-        )
-        if len(summary) >= output_len:
+        summary = self._string_output_summary("tool_search", serialized_results)
+        if summary is None:
             return None, 0
 
         trimmed_item = dict(item)

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -1128,6 +1128,77 @@ class TestEdgeCases:
         # Output left untouched because summary would be longer
         assert _output(result, 2) == borderline
 
+    @pytest.mark.parametrize("max_output_chars", [1, len("[Trimmed]"), 15, 40, 100])
+    @pytest.mark.parametrize("preview_chars", [0, 20, 200, 990])
+    @pytest.mark.parametrize("output_len", [200, 501, 1000, 5000])
+    def test_string_output_respects_budget(
+        self, max_output_chars: int, preview_chars: int, output_len: int
+    ) -> None:
+        """A trimmed string summary never exceeds ``max_output_chars`` at any budget."""
+        large = "x" * output_len
+        items = [
+            _user("q1"),
+            _func_call("c1", "search"),
+            _func_output("c1", large),
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+        trimmer = ToolOutputTrimmer(max_output_chars=max_output_chars, preview_chars=preview_chars)
+        result = trimmer(_make_data(items))
+        trimmed = _output(result, 2)
+
+        # Either left untrimmed (rich summary was not shorter) or bounded by the budget.
+        if trimmed != large:
+            assert isinstance(trimmed, str)
+            assert len(trimmed) <= max_output_chars
+        # Trimming is idempotent regardless of which branch ran.
+        assert trimmer(_make_data(result.input)).input == result.input
+
+    def test_string_output_matches_issue_repro(self) -> None:
+        """The reported case (1000 chars, budget 40) yields a summary within the budget."""
+        items = [
+            _user("q1"),
+            _func_call("c1", "search"),
+            _func_output("c1", "x" * 1000),
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+        result = ToolOutputTrimmer(max_output_chars=40)(_make_data(items))
+        trimmed = _output(result, 2)
+        assert isinstance(trimmed, str)
+        assert trimmed != "x" * 1000
+        assert len(trimmed) <= 40
+        assert trimmed.startswith("[Trimmed")
+
+    def test_legacy_tool_search_output_respects_budget(self) -> None:
+        """Legacy free-text tool_search results are also bounded by ``max_output_chars``."""
+        items = [
+            _user("q1"),
+            {
+                "type": "tool_search_output",
+                "call_id": "ts1",
+                "results": [{"text": "y" * 1000}],
+            },
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+        trimmer = ToolOutputTrimmer(max_output_chars=40, preview_chars=200)
+        result = trimmer(_make_data(items))
+        trimmed_item = cast(dict[str, Any], result.input[1])
+        text = trimmed_item["results"][0]["text"]
+        assert len(text) <= 40
+        assert text.startswith("[Trimmed")
+        assert trimmer(_make_data(result.input)).input == result.input
+
     def test_unknown_tool_name_fallback(self) -> None:
         """When a function_call_output has no matching function_call, the summary
         should show 'unknown_tool' instead of a blank name."""


### PR DESCRIPTION
### Summary

`ToolOutputTrimmer` could emit a string summary **longer** than the configured `max_output_chars`. When trimming a string `function_call_output`, the summary was accepted as long as it was merely shorter than the *original* output — so a rich `[Trimmed: … ]\n<preview>` summary whose length fell between `max_output_chars` and the original size passed through unbounded. This defeats the purpose of the budget (bounding replayed context) and is inconsistent with the structured-output path, which already fits every replacement within `max_output_chars`.

Fixes #4622.

**Change:** route string `function_call_output` summaries and legacy free-text `tool_search_output` results through a shared `_string_output_summary` helper that:

1. keeps the full-fidelity preview summary verbatim when it already fits the budget (unchanged behavior for the common case);
2. otherwise shrinks the preview and falls back through progressively shorter headers (`[Trimmed: <tool> output — N chars → M char preview]` → `[Trimmed: <tool> output — N chars]` → `[Trimmed: <tool>]` → `[Trimmed]`), so the replacement never exceeds `max_output_chars`;
3. still leaves the output **untrimmed** when even the rich summary would not be shorter than the original — the existing documented escape hatch (`test_skips_trim_when_summary_would_exceed_original`), matching the structured path.

The header/preview cascade mirrors the one already used for structured outputs, so the two paths now share one budget contract. Docstrings for `max_output_chars`/`preview_chars` are updated to state that every replacement fits the budget and previews may shrink to fit.

### Test plan

- New tests in `tests/extensions/test_tool_output_trimmer.py`:
  - `test_string_output_respects_budget` — parametrized over `max_output_chars ∈ {1, 9, 15, 40, 100}` × `preview_chars ∈ {0, 20, 200, 990}` × `output_len ∈ {200, 501, 1000, 5000}`: a trimmed summary is always `≤ max_output_chars`, untrimmed outputs are left exactly as-is, and trimming is idempotent.
  - `test_string_output_matches_issue_repro` — the reported 1000-char output at budget 40 now yields a ≤40-char summary.
  - `test_legacy_tool_search_output_respects_budget` — free-text `tool_search_output` results are bounded too.
- 54 of the new parametrized cases (including the issue repro and the legacy path) fail on `main` without the source change.
- `uv run pytest tests/extensions tests/test_released_api_contract.py`: 1687 passed, 7 skipped.
- Full suite, `uv run ruff format --check`, `uv run ruff check` (on changed files), and `uv run mypy src/agents/extensions/tool_output_trimmer.py` pass locally.

### Issue number

Fixes #4622

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
