### PR TITLE
fix(core): accept JSON Schema type arrays of object for tool outputs

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2176,7 +2176,10 @@ def _json_schema_is_object(schema: dict[str, Any]) -> bool:
     current: Any = schema
     seen_refs: set[str] = set()
     while isinstance(current, dict):
-        if current.get("type") == "object":
+        # JSON Schema allows a one-element type array; treat ["object"] like "object" so
+        # OpenAPI/MCP-style output schemas match the params and strict-schema paths.
+        typ = current.get("type")
+        if typ == "object" or typ == ["object"]:
             return True
         ref = current.get("$ref")
         if not isinstance(ref, str) or not ref.startswith("#/") or ref in seen_refs:

--- a/tests/test_programmatic_tool_calling.py
+++ b/tests/test_programmatic_tool_calling.py
@@ -408,6 +408,24 @@ def test_function_tool_rejects_non_object_or_non_strict_raw_output_schema(
         )
 
 
+def test_function_tool_accepts_single_element_object_type_array_output_schema() -> None:
+    """JSON Schema type arrays such as ``["object"]`` are equivalent to ``"object"``."""
+
+    tool = function_tool(
+        lambda: {"a": "x"},
+        allowed_callers=["programmatic"],
+        output_json_schema={
+            "type": ["object"],
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+            "additionalProperties": False,
+        },
+    )
+    assert tool.output_json_schema is not None
+    assert tool.output_json_schema["type"] == "object"
+    assert tool.output_json_schema["additionalProperties"] is False
+
+
 @pytest.mark.asyncio
 async def test_function_tool_validates_inferred_output_type() -> None:
     @function_tool(allowed_callers=["programmatic"])


### PR DESCRIPTION
### Summary

`_json_schema_is_object()` only treated `\"type\": \"object\"` as an object schema. JSON Schema also allows a one-element type array (`\"type\": [\"object\"]`), which OpenAPI and MCP generators commonly emit.

That form already works for **params** because `ensure_strict_json_schema` / `_ensure_strict_root` normalize it. The **output** path checks `_json_schema_is_object` first, so `function_tool(..., output_json_schema={\"type\": [\"object\"], ...})` raised `UserError` before conversion.

### Reproduction

```python
from agents import function_tool

schema = {
    \"type\": [\"object\"],
    \"properties\": {\"a\": {\"type\": \"string\"}},
    \"required\": [\"a\"],
    \"additionalProperties\": False,
}

function_tool(lambda: {\"a\": \"x\"}, allowed_callers=[\"programmatic\"], output_json_schema=schema)
# Before: UserError: output_json_schema must define a JSON object schema.
# After: accepted and stored with type == \"object\"
```

### Solution

Treat `type == [\"object\"]` as an object, matching `_ensure_strict_root`. Other type arrays such as `[\"object\", \"null\"]` still fail the object gate / strict conversion.

### Test plan

- [x] Added a programmatic-tool regression that constructs a tool from `type: [\"object\"]`
- [x] `uv run pytest tests/test_programmatic_tool_calling.py tests/test_function_tool.py` (202 passed)
- [x] `make format`, `make lint`, `make typecheck` passed
- [x] Full `make tests`: 9193 passed, 1 pre-existing failure in `tests/sandbox/test_run_cwd.py::test_python_skill_uses_absolute_root_from_nested_workdir` (reproduced on unmodified `main`)

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run format, lint, typecheck, and targeted tests
- [ ] If using Codex, I've run `/review` before submitting this PR