### PR TITLE
feat: add named OrcaRouter model provider example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -89,6 +89,8 @@ Check out a variety of sample implementations that use the SDK in the examples s
 
 - **[model_providers](https://github.com/openai/openai-agents-python/tree/main/examples/model_providers):** Explore how to use non-OpenAI models with the SDK, including custom providers and third-party adapters.
 
+    -   A named [OrcaRouter](https://www.orcarouter.ai) example that routes a Chat Completions model through the OrcaRouter gateway (`examples/model_providers/custom_example_orcarouter.py`)
+
 - **[realtime](https://github.com/openai/openai-agents-python/tree/main/examples/realtime):** Examples showing how to build real-time experiences using the SDK, including:
 
     -   Web application patterns with structured text and image messages

--- a/examples/model_providers/README.md
+++ b/examples/model_providers/README.md
@@ -22,3 +22,16 @@ Direct-model examples let you override the target model:
 uv run examples/model_providers/any_llm_provider.py --model openrouter/openai/gpt-5.4-mini
 uv run examples/model_providers/litellm_provider.py --model openrouter/openai/gpt-5.4-mini
 ```
+
+[OrcaRouter](https://www.orcarouter.ai) is another OpenAI-compatible gateway that exposes a
+single base URL across many models, with adaptive routing, automatic failover, and
+gateway-level security for AI agents. To try it with a direct model, set the
+`ORCAROUTER_API_KEY` environment variable and run the named example:
+
+```bash
+export ORCAROUTER_API_KEY="..."
+uv run examples/model_providers/custom_example_orcarouter.py
+```
+
+By default the example uses `gpt-5.6-luna`; override it with the `ORCAROUTER_MODEL`
+environment variable.

--- a/examples/model_providers/custom_example_orcarouter.py
+++ b/examples/model_providers/custom_example_orcarouter.py
@@ -1,0 +1,63 @@
+import asyncio
+import os
+
+from openai import AsyncOpenAI
+
+from agents import (
+    Agent,
+    OpenAIChatCompletionsModel,
+    Runner,
+    set_tracing_disabled,
+)
+from agents.decorators import tool
+
+"""This example uses OrcaRouter as a named provider for a specific agent.
+
+OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible AI gateway. Like
+OpenRouter, it exposes a single base URL and a provider/model namespace across many
+models, but it also adds adaptive routing, automatic failover, and gateway-level
+security for AI agents on the same endpoint. We point the Chat Completions model at
+the OrcaRouter base URL and use the dedicated ORCAROUTER_API_KEY, mirroring how the
+OpenRouter examples in this repository are wired up.
+
+Note that in this example, we disable tracing under the assumption that you don't have
+an API key from platform.openai.com. If you do have one, you can either set the
+`OPENAI_API_KEY` env var or call set_tracing_export_api_key() to set a tracing specific
+key.
+"""
+API_KEY = os.getenv("ORCAROUTER_API_KEY") or ""
+MODEL_NAME = os.getenv("ORCAROUTER_MODEL") or "gpt-5.6-luna"
+
+if not API_KEY:
+    raise ValueError("Please set ORCAROUTER_API_KEY via env var or code.")
+
+client = AsyncOpenAI(base_url="https://api.orcarouter.ai/v1", api_key=API_KEY)
+set_tracing_disabled(disabled=True)
+
+# An alternate approach that would also work:
+# PROVIDER = OpenAIProvider(openai_client=client)
+# agent = Agent(..., model="some-custom-model")
+# Runner.run(agent, ..., run_config=RunConfig(model_provider=PROVIDER))
+
+
+@tool
+def get_weather(city: str):
+    print(f"[debug] getting weather for {city}")
+    return f"The weather in {city} is sunny."
+
+
+async def main():
+    # This agent will use OrcaRouter for its model calls.
+    agent = Agent(
+        name="Assistant",
+        instructions="You only respond in haikus.",
+        model=OpenAIChatCompletionsModel(model=MODEL_NAME, openai_client=client),
+        tools=[get_weather],
+    )
+
+    result = await Runner.run(agent, "What's the weather in Tokyo?")
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows that is provider-agnostic, supporting the OpenAI Responses and Chat Completions APIs as well as 100+ other LLMs. The `examples/model_providers` directory is where users learn how to route their agents through non-OpenAI providers.

Today the examples all use OpenRouter as the default gateway "so you only need one API key." This PR mirrors that existing wiring with a first-class, named **OrcaRouter** example: `examples/model_providers/custom_example_orcarouter.py`. Like OpenRouter, [OrcaRouter](https://www.orcarouter.ai) exposes a provider/model namespace behind a single OpenAI-compatible base URL — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

By following the exact pattern the repo already uses for OpenRouter (`AsyncOpenAI` pointed at `https://openrouter.ai/api/v1` with `OPENROUTER_API_KEY`), the new example points `OpenAIChatCompletionsModel` at `https://api.orcarouter.ai/v1` with a dedicated `ORCAROUTER_API_KEY`, so users of this SDK get the OrcaRouter stack without treating it as an anonymous custom base URL.

### Changes

- **`examples/model_providers/custom_example_orcarouter.py`** — new named OrcaRouter example, mirroring `custom_example_agent.py` and the OpenRouter wiring in `examples/reasoning_content/gpt_oss_stream.py`. Defaults to `gpt-5.6-luna`, overridable via `ORCAROUTER_MODEL`.
- **`examples/model_providers/README.md`** — documents the new example alongside the existing OpenRouter-based ones.
- **`docs/examples.md`** — lists the new named example under `model_providers`.

## Test plan

- `ruff check` and `ruff format --check` (pinned to the repo's `ruff==0.9.2`) pass on the new file and across the full repository.
- `tests/models/` passes: **843 passed**.
- Live-verified: ran `custom_example_orcarouter.py` with a real `ORCAROUTER_API_KEY` against `https://api.orcarouter.ai/v1`; the agent completed a full tool-calling run and returned the expected output.

## Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
