### PR TITLE
feat(mcp): add server-wide guardrails to MCP tools

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -44,6 +44,7 @@ from ..logger import (
 )
 from ..run_context import RunContextWrapper
 from ..tool import ToolErrorFunction
+from ..tool_guardrails import ToolInputGuardrail, ToolOutputGuardrail
 from ..util._types import MaybeAwaitable
 from . import _compat as mcp_compat
 from ._compat import (
@@ -549,6 +550,9 @@ class MCPServer(abc.ABC):
         failure_error_function: ToolErrorFunction | None | _UnsetType = _UNSET,
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
+        *,
+        tool_input_guardrails: list[ToolInputGuardrail[Any]] | None = None,
+        tool_output_guardrails: list[ToolOutputGuardrail[Any]] | None = None,
     ):
         """
         Args:
@@ -570,6 +574,10 @@ class MCPServer(abc.ABC):
                 tool calls. It is invoked by the Agents SDK before calling `call_tool`.
             custom_data_extractor: Optional callable that produces SDK-only custom data for
                 emitted MCP tool output items.
+            tool_input_guardrails: Optional list of guardrails applied to every tool on this
+                server before the tool is invoked.
+            tool_output_guardrails: Optional list of guardrails applied to every tool on this
+                server after the tool returns.
         """
         self.use_structured_content = use_structured_content
         self._needs_approval_policy = self._normalize_needs_approval(
@@ -578,6 +586,8 @@ class MCPServer(abc.ABC):
         self._failure_error_function = failure_error_function
         self.tool_meta_resolver = tool_meta_resolver
         self.custom_data_extractor = custom_data_extractor
+        self.tool_input_guardrails = tool_input_guardrails
+        self.tool_output_guardrails = tool_output_guardrails
 
     @abc.abstractmethod
     async def connect(self):
@@ -879,6 +889,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
         retry_backoff_seconds_max: float | None = None,
+        *,
+        tool_input_guardrails: list[ToolInputGuardrail[Any]] | None = None,
+        tool_output_guardrails: list[ToolOutputGuardrail[Any]] | None = None,
     ):
         """
         Args:
@@ -918,6 +931,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 emitted MCP tool output items.
             retry_backoff_seconds_max: The non-negative finite maximum delay, in seconds, between
                 retries. Defaults to `None`, which leaves exponential backoff uncapped.
+            tool_input_guardrails: Optional list of guardrails applied to every tool on this
+                server before the tool is invoked.
+            tool_output_guardrails: Optional list of guardrails applied to every tool on this
+                server after the tool returns.
         """
         mcp_compat.enable_legacy_httpx_compat()
         super().__init__(
@@ -926,6 +943,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             failure_error_function=failure_error_function,
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
         self.session: ClientSession | None = None
         self.exit_stack: AsyncExitStack = AsyncExitStack()
@@ -1888,6 +1907,9 @@ class MCPServerStdio(_MCPServerWithClientSession):
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
         retry_backoff_seconds_max: float | None = None,
+        *,
+        tool_input_guardrails: list[ToolInputGuardrail[Any]] | None = None,
+        tool_output_guardrails: list[ToolOutputGuardrail[Any]] | None = None,
     ):
         """Create a new MCP server based on the stdio transport.
 
@@ -1932,6 +1954,10 @@ class MCPServerStdio(_MCPServerWithClientSession):
                 emitted MCP tool output items.
             retry_backoff_seconds_max: The non-negative finite maximum delay, in seconds, between
                 retries. Defaults to `None`, which leaves exponential backoff uncapped.
+            tool_input_guardrails: Optional list of guardrails applied to every tool on this
+                server before the tool is invoked.
+            tool_output_guardrails: Optional list of guardrails applied to every tool on this
+                server after the tool returns.
         """
         super().__init__(
             cache_tools_list=cache_tools_list,
@@ -1946,6 +1972,8 @@ class MCPServerStdio(_MCPServerWithClientSession):
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
             retry_backoff_seconds_max=retry_backoff_seconds_max,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
 
         self.params = StdioServerParameters(
@@ -2021,6 +2049,9 @@ class MCPServerSse(_MCPServerWithClientSession):
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
         retry_backoff_seconds_max: float | None = None,
+        *,
+        tool_input_guardrails: list[ToolInputGuardrail[Any]] | None = None,
+        tool_output_guardrails: list[ToolOutputGuardrail[Any]] | None = None,
     ):
         """Create a new MCP server based on the HTTP with SSE transport.
 
@@ -2067,6 +2098,10 @@ class MCPServerSse(_MCPServerWithClientSession):
                 emitted MCP tool output items.
             retry_backoff_seconds_max: The non-negative finite maximum delay, in seconds, between
                 retries. Defaults to `None`, which leaves exponential backoff uncapped.
+            tool_input_guardrails: Optional list of guardrails applied to every tool on this
+                server before the tool is invoked.
+            tool_output_guardrails: Optional list of guardrails applied to every tool on this
+                server after the tool returns.
         """
         super().__init__(
             cache_tools_list=cache_tools_list,
@@ -2081,6 +2116,8 @@ class MCPServerSse(_MCPServerWithClientSession):
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
             retry_backoff_seconds_max=retry_backoff_seconds_max,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
 
         self.params = params
@@ -2182,6 +2219,9 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
         retry_backoff_seconds_max: float | None = None,
+        *,
+        tool_input_guardrails: list[ToolInputGuardrail[Any]] | None = None,
+        tool_output_guardrails: list[ToolOutputGuardrail[Any]] | None = None,
     ):
         """Create a new MCP server based on the Streamable HTTP transport.
 
@@ -2229,6 +2269,10 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 emitted MCP tool output items.
             retry_backoff_seconds_max: The non-negative finite maximum delay, in seconds, between
                 retries. Defaults to `None`, which leaves exponential backoff uncapped.
+            tool_input_guardrails: Optional list of guardrails applied to every tool on this
+                server before the tool is invoked.
+            tool_output_guardrails: Optional list of guardrails applied to every tool on this
+                server after the tool returns.
         """
         super().__init__(
             cache_tools_list=cache_tools_list,
@@ -2243,6 +2287,8 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
             retry_backoff_seconds_max=retry_backoff_seconds_max,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
 
         self.params = params

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -575,6 +575,16 @@ class MCPUtil:
             ),
             failure_error_function=effective_failure_error_function,
             strict_json_schema=is_strict,
+            tool_input_guardrails=(
+                list(server.tool_input_guardrails)
+                if server.tool_input_guardrails is not None
+                else None
+            ),
+            tool_output_guardrails=(
+                list(server.tool_output_guardrails)
+                if server.tool_output_guardrails is not None
+                else None
+            ),
             needs_approval=needs_approval,
             mcp_title=resolve_mcp_tool_title(tool),
             tool_origin=ToolOrigin(

--- a/tests/mcp/helpers.py
+++ b/tests/mcp/helpers.py
@@ -21,6 +21,7 @@ from agents.mcp import MCPServer
 from agents.mcp.server import _UNSET, _MCPServerWithClientSession, _UnsetType
 from agents.mcp.util import MCPToolCustomDataExtractor, MCPToolMetaResolver, ToolFilter
 from agents.tool import ToolErrorFunction
+from agents.tool_guardrails import ToolInputGuardrail, ToolOutputGuardrail
 
 from .model_compat import ListResourceTemplatesResult, Tool as MCPTool
 
@@ -77,6 +78,8 @@ class FakeMCPServer(MCPServer):
         failure_error_function: ToolErrorFunction | None | _UnsetType = _UNSET,
         tool_meta_resolver: MCPToolMetaResolver | None = None,
         custom_data_extractor: MCPToolCustomDataExtractor | None = None,
+        tool_input_guardrails: list[ToolInputGuardrail[Any]] | None = None,
+        tool_output_guardrails: list[ToolOutputGuardrail[Any]] | None = None,
     ):
         super().__init__(
             use_structured_content=False,
@@ -84,6 +87,8 @@ class FakeMCPServer(MCPServer):
             failure_error_function=failure_error_function,
             tool_meta_resolver=tool_meta_resolver,
             custom_data_extractor=custom_data_extractor,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
         )
         self.tools: list[MCPToolType] = tools or []
         self.tool_calls: list[str] = []

--- a/tests/mcp/test_mcp_approval.py
+++ b/tests/mcp/test_mcp_approval.py
@@ -3,9 +3,19 @@ import asyncio
 import pytest
 from mcp.types import Tool as MCPTool
 
-from agents import Agent, RunContextWrapper, Runner
+from agents import (
+    Agent,
+    RunConfig,
+    RunContextWrapper,
+    Runner,
+    ToolExecutionConfig,
+    ToolGuardrailFunctionOutput,
+    ToolInputGuardrailData,
+)
 from agents.exceptions import UserError
+from agents.run_state import RunState
 from agents.testing import ScriptedModel
+from agents.tool_guardrails import tool_input_guardrail
 
 from ..test_responses import get_function_tool_call, get_text_message
 from ..utils.hitl import queue_function_call_and_text, resume_after_first_approval
@@ -38,6 +48,66 @@ async def test_mcp_require_approval_pauses_and_resumes():
     assert not resumed.interruptions
     assert server.tool_calls == ["add"]
     assert resumed.final_output == "done"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("pre_approval", [False, True])
+async def test_mcp_guardrails_preserve_approval_and_serialized_resume_order(
+    streaming: bool,
+    pre_approval: bool,
+):
+    guardrail_calls: list[tuple[str, str]] = []
+
+    @tool_input_guardrail
+    def allow_input(data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        guardrail_calls.append((data.context.tool_name, data.context.tool_arguments))
+        return ToolGuardrailFunctionOutput.allow()
+
+    server = FakeMCPServer(
+        require_approval="always",
+        tool_input_guardrails=[allow_input],
+    )
+    server.add_tool("add", {"type": "object", "properties": {}})
+    model = ScriptedModel(
+        [
+            [get_function_tool_call("add", "{}", call_id="guarded_mcp_call")],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="TestAgent", model=model, mcp_servers=[server])
+    run_config = RunConfig(
+        tool_execution=ToolExecutionConfig(
+            pre_approval_tool_input_guardrails=pre_approval,
+        )
+    )
+
+    if streaming:
+        first = Runner.run_streamed(agent, "call add", run_config=run_config)
+        async for _ in first.stream_events():
+            pass
+    else:
+        first = await Runner.run(agent, "call add", run_config=run_config)
+
+    assert len(first.interruptions) == 1
+    assert server.tool_calls == []
+    assert guardrail_calls == ([("add", "{}")] if pre_approval else [])
+
+    state = first.to_state()
+    state.approve(first.interruptions[0])
+    restored_state = await RunState.from_string(agent, state.to_string())
+
+    if streaming:
+        resumed = Runner.run_streamed(agent, restored_state, run_config=run_config)
+        async for _ in resumed.stream_events():
+            pass
+    else:
+        resumed = await Runner.run(agent, restored_state, run_config=run_config)
+
+    expected_guardrail_runs = 2 if pre_approval else 1
+    assert resumed.final_output == "done"
+    assert server.tool_calls == ["add"]
+    assert guardrail_calls == [("add", "{}")] * expected_guardrail_runs
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -18,6 +18,9 @@ from agents import (
     FunctionTool,
     Handoff,
     RunContextWrapper,
+    ToolGuardrailFunctionOutput,
+    ToolInputGuardrail,
+    ToolOutputGuardrail,
     default_tool_error_function,
     handoff,
 )
@@ -27,7 +30,13 @@ from agents.exceptions import (
     ModelBehaviorError,
     UserError,
 )
-from agents.mcp import MCPServer, MCPUtil
+from agents.mcp import (
+    MCPServer,
+    MCPServerSse,
+    MCPServerStdio,
+    MCPServerStreamableHttp,
+    MCPUtil,
+)
 from agents.mcp._compat import MCPError, tool_input_schema
 from agents.tool_context import ToolContext
 
@@ -115,6 +124,117 @@ async def test_get_all_function_tools():
     tools = await MCPUtil.get_all_function_tools(servers, True, run_context, agent)
     assert len(tools) == 5
     assert all(tool.name in names for tool in tools)
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_guardrails_apply_to_every_converted_tool_with_isolated_lists():
+    input_guardrail = ToolInputGuardrail(
+        guardrail_function=lambda _: ToolGuardrailFunctionOutput.allow()
+    )
+    output_guardrail = ToolOutputGuardrail(
+        guardrail_function=lambda _: ToolGuardrailFunctionOutput.allow()
+    )
+    server = FakeMCPServer(
+        tool_input_guardrails=[input_guardrail],
+        tool_output_guardrails=[output_guardrail],
+    )
+    server.add_tool("first", {})
+    server.add_tool("second", {})
+
+    tools = await MCPUtil.get_all_function_tools(
+        [server],
+        False,
+        RunContextWrapper(context=None),
+        Agent(name="test_agent"),
+    )
+
+    assert [tool.name for tool in tools] == ["first", "second"]
+    first, second = tools
+    assert isinstance(first, FunctionTool)
+    assert isinstance(second, FunctionTool)
+    assert first.tool_input_guardrails is not None
+    assert first.tool_output_guardrails is not None
+    assert first.tool_input_guardrails == [input_guardrail]
+    assert second.tool_input_guardrails == [input_guardrail]
+    assert first.tool_output_guardrails == [output_guardrail]
+    assert second.tool_output_guardrails == [output_guardrail]
+    assert first.tool_input_guardrails is not server.tool_input_guardrails
+    assert first.tool_input_guardrails is not second.tool_input_guardrails
+    assert first.tool_output_guardrails is not server.tool_output_guardrails
+    assert first.tool_output_guardrails is not second.tool_output_guardrails
+
+    first.tool_input_guardrails.clear()
+    first.tool_output_guardrails.clear()
+    assert server.tool_input_guardrails == [input_guardrail]
+    assert server.tool_output_guardrails == [output_guardrail]
+    assert second.tool_input_guardrails == [input_guardrail]
+    assert second.tool_output_guardrails == [output_guardrail]
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_guardrails_do_not_leak_across_servers_or_filtered_tools():
+    input_guardrail = ToolInputGuardrail(
+        guardrail_function=lambda _: ToolGuardrailFunctionOutput.allow()
+    )
+    guarded_server = FakeMCPServer(
+        tool_filter={"allowed_tool_names": ["guarded"]},
+        tool_input_guardrails=[input_guardrail],
+    )
+    guarded_server.add_tool("guarded", {})
+    guarded_server.add_tool("filtered_out", {})
+    unguarded_server = FakeMCPServer()
+    unguarded_server.add_tool("unguarded", {})
+
+    tools = await MCPUtil.get_all_function_tools(
+        [guarded_server, unguarded_server],
+        False,
+        RunContextWrapper(context=None),
+        Agent(name="test_agent"),
+    )
+
+    assert [tool.name for tool in tools] == ["guarded", "unguarded"]
+    guarded, unguarded = tools
+    assert isinstance(guarded, FunctionTool)
+    assert isinstance(unguarded, FunctionTool)
+    assert guarded.tool_input_guardrails == [input_guardrail]
+    assert guarded.tool_output_guardrails is None
+    assert unguarded.tool_input_guardrails is None
+    assert unguarded.tool_output_guardrails is None
+
+
+def test_public_mcp_server_constructors_forward_guardrail_configuration():
+    input_guardrails: list[ToolInputGuardrail[Any]] = []
+    output_guardrails: list[ToolOutputGuardrail[Any]] = []
+    servers = [
+        MCPServerStdio(
+            params={"command": "test"},
+            tool_input_guardrails=input_guardrails,
+            tool_output_guardrails=output_guardrails,
+        ),
+        MCPServerSse(
+            params={"url": "https://example.test/sse"},
+            tool_input_guardrails=input_guardrails,
+            tool_output_guardrails=output_guardrails,
+        ),
+        MCPServerStreamableHttp(
+            params={"url": "https://example.test/mcp"},
+            tool_input_guardrails=input_guardrails,
+            tool_output_guardrails=output_guardrails,
+        ),
+    ]
+
+    assert all(server.tool_input_guardrails is input_guardrails for server in servers)
+    assert all(server.tool_output_guardrails is output_guardrails for server in servers)
+
+    tool = MCPUtil.to_function_tool(
+        MCPTool(name="test", inputSchema={}),
+        servers[0],
+        convert_schemas_to_strict=False,
+    )
+    assert tool.tool_input_guardrails == []
+    assert tool.tool_output_guardrails == []
+    assert tool.tool_input_guardrails is not input_guardrails
+    assert tool.tool_output_guardrails is not output_guardrails
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_runner_calls_mcp.py
+++ b/tests/mcp/test_runner_calls_mcp.py
@@ -10,15 +10,30 @@ from agents import (
     ModelBehaviorError,
     RunContextWrapper,
     Runner,
+    ToolGuardrailFunctionOutput,
+    ToolInputGuardrailData,
+    ToolOutputGuardrailData,
     UserError,
     default_tool_error_function,
     handoff,
 )
 from agents.exceptions import AgentsException
 from agents.testing import ScriptedModel
+from agents.tool_guardrails import tool_input_guardrail, tool_output_guardrail
 
 from ..test_responses import get_function_tool_call, get_text_message
 from .helpers import FakeMCPServer
+
+
+def _model_tool_outputs(model: ScriptedModel) -> list[Any]:
+    values: list[Any] = []
+    for item in model.calls[-1].input:
+        item_type = item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+        if item_type == "function_call_output":
+            values.append(
+                item.get("output") if isinstance(item, dict) else getattr(item, "output", None)
+            )
+    return values
 
 
 @pytest.mark.asyncio
@@ -53,6 +68,75 @@ async def test_runner_calls_mcp_tool(streaming: bool):
         await Runner.run(agent, input="user_message")
 
     assert server.tool_calls == ["test_tool_2"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_mcp_input_guardrail_rejection_prevents_server_call(streaming: bool):
+    seen_inputs: list[tuple[str, str]] = []
+
+    @tool_input_guardrail
+    def reject_input(data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        seen_inputs.append((data.context.tool_name, data.context.tool_arguments))
+        return ToolGuardrailFunctionOutput.reject_content("blocked MCP input")
+
+    server = FakeMCPServer(tool_input_guardrails=[reject_input])
+    server.add_tool("sensitive", {})
+    model = ScriptedModel(
+        [
+            [get_function_tool_call("sensitive", '{"secret":"value"}')],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="test", model=model, mcp_servers=[server])
+
+    if streaming:
+        result = Runner.run_streamed(agent, input="user_message")
+        async for _ in result.stream_events():
+            pass
+    else:
+        result = await Runner.run(agent, input="user_message")
+
+    assert result.final_output == "done"
+    assert server.tool_calls == []
+    assert seen_inputs == [("sensitive", '{"secret":"value"}')]
+    assert len(result.tool_input_guardrail_results) == 1
+    assert _model_tool_outputs(model) == ["blocked MCP input"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_mcp_output_guardrail_checks_converted_output_before_model_input(streaming: bool):
+    seen_outputs: list[Any] = []
+
+    @tool_output_guardrail
+    def reject_output(data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+        seen_outputs.append(data.output)
+        return ToolGuardrailFunctionOutput.reject_content("blocked MCP output")
+
+    server = FakeMCPServer(tool_output_guardrails=[reject_output])
+    server.add_tool("lookup", {})
+    model = ScriptedModel(
+        [
+            [get_function_tool_call("lookup", "{}")],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="test", model=model, mcp_servers=[server])
+
+    if streaming:
+        result = Runner.run_streamed(agent, input="user_message")
+        async for _ in result.stream_events():
+            pass
+    else:
+        result = await Runner.run(agent, input="user_message")
+
+    assert result.final_output == "done"
+    assert server.tool_calls == ["lookup"]
+    assert seen_outputs == [{"type": "text", "text": server.tool_results[0]}]
+    assert len(result.tool_output_guardrail_results) == 1
+    assert _model_tool_outputs(model) == ["blocked MCP output"]
+    assert server.tool_results[0] not in str(model.calls[-1].input)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request adds optional input and output guardrails to local MCP servers and applies them uniformly to every converted tool.

Input guardrails run through the existing tool execution and approval lifecycle. Output guardrails inspect the converted SDK `ToolOutput`, rather than the raw MCP `CallToolResult`. The coverage includes filtering, multiple servers, streaming and non-streaming execution, approval ordering, serialized resume, and isolated guardrail list snapshots.

This pull request resolves #4620.