### PR TITLE
fix(core): read tool args without Pydantic property shadowing

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -51,6 +51,10 @@ class FuncSchema:
         positional_args: list[Any] = []
         keyword_args: dict[str, Any] = {}
         seen_var_positional = False
+        # Read instance storage first so Pydantic properties such as ``model_extra``
+        # and ``model_fields_set`` do not shadow tool parameters of the same name.
+        # ``model_dump()`` is unsuitable here because it converts nested models to dicts.
+        instance_values = object.__getattribute__(data, "__dict__")
 
         # Use enumerate() so we can skip the first parameter if it's context.
         for idx, (name, param) in enumerate(self.signature.parameters.items()):
@@ -58,7 +62,7 @@ class FuncSchema:
             if self.takes_context and idx == 0:
                 continue
 
-            value = getattr(data, name, None)
+            value = instance_values[name] if name in instance_values else getattr(data, name, None)
             if param.kind == param.VAR_POSITIONAL:
                 # e.g. *args: extend positional args and mark that *args is now seen
                 positional_args.extend(value or [])

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -93,6 +93,44 @@ def test_simple_function():
         func_schema.params_pydantic_model(**{"a": "not an integer"})
 
 
+def function_with_model_extra_param(query: str, model_extra: str) -> str:
+    return f"{query}:{model_extra}"
+
+
+def function_with_model_fields_set_param(query: str, model_fields_set: int) -> str:
+    return f"{query}:{model_fields_set}"
+
+
+def test_to_call_args_does_not_shadow_pydantic_model_extra():
+    """A parameter named ``model_extra`` must not be replaced by BaseModel.model_extra."""
+
+    with pytest.warns(UserWarning, match="model_extra"):
+        func_schema = function_schema(function_with_model_extra_param, use_docstring_info=False)
+    parsed = func_schema.params_pydantic_model.model_validate(
+        {"query": "hello", "model_extra": "gpt-4.1"}
+    )
+
+    args, kwargs_dict = func_schema.to_call_args(parsed)
+    result = function_with_model_extra_param(*args, **kwargs_dict)
+    assert result == "hello:gpt-4.1"
+
+
+def test_to_call_args_does_not_shadow_pydantic_model_fields_set():
+    """A parameter named ``model_fields_set`` must not be replaced by BaseModel.model_fields_set."""
+
+    with pytest.warns(UserWarning, match="model_fields_set"):
+        func_schema = function_schema(
+            function_with_model_fields_set_param, use_docstring_info=False
+        )
+    parsed = func_schema.params_pydantic_model.model_validate(
+        {"query": "hello", "model_fields_set": 42}
+    )
+
+    args, kwargs_dict = func_schema.to_call_args(parsed)
+    result = function_with_model_fields_set_param(*args, **kwargs_dict)
+    assert result == "hello:42"
+
+
 def varargs_function(x: int, *numbers: float, flag: bool = False, **kwargs: Any):
     return x, numbers, flag, kwargs
 


### PR DESCRIPTION
### Summary

`FuncSchema.to_call_args()` used `getattr()` to recover tool arguments from the generated Pydantic model. For parameters named `model_extra` or `model_fields_set`, that hits `BaseModel` properties instead of the validated fields, so the tool is invoked with `None` or a set of field names even though JSON validation succeeded.

This is distinct from #3547 / #3572, which were about names that crash `create_model()`. These names build and validate successfully, then silently pass the wrong values.

### Reproduction

```python
from agents.function_schema import function_schema

def search(query: str, model_extra: str) -> str:
    return f"{query}:{model_extra}"

fs = function_schema(search, use_docstring_info=False)
parsed = fs.params_pydantic_model.model_validate(
    {"query": "hello", "model_extra": "gpt-4.1"}
)
args, kwargs = fs.to_call_args(parsed)
print(args)  # Before: ['hello', None]
```

### Solution

Read instance `__dict__` first so Pydantic properties cannot shadow tool parameters. Nested model objects are preserved (unlike `model_dump()`).

### Test plan

- [x] Added regression tests for `model_extra` and `model_fields_set`
- [x] `uv run pytest tests/test_function_schema.py tests/test_function_tool.py` (101 passed)
- [x] `uv run ruff format` / `ruff check` on the changed files
- [x] `uv run pyright` on the changed files
- [x] `git diff --check` clean

### Issue number

N/A — no matching open issue. Adjacent reserved-name construction failures (#3547, #3549, #3572) were closed wontfix; this path is a silent wrong-argument bug after successful schema construction.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run targeted format, lint, typecheck, and tests on the changed files
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (full `make format` currently fails on an unrelated pre-existing E501 in `.agents/skills/implementation-final-review/scripts/test_skill_contract.py` on `main`)
- [ ] If using Codex, I've run `/review` before submitting this PR