### PR TITLE
feat(mcp): support tool guardrails on local servers

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -44,6 +44,7 @@ from ..logger import (
 )
 from ..run_context import RunContextWrapper
 from ..tool import ToolErrorFunction
+from ..tool_guardrails import ToolInputGuardrail, ToolOutputGuardrail
 from ..util._types import MaybeAwaitable
 from . import _compat as mcp_compat
 from ._compat import (
@@ -549,6 +550,12 @@ class MCPServer(abc.ABC):
         failure_error_function: ToolErrorFunction | None | _UnsetType = _UNSET,
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
+        tool_input_guardrails: (
+            list[ToolInputGuardrail[Any]] | dict[str, list[ToolInputGuardrail[Any]]] | None
+        ) = None,
+        tool_output_guardrails: (
+            list[ToolOutputGuardrail[Any]] | dict[str, list[ToolOutputGuardrail[Any]]] | None
+        ) = None,
     ):
         """
         Args:
@@ -570,6 +577,10 @@ class MCPServer(abc.ABC):
                 tool calls. It is invoked by the Agents SDK before calling `call_tool`.
             custom_data_extractor: Optional callable that produces SDK-only custom data for
                 emitted MCP tool output items.
+            tool_input_guardrails: Input guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
+            tool_output_guardrails: Output guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
         """
         self.use_structured_content = use_structured_content
         self._needs_approval_policy = self._normalize_needs_approval(
@@ -578,6 +589,24 @@ class MCPServer(abc.ABC):
         self._failure_error_function = failure_error_function
         self.tool_meta_resolver = tool_meta_resolver
         self.custom_data_extractor = custom_data_extractor
+        self.tool_input_guardrails = tool_input_guardrails
+        self.tool_output_guardrails = tool_output_guardrails
+
+    def _get_tool_input_guardrails_for_tool(self, tool: MCPTool) -> list[ToolInputGuardrail[Any]]:
+        configured = self.tool_input_guardrails
+        if configured is None:
+            return []
+        if isinstance(configured, dict):
+            return list(configured.get(tool.name, []))
+        return list(configured)
+
+    def _get_tool_output_guardrails_for_tool(self, tool: MCPTool) -> list[ToolOutputGuardrail[Any]]:
+        configured = self.tool_output_guardrails
+        if configured is None:
+            return []
+        if isinstance(configured, dict):
+            return list(configured.get(tool.name, []))
+        return list(configured)
 
     @abc.abstractmethod
     async def connect(self):
@@ -879,6 +908,12 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
         retry_backoff_seconds_max: float | None = None,
+        tool_input_guardrails: (
+            list[ToolInputGuardrail[Any]] | dict[str, list[ToolInputGuardrail[Any]]] | None
+        ) = None,
+        tool_output_guardrails: (
+            list[ToolOutputGuardrail[Any]] | dict[str, list[ToolOutputGuardrail[Any]]] | None
+        ) = None,
     ):
         """
         Args:
@@ -916,6 +951,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 tool calls. It is invoked by the Agents SDK before calling `call_tool`.
             custom_data_extractor: Optional callable that produces SDK-only custom data for
                 emitted MCP tool output items.
+            tool_input_guardrails: Input guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
+            tool_output_guardrails: Output guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
             retry_backoff_seconds_max: The non-negative finite maximum delay, in seconds, between
                 retries. Defaults to `None`, which leaves exponential backoff uncapped.
         """
@@ -926,6 +965,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             failure_error_function=failure_error_function,
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
         self.session: ClientSession | None = None
         self.exit_stack: AsyncExitStack = AsyncExitStack()
@@ -1888,6 +1929,12 @@ class MCPServerStdio(_MCPServerWithClientSession):
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
         retry_backoff_seconds_max: float | None = None,
+        tool_input_guardrails: (
+            list[ToolInputGuardrail[Any]] | dict[str, list[ToolInputGuardrail[Any]]] | None
+        ) = None,
+        tool_output_guardrails: (
+            list[ToolOutputGuardrail[Any]] | dict[str, list[ToolOutputGuardrail[Any]]] | None
+        ) = None,
     ):
         """Create a new MCP server based on the stdio transport.
 
@@ -1930,6 +1977,10 @@ class MCPServerStdio(_MCPServerWithClientSession):
                 tool calls. It is invoked by the Agents SDK before calling `call_tool`.
             custom_data_extractor: Optional callable that produces SDK-only custom data for
                 emitted MCP tool output items.
+            tool_input_guardrails: Input guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
+            tool_output_guardrails: Output guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
             retry_backoff_seconds_max: The non-negative finite maximum delay, in seconds, between
                 retries. Defaults to `None`, which leaves exponential backoff uncapped.
         """
