### PR TITLE
feat: add tool guardrails to Agent.as_tool

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     from .run import RunConfig
     from .run_state import RunState
     from .stream_events import StreamEvent
+    from .tool_guardrails import ToolInputGuardrail, ToolOutputGuardrail
 
 
 @dataclass
@@ -602,6 +603,8 @@ class Agent(AgentBase, Generic[TContext]):
         parameters: type[Any] | None = None,
         input_builder: StructuredToolInputBuilder | None = None,
         include_input_schema: bool = False,
+        tool_input_guardrails: list[ToolInputGuardrail[Any]] | None = None,
+        tool_output_guardrails: list[ToolOutputGuardrail[Any]] | None = None,
     ) -> FunctionTool:
         """Transform this agent into a tool, callable by other agents.
 
@@ -631,6 +634,8 @@ class Agent(AgentBase, Generic[TContext]):
             parameters: Structured input type for the tool arguments (dataclass or Pydantic model).
             input_builder: Optional function to build the nested agent input from structured data.
             include_input_schema: Whether to include the full JSON schema in structured input.
+            tool_input_guardrails: Optional guardrails to run before this agent tool executes.
+            tool_output_guardrails: Optional guardrails to run after this agent tool returns.
         """
 
         if run_config is not None:
@@ -1025,6 +1030,8 @@ class Agent(AgentBase, Generic[TContext]):
             failure_error_function=failure_error_function,
             strict_json_schema=True,
             is_enabled=is_enabled,
+            tool_input_guardrails=tool_input_guardrails,
+            tool_output_guardrails=tool_output_guardrails,
             needs_approval=needs_approval,
             tool_origin=ToolOrigin(
                 type=ToolOriginType.AGENT_AS_TOOL,

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -31,6 +31,9 @@ from agents import (
     SessionSettings,
     ToolApprovalItem,
     ToolCallOutputItem,
+    ToolGuardrailFunctionOutput,
+    ToolInputGuardrail,
+    ToolOutputGuardrail,
     TResponseInputItem,
     Usage,
     UserError,
@@ -217,6 +220,68 @@ async def test_agent_as_tool_derived_names_are_disambiguated_by_namespace():
         "sales.refund",
         "support.refund",
     ]
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_input_guardrail_can_block_nested_run():
+    nested_model = ScriptedModel([[get_text_message("nested result")]])
+    nested_agent = Agent(name="delegate", model=nested_model)
+    input_guardrail = ToolInputGuardrail(
+        guardrail_function=lambda _: ToolGuardrailFunctionOutput.reject_content(
+            "delegation blocked"
+        )
+    )
+    delegate_tool = nested_agent.as_tool(
+        tool_name="delegate",
+        tool_description="Delegate work",
+        tool_input_guardrails=[input_guardrail],
+    )
+    outer_model = ScriptedModel(
+        [
+            [get_function_tool_call("delegate", json.dumps({"input": "do work"}))],
+            [get_text_message("done")],
+        ]
+    )
+    outer_agent = Agent(name="outer", model=outer_model, tools=[delegate_tool])
+
+    result = await Runner.run(outer_agent, "start")
+
+    assert result.final_output == "done"
+    assert nested_model.calls == ()
+    assert len(result.tool_input_guardrail_results) == 1
+    outputs = [item.output for item in result.new_items if isinstance(item, ToolCallOutputItem)]
+    assert outputs == ["delegation blocked"]
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_output_guardrail_can_replace_nested_result():
+    nested_model = ScriptedModel([[get_text_message("sensitive nested result")]])
+    nested_agent = Agent(name="delegate", model=nested_model)
+    output_guardrail = ToolOutputGuardrail(
+        guardrail_function=lambda _: ToolGuardrailFunctionOutput.reject_content(
+            "delegation output withheld"
+        )
+    )
+    delegate_tool = nested_agent.as_tool(
+        tool_name="delegate",
+        tool_description="Delegate work",
+        tool_output_guardrails=[output_guardrail],
+    )
+    outer_model = ScriptedModel(
+        [
+            [get_function_tool_call("delegate", json.dumps({"input": "do work"}))],
+            [get_text_message("done")],
+        ]
+    )
+    outer_agent = Agent(name="outer", model=outer_model, tools=[delegate_tool])
+
+    result = await Runner.run(outer_agent, "start")
+
+    assert result.final_output == "done"
+    assert len(nested_model.calls) == 1
+    assert len(result.tool_output_guardrail_results) == 1
+    outputs = [item.output for item in result.new_items if isinstance(item, ToolCallOutputItem)]
+    assert outputs == ["delegation output withheld"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request adds `tool_input_guardrails` and `tool_output_guardrails` to `Agent.as_tool()`.

Agent tools already use the standard `FunctionTool` execution pipeline. The new parameters are passed directly to that existing pipeline, so delegated-agent tools now get the same input/output guardrail semantics as ordinary function tools, including existing approval ordering and tool guardrail result reporting.

The existing `Agent.as_tool()` positional contract is preserved; both parameters are optional and appended to the public signature.

### Test plan

- `uv run pytest -q tests/test_agent_as_tool.py` — 72 passed
- Changed-file Ruff formatting and lint — passed
- Focused mypy for `src/agents/agent.py` — passed
- Fork repository CI on the verified implementation — passed

Regression coverage proves that:
- an input guardrail can reject the delegated call before the nested agent model runs;
- an output guardrail can replace the nested agent result before it is returned to the parent model.

### Issue number

Closes #4637

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR