### PR TITLE
fix(sessions): recover failed resumed Session writes on a renewed interruption

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -739,7 +739,8 @@ async def save_resumed_turn_items(
         wrapper=wrapper,
         resumed_write_state=(
             run_state
-            if run_state is not None and isinstance(run_state._current_step, NextStepRunAgain)
+            if run_state is not None
+            and isinstance(run_state._current_step, NextStepRunAgain | NextStepInterruption)
             else None
         ),
     )

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -4358,11 +4358,11 @@ async def _build_run_state_from_json(
     )
     pending_write = state_json.get("pending_session_write")
     if pending_write is not None:
-        from .run_internal.run_steps import NextStepRunAgain
+        from .run_internal.run_steps import NextStepInterruption, NextStepRunAgain
 
         if (
             (schema_major, schema_minor) < (1, 17)
-            or not isinstance(state._current_step, NextStepRunAgain)
+            or not isinstance(state._current_step, NextStepRunAgain | NextStepInterruption)
             or not isinstance(pending_write, dict)
             or set(pending_write) != {"session_id", "items", "before", "persisted_count"}
             or not isinstance(pending_write.get("session_id"), str)

--- a/tests/test_run_impl_resume_paths.py
+++ b/tests/test_run_impl_resume_paths.py
@@ -210,6 +210,71 @@ async def test_resumed_session_append_survives_repeated_failure_and_late_input()
     assert effects == [7]
 
 
+async def _partially_approved_session_state(streamed: bool):
+    """Pause on two approval-gated calls in one response and approve only the first."""
+    effects: list[int] = []
+
+    @tool(needs_approval=True)
+    async def charge(amount: int) -> str:
+        effects.append(amount)
+        return "receipt-7"
+
+    @tool(needs_approval=True)
+    async def notify() -> str:
+        raise AssertionError("the unresolved approval must not execute")
+
+    model = ScriptedModel(
+        [
+            [
+                get_function_tool_call("charge", '{"amount":7}', call_id="charge-1"),
+                get_function_tool_call("notify", "{}", call_id="notify-1"),
+            ],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="payment", model=model, tools=[charge, notify])
+    session = _FailingResumeSession()
+    paused = await _run_session_resume(agent, "charge 7 and notify", session, streamed)
+    state = paused.to_state()
+    charge_approval = next(
+        item for item in state.get_interruptions() if item.raw_item.call_id == "charge-1"
+    )
+    state.approve(charge_approval)
+    return agent, model, session, state, effects
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("round_trip", [False, True], ids=["live", "json"])
+async def test_renewed_interruption_recovers_failed_resumed_session_append(
+    streamed: bool, round_trip: bool
+) -> None:
+    agent, model, session, state, effects = await _partially_approved_session_state(streamed)
+    session.failure = "before"
+    with pytest.raises(RuntimeError) as error:
+        await _run_session_resume(agent, state, session, streamed)
+    assert error.value is session.error
+    assert effects == [7]
+    assert _charge_pair(await session.get_items()) == ["function_call"]
+
+    if round_trip:
+        state = await RunState.from_json(agent, state.to_json())
+
+    pending = await _run_session_resume(agent, state, session, streamed)
+    pending_state = pending.to_state()
+    remaining = pending_state.get_interruptions()
+    assert [item.raw_item.call_id for item in remaining] == ["notify-1"]
+    assert len(model.calls) == 1
+
+    pending_state.reject(remaining[0], rejection_message="declined")
+    result = await _run_session_resume(agent, pending_state, session, streamed)
+    assert result.final_output == "done"
+    assert effects == [7]
+    expected_pair = ["function_call", "function_call_output"]
+    assert _charge_pair(await session.get_items()) == expected_pair
+    assert _charge_pair(result.to_input_list()) == expected_pair
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("streamed", [False, True])
 @pytest.mark.parametrize("round_trip", [False, True], ids=["live", "json"])


### PR DESCRIPTION
### Summary

Resuming a turn that resolves one approval while another stays pending advances the run to `NextStepInterruption`. Both halves of the pending-write recovery added in #4630 are gated on `NextStepRunAgain`:

- `save_resumed_turn_items()` only passes `resumed_write_state` when the step is `NextStepRunAgain`, so this transition records no pending write.
- `RunState` deserialization rejects a restored pending write unless the step is `NextStepRunAgain`.

So when the resumed `Session` append raises on that transition, the failed batch has no recovery marker. The approved tool already ran and its guardrails and hooks already completed, but the `function_call_output` never reaches the durable `Session`, while `RunState` and `RunResult.to_input_list()` both keep it. Resolving the second approval then continues into another model call on top of a `Session` that holds a `function_call` with no matching output, and a later fresh run prunes the orphan, so the completed action disappears from future context.

This is the same durable divergence #4630 fixed for `NextStepRunAgain`, on a transition that PR did not cover. Its description scopes out handoff and terminal recovery, not this one.

Measured on an eight row matrix (sync and streamed, live and JSON round trip, atomic failure and commit-then-raise), comparing the durable `Session` against the replay:

```
before   session_ok 4/8   the four atomic-failure rows store function_call with no output
after    session_ok 8/8
```

The change widens both gates to accept `NextStepInterruption` so the existing pending-write mechanism covers the transition. No new machinery, no schema change: `pending_session_write` already carries everything recovery needs, and `resume_pending_session_write()` already reconciles it before the next model call.

Scope note: #4646 also reports that the completed tool's input/output guardrail results are dropped from `RunState` and every later result on this path. That is a separate ordering problem in `run.py`, where the guardrail results are published after the append that raises, and it is deliberately not touched here.

### Test plan

`tests/test_run_impl_resume_paths.py::test_renewed_interruption_recovers_failed_resumed_session_append`, parametrized over streamed and non streamed and over a live state and a JSON round trip. It pauses on two approval-gated calls in one response, approves only the first, fails the resumed append, then resolves the second approval and asserts the durable `Session` and the replay agree.

Verified it fails without the source change by reverting `src/` and rerunning: all four cases fail with `['function_call'] != ['function_call', 'function_call_output']`.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full test suite, including the existing #4630 coverage.

### Issue number

Partially addresses #4646

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

I'm a freshman in college learning this codebase by chasing real bugs in it, so please double check my reasoning on the transaction boundary here. I picked the smallest change that made the durable state agree with the replay rather than proposing a new contract, since the pending-write mechanism already existed and only the gate looked too narrow. Happy to fold in the guardrail-result half or drop this entirely if you'd rather handle the whole transition in one go.
