### PR TITLE
fix(core): keep completed tool guardrail results when a resumed append fails

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1135,17 +1135,18 @@ class AgentRunner:
                                     generated_items=generated_items,
                                     session_items=session_items,
                                 )
-                                # Publish this turn's tool guardrail results before the
-                                # resumed Session append, which can raise and skip the
-                                # interruption branch below. The tool already ran.
-                                run_state._tool_input_guardrail_results = [
-                                    *tool_input_guardrail_results,
-                                    *turn_result.tool_input_guardrail_results,
-                                ]
-                                run_state._tool_output_guardrail_results = [
-                                    *tool_output_guardrail_results,
-                                    *turn_result.tool_output_guardrail_results,
-                                ]
+                                if isinstance(turn_result.next_step, NextStepInterruption):
+                                    # Publish this turn's tool guardrail results before the
+                                    # resumed Session append, which can raise and skip the
+                                    # interruption branch below. The tool already ran.
+                                    run_state._tool_input_guardrail_results = [
+                                        *tool_input_guardrail_results,
+                                        *turn_result.tool_input_guardrail_results,
+                                    ]
+                                    run_state._tool_output_guardrail_results = [
+                                        *tool_output_guardrail_results,
+                                        *turn_result.tool_output_guardrail_results,
+                                    ]
 
                             if (
                                 session_persistence_enabled

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1135,6 +1135,17 @@ class AgentRunner:
                                     generated_items=generated_items,
                                     session_items=session_items,
                                 )
+                                # Publish this turn's tool guardrail results before the
+                                # resumed Session append, which can raise and skip the
+                                # interruption branch below. The tool already ran.
+                                run_state._tool_input_guardrail_results = [
+                                    *tool_input_guardrail_results,
+                                    *turn_result.tool_input_guardrail_results,
+                                ]
+                                run_state._tool_output_guardrail_results = [
+                                    *tool_output_guardrail_results,
+                                    *turn_result.tool_output_guardrail_results,
+                                ]
 
                             if (
                                 session_persistence_enabled

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1354,17 +1354,18 @@ async def start_streaming(
                             generated_items=generated_items,
                             session_items=streamed_result.new_items,
                         )
-                        # Publish this turn's tool guardrail results before the resumed
-                        # Session append, which can raise and skip the interruption
-                        # branch below. The tool already ran.
-                        run_state._tool_input_guardrail_results = [
-                            *accepted_tool_input_guardrail_results,
-                            *turn_result.tool_input_guardrail_results,
-                        ]
-                        run_state._tool_output_guardrail_results = [
-                            *accepted_tool_output_guardrail_results,
-                            *turn_result.tool_output_guardrail_results,
-                        ]
+                        if isinstance(turn_result.next_step, NextStepInterruption):
+                            # Publish this turn's tool guardrail results before the resumed
+                            # Session append, which can raise and skip the interruption
+                            # branch below. The tool already ran.
+                            run_state._tool_input_guardrail_results = [
+                                *accepted_tool_input_guardrail_results,
+                                *turn_result.tool_input_guardrail_results,
+                            ]
+                            run_state._tool_output_guardrail_results = [
+                                *accepted_tool_output_guardrail_results,
+                                *turn_result.tool_output_guardrail_results,
+                            ]
                         run_state._current_turn_persisted_item_count = (
                             streamed_result._current_turn_persisted_item_count
                         )

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1354,6 +1354,17 @@ async def start_streaming(
                             generated_items=generated_items,
                             session_items=streamed_result.new_items,
                         )
+                        # Publish this turn's tool guardrail results before the resumed
+                        # Session append, which can raise and skip the interruption
+                        # branch below. The tool already ran.
+                        run_state._tool_input_guardrail_results = [
+                            *accepted_tool_input_guardrail_results,
+                            *turn_result.tool_input_guardrail_results,
+                        ]
+                        run_state._tool_output_guardrail_results = [
+                            *accepted_tool_output_guardrail_results,
+                            *turn_result.tool_output_guardrail_results,
+                        ]
                         run_state._current_turn_persisted_item_count = (
                             streamed_result._current_turn_persisted_item_count
                         )

--- a/tests/test_run_impl_resume_paths.py
+++ b/tests/test_run_impl_resume_paths.py
@@ -38,6 +38,11 @@ from agents.run_internal.run_loop import (
 )
 from agents.run_state import RunState
 from agents.testing import ScriptedModel
+from agents.tool_guardrails import (
+    ToolGuardrailFunctionOutput,
+    tool_input_guardrail,
+    tool_output_guardrail,
+)
 from agents.usage import Usage
 from tests.test_responses import get_function_tool_call, get_text_message
 from tests.utils.hitl import (
@@ -984,3 +989,76 @@ async def test_resolve_interrupted_turn_only_uses_name_fallback_for_legacy_appro
             isinstance(item, ToolCallOutputItem) and item.output == "one"
             for item in result.new_step_items
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("round_trip", [False, True], ids=["live", "json"])
+async def test_failed_resumed_append_keeps_completed_tool_guardrail_results(
+    streamed: bool, round_trip: bool
+) -> None:
+    """A failed resumed append must not discard guardrail results the tool already produced."""
+
+    @tool_input_guardrail
+    def allow_input(_data: Any) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info="input-ok")
+
+    @tool_output_guardrail
+    def allow_output(_data: Any) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info="output-ok")
+
+    @tool(
+        needs_approval=True,
+        tool_input_guardrails=[allow_input],
+        tool_output_guardrails=[allow_output],
+    )
+    async def charge(amount: int) -> str:
+        return "receipt-7"
+
+    @tool(needs_approval=True)
+    async def notify() -> str:
+        raise AssertionError("the unresolved approval must not execute")
+
+    model = ScriptedModel(
+        [
+            [
+                get_function_tool_call("charge", '{"amount":7}', call_id="charge-1"),
+                get_function_tool_call("notify", "{}", call_id="notify-1"),
+            ],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="payment", model=model, tools=[charge, notify])
+    session = _FailingResumeSession()
+
+    paused = await _run_session_resume(agent, "charge 7 and notify", session, streamed)
+    state = paused.to_state()
+    state.approve(
+        next(item for item in state.get_interruptions() if item.raw_item.call_id == "charge-1")
+    )
+
+    session.failure = "before"
+    with pytest.raises(RuntimeError) as error:
+        await _run_session_resume(agent, state, session, streamed)
+    assert error.value is session.error
+
+    # The tool ran and both guardrails completed, so the checkpoint must retain their results.
+    assert len(state._tool_input_guardrail_results) == 1
+    assert len(state._tool_output_guardrail_results) == 1
+    serialized = state.to_json()
+    assert len(serialized["tool_input_guardrail_results"]) == 1
+    assert len(serialized["tool_output_guardrail_results"]) == 1
+
+    if round_trip:
+        state = await RunState.from_json(agent, serialized)
+
+    pending = await _run_session_resume(agent, state, session, streamed)
+    pending_state = pending.to_state()
+    remaining = pending_state.get_interruptions()
+    assert [item.raw_item.call_id for item in remaining] == ["notify-1"]
+
+    pending_state.reject(remaining[0], rejection_message="declined")
+    result = await _run_session_resume(agent, pending_state, session, streamed)
+    assert result.final_output == "done"
+    assert len(result.tool_input_guardrail_results) == 1
+    assert len(result.tool_output_guardrail_results) == 1


### PR DESCRIPTION
### Summary

On a resumed turn that resolves one approval while another stays pending, the run publishes that turn's tool guardrail results only inside the `NextStepInterruption` branch, and that branch sits after the resumed `Session` append:

```python
save_resumed_turn_items(...)            # can raise
...
if isinstance(turn_result.next_step, NextStepInterruption):
    tool_input_guardrail_results.extend(turn_result.tool_input_guardrail_results)
    tool_output_guardrail_results.extend(turn_result.tool_output_guardrail_results)
```

When that append raises, the approved tool has already executed and both its input and output guardrails have already returned, but nothing carries their results into `RunState`. The run-level lists die with the raised call, and `RunState` only ever receives guardrail results from a built result (`result.py`), which never happens on this path. Nothing republishes them later either, because the recovery resume does not re-execute the tool. So the results are gone permanently: absent from the checkpoint, from its serialization, and from the final `RunResult`.

Measured with an allow-only input guardrail and an allow-only output guardrail on the approved tool, across sync and streamed and across a live state and a JSON round trip. `ran` is how many times each guardrail actually executed:

```
before   ran=(1,1)   state=(0,0)  serialized=(0,0)  final=(0,0)     0/4 rows retain them
after    ran=(1,1)   state=(1,1)  serialized=(1,1)  final=(1,1)     4/4
```

The change publishes them next to the other resumed state updates, before the append, in both `run.py` and `run_loop.py`. Both paths already seed their run-level accumulators from `RunState` once at run start, before the turn loop, so writing the turn's results into state mid-turn cannot double count. Confirmed on the clean path, which still reports `(1, 1)` and not `(2, 2)` in both sync and streamed.

This is the second defect reported in #4646. It is independent of #4650: different root cause, different files, and the two diffs do not touch the same functions. #4650 makes the durable `Session` recover the dropped append; this one makes the completed guardrail results survive the same failure. Either can land without the other.

### Test plan

`tests/test_run_impl_resume_paths.py::test_failed_resumed_append_keeps_completed_tool_guardrail_results`, parametrized over streamed and non streamed and over a live state and a JSON round trip. It pauses on two approval-gated calls in one response, approves only the first, fails the resumed append, then asserts the checkpoint and its serialization each retain one input and one output guardrail result, and that the final result still reports them after the second approval is rejected.

Verified it fails without the source change by reverting `src/` and rerunning: all four cases fail.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full test suite.

### Issue number

Partially addresses #4646

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

Second half of the same issue, split out because the root cause is a different one and I did not want to bury two fixes in one diff. I'm a freshman in college and still learning this part of the runner, so the thing I'd most like checked is my claim that publishing before the append cannot double count. I reasoned it from the accumulators being seeded once at run start and then verified the clean path stays at one result each, but you know the ordering here far better than I do.