@@ -1946,6 +1997,8 @@ class MCPServerStdio(_MCPServerWithClientSession):
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
             retry_backoff_seconds_max=retry_backoff_seconds_max,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
 
         self.params = StdioServerParameters(
@@ -2021,6 +2074,12 @@ class MCPServerSse(_MCPServerWithClientSession):
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
         retry_backoff_seconds_max: float | None = None,
+        tool_input_guardrails: (
+            list[ToolInputGuardrail[Any]] | dict[str, list[ToolInputGuardrail[Any]]] | None
+        ) = None,
+        tool_output_guardrails: (
+            list[ToolOutputGuardrail[Any]] | dict[str, list[ToolOutputGuardrail[Any]]] | None
+        ) = None,
     ):
         """Create a new MCP server based on the HTTP with SSE transport.
 
@@ -2065,6 +2124,10 @@ class MCPServerSse(_MCPServerWithClientSession):
                 tool calls. It is invoked by the Agents SDK before calling `call_tool`.
             custom_data_extractor: Optional callable that produces SDK-only custom data for
                 emitted MCP tool output items.
+            tool_input_guardrails: Input guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
+            tool_output_guardrails: Output guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
             retry_backoff_seconds_max: The non-negative finite maximum delay, in seconds, between
                 retries. Defaults to `None`, which leaves exponential backoff uncapped.
         """
@@ -2081,6 +2144,8 @@ class MCPServerSse(_MCPServerWithClientSession):
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
             retry_backoff_seconds_max=retry_backoff_seconds_max,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
 
         self.params = params
@@ -2182,6 +2247,12 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
         retry_backoff_seconds_max: float | None = None,
+        tool_input_guardrails: (
+            list[ToolInputGuardrail[Any]] | dict[str, list[ToolInputGuardrail[Any]]] | None
+        ) = None,
+        tool_output_guardrails: (
+            list[ToolOutputGuardrail[Any]] | dict[str, list[ToolOutputGuardrail[Any]]] | None
+        ) = None,
     ):
         """Create a new MCP server based on the Streamable HTTP transport.
 
@@ -2227,6 +2298,10 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 tool calls. It is invoked by the Agents SDK before calling `call_tool`.
             custom_data_extractor: Optional callable that produces SDK-only custom data for
                 emitted MCP tool output items.
+            tool_input_guardrails: Input guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
+            tool_output_guardrails: Output guardrails for converted local MCP tools. A list
+                applies to every tool; a dict applies guardrails by original MCP tool name.
             retry_backoff_seconds_max: The non-negative finite maximum delay, in seconds, between
                 retries. Defaults to `None`, which leaves exponential backoff uncapped.
         """
@@ -2243,6 +2318,8 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
             retry_backoff_seconds_max=retry_backoff_seconds_max,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
 
         self.params = params

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -576,6 +576,8 @@ class MCPUtil:
             failure_error_function=effective_failure_error_function,
             strict_json_schema=is_strict,
             needs_approval=needs_approval,
+            tool_input_guardrails=server._get_tool_input_guardrails_for_tool(tool),
+            tool_output_guardrails=server._get_tool_output_guardrails_for_tool(tool),
             mcp_title=resolve_mcp_tool_title(tool),
             tool_origin=ToolOrigin(
                 type=ToolOriginType.MCP,

--- a/tests/mcp/helpers.py
+++ b/tests/mcp/helpers.py
@@ -21,6 +21,7 @@ from agents.mcp import MCPServer
 from agents.mcp.server import _UNSET, _MCPServerWithClientSession, _UnsetType
 from agents.mcp.util import MCPToolCustomDataExtractor, MCPToolMetaResolver, ToolFilter
 from agents.tool import ToolErrorFunction
+from agents.tool_guardrails import ToolInputGuardrail, ToolOutputGuardrail
 
 from .model_compat import ListResourceTemplatesResult, Tool as MCPTool
 
@@ -77,6 +78,12 @@ class FakeMCPServer(MCPServer):
         failure_error_function: ToolErrorFunction | None | _UnsetType = _UNSET,
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
+        tool_input_guardrails: (
+            list[ToolInputGuardrail[Any]] | dict[str, list[ToolInputGuardrail[Any]]] | None
+        ) = None,
+        tool_output_guardrails: (
+            list[ToolOutputGuardrail[Any]] | dict[str, list[ToolOutputGuardrail[Any]]] | None
+        ) = None,
     ):
         super().__init__(
             use_structured_content=False,
@@ -84,6 +91,8 @@ class FakeMCPServer(MCPServer):
             failure_error_function=failure_error_function,
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
         self.tools: list[MCPToolType] = tools or []
         self.tool_calls: list[str] = []

--- a/tests/mcp/test_mcp_tool_guardrails.py
+++ b/tests/mcp/test_mcp_tool_guardrails.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agents import Agent, RunConfig, RunContextWrapper, Runner, ToolExecutionConfig
+from agents.mcp import MCPServerSse, MCPServerStdio, MCPServerStreamableHttp, MCPUtil
+from agents.testing import ScriptedModel
+from agents.tool import FunctionTool
+from agents.tool_guardrails import (
+    ToolGuardrailFunctionOutput,
+    ToolInputGuardrail,
+    ToolInputGuardrailData,
+    ToolOutputGuardrail,
+    ToolOutputGuardrailData,
+    tool_input_guardrail,
+    tool_output_guardrail,
+)
+
+from ..test_responses import get_function_tool_call, get_text_message
+from .helpers import FakeMCPServer
+
+
+def _allow_input(_data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+    return ToolGuardrailFunctionOutput.allow()
+
+
+def _allow_output(_data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+    return ToolGuardrailFunctionOutput.allow()
+
+
+_INPUT_GUARDRAIL = ToolInputGuardrail(_allow_input)
+_OUTPUT_GUARDRAIL = ToolOutputGuardrail(_allow_output)
+
+
+def test_local_mcp_transport_constructors_accept_tool_guardrails() -> None:
+    servers = [
+        MCPServerStdio(
+            params={"command": "python"},
+            tool_input_guardrails=[_INPUT_GUARDRAIL],
+            tool_output_guardrails=[_OUTPUT_GUARDRAIL],
+        ),
+        MCPServerSse(
+            params={"url": "https://example.test/sse"},
+            tool_input_guardrails=[_INPUT_GUARDRAIL],
+            tool_output_guardrails=[_OUTPUT_GUARDRAIL],
+        ),
+        MCPServerStreamableHttp(
+            params={"url": "https://example.test/mcp"},
+            tool_input_guardrails=[_INPUT_GUARDRAIL],
+            tool_output_guardrails=[_OUTPUT_GUARDRAIL],
+        ),
+    ]
+
+    for server in servers:
+        assert server.tool_input_guardrails == [_INPUT_GUARDRAIL]
+        assert server.tool_output_guardrails == [_OUTPUT_GUARDRAIL]
+
+
+@pytest.mark.asyncio
+async def test_mcp_guardrail_mapping_uses_original_tool_name_before_public_prefixing() -> None:
+    server = FakeMCPServer(
+        server_name="billing",
+        tool_input_guardrails={"charge": [_INPUT_GUARDRAIL]},
+        tool_output_guardrails={"charge": [_OUTPUT_GUARDRAIL]},
+    )
+    server.add_tool("charge", {})
+    server.add_tool("lookup", {})
+
+    tools = await MCPUtil.get_function_tools(
+        server,
+        False,
+        RunContextWrapper(context=None),
+        Agent(name="test", instructions="test"),
+        include_server_in_tool_names=True,
+    )
+    by_name = {tool.name: tool for tool in tools if isinstance(tool, FunctionTool)}
+
+    charge_tool = by_name["mcp_billing__charge"]
+    lookup_tool = by_name["mcp_billing__lookup"]
+    assert charge_tool.tool_input_guardrails == [_INPUT_GUARDRAIL]
+    assert charge_tool.tool_output_guardrails == [_OUTPUT_GUARDRAIL]
+    assert not lookup_tool.tool_input_guardrails
+    assert not lookup_tool.tool_output_guardrails
+
+
+async def _run_agent(agent: Agent[Any], *, streaming: bool):
+    if streaming:
+        result = Runner.run_streamed(agent, input="use the tool")
+        async for _ in result.stream_events():
+            pass
+        return result
+    return await Runner.run(agent, input="use the tool")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_local_mcp_guardrails_run_through_function_tool_pipeline(streaming: bool) -> None:
+    events: list[tuple[str, str]] = []
+
+    @tool_input_guardrail
+    def input_guardrail(data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        events.append(("input", data.context.tool_name))
+        return ToolGuardrailFunctionOutput.allow()
+
+    @tool_output_guardrail
+    def output_guardrail(data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+        events.append(("output", data.context.tool_name))
+        return ToolGuardrailFunctionOutput.allow()
+
+    server = FakeMCPServer(
+        tool_input_guardrails=[input_guardrail],
+        tool_output_guardrails=[output_guardrail],
+    )
+    server.add_tool("search", {})
+
+    model = ScriptedModel(
+        steps=[
+            [get_function_tool_call("search", "{}", call_id="call-search")],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="test", model=model, mcp_servers=[server])
+
+    result = await _run_agent(agent, streaming=streaming)
+
+    assert server.tool_calls == ["search"]
+    assert events == [("input", "search"), ("output", "search")]
+    assert len(result.tool_input_guardrail_results) == 1
+    assert len(result.tool_output_guardrail_results) == 1
+
+
+@pytest.mark.asyncio
+async def test_local_mcp_input_guardrail_can_reject_before_server_call() -> None:
+    @tool_input_guardrail
+    def reject_input(_data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.reject_content("blocked by MCP input guardrail")
+
+    server = FakeMCPServer(tool_input_guardrails=[reject_input])
+    server.add_tool("delete", {})
+
+    model = ScriptedModel(
+        steps=[
+            [get_function_tool_call("delete", "{}", call_id="call-delete")],
+            [get_text_message("done")],
+        ]
+    )
+    result = await Runner.run(
+        Agent(name="test", model=model, mcp_servers=[server]),
+        input="delete",
+    )
+
+    assert server.tool_calls == []
+    assert len(result.tool_input_guardrail_results) == 1
+    assert result.tool_input_guardrail_results[0].output.behavior["type"] == "reject_content"
+
+
+@pytest.mark.asyncio
+async def test_local_mcp_guardrails_follow_existing_preapproval_semantics() -> None:
+    calls: list[str] = []
+
+    @tool_input_guardrail
+    def input_guardrail(data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        calls.append(data.context.tool_name)
+        return ToolGuardrailFunctionOutput.allow()
+
+    server = FakeMCPServer(
+        require_approval="always",
+        tool_input_guardrails=[input_guardrail],
+    )
+    server.add_tool("charge", {})
+
+    model = ScriptedModel(
+        steps=[
+            [get_function_tool_call("charge", "{}", call_id="call-charge")],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="test", model=model, mcp_servers=[server])
+    config = RunConfig(tool_execution=ToolExecutionConfig(pre_approval_tool_input_guardrails=True))
+
+    first = await Runner.run(agent, "charge", run_config=config)
+    assert first.interruptions
+    assert calls == ["charge"]
+    assert server.tool_calls == []
+
+    state = first.to_state()
+    state.approve(state.get_interruptions()[0])
+    resumed = await Runner.run(agent, state, run_config=config)
+
+    assert resumed.final_output == "done"
+    assert calls == ["charge", "charge"]
+    assert server.tool_calls == ["charge"]
+    assert len(resumed.tool_input_guardrail_results) == 1


### PR DESCRIPTION
### Summary

This pull request adds existing tool input/output guardrail support to locally executed MCP tools.

`MCPServer`, `MCPServerStdio`, `MCPServerSse`, and `MCPServerStreamableHttp` now accept optional `tool_input_guardrails` and `tool_output_guardrails`. A list applies to every tool on the server, while a mapping keyed by the original MCP tool name allows per-tool configuration.

`MCPUtil` attaches the selected guardrails to the converted `FunctionTool`, so local MCP tools use the existing tool-guardrail execution, approval, result-reporting, and tracing pipeline rather than introducing a separate MCP execution path. Existing `ToolExecutionConfig` pre-approval semantics are inherited unchanged. Hosted MCP behavior is unchanged, and local MCP behavior is unchanged when guardrails are omitted.

### Test plan

- `uv run pytest -q tests/mcp/test_mcp_tool_guardrails.py tests/mcp/test_mcp_util.py tests/mcp/test_runner_calls_mcp.py tests/mcp/test_mcp_approval.py` — 159 passed
- Changed-file Ruff formatting/lint — passed
- `uv run mypy src/agents/mcp/server.py src/agents/mcp/util.py` — passed
- Fork CI: lint, typecheck, MCP v1 compatibility, native macOS sandbox, Windows mypy, prospective release contract, and Windows packaged-contract checks passed on the clean rebased commit

### Issue number

Closes #4620

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR