### PR TITLE
fix(mcp): reject duplicate tools from one server

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -281,6 +281,7 @@ class MCPUtil:
             server_tool_batches = []
             for server_index, server in enumerate(servers):
                 listed_tools = await cls._list_tools_with_span(server, run_context, agent)
+                cls._validate_unique_tool_names(server, listed_tools)
                 server_tool_batches.append((server_index, server, listed_tools))
 
             prefixed_tool_name_overrides = cls._build_prefixed_tool_name_overrides(
@@ -375,6 +376,17 @@ class MCPUtil:
         ]
 
     @classmethod
+    def _validate_unique_tool_names(cls, server: MCPServer, tools: list[MCPTool]) -> None:
+        duplicate_tool_names = sorted(
+            name for name, count in Counter(tool.name for tool in tools).items() if count > 1
+        )
+        if duplicate_tool_names:
+            raise UserError(
+                "Duplicate tool names found on MCP server "
+                f"`{get_mcp_server_log_name(server.name)}`: {', '.join(duplicate_tool_names)}"
+            )
+
+    @classmethod
     async def get_function_tools(
         cls,
         server: MCPServer,
@@ -390,6 +402,7 @@ class MCPUtil:
         """Get all function tools from a single MCP server."""
 
         tools = await cls._list_tools_with_span(server, run_context, agent)
+        cls._validate_unique_tool_names(server, tools)
 
         tool_name_overrides: list[str] | None = None
         if tool_name_override is not None:

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -264,6 +264,29 @@ async def test_get_all_function_tools_duplicate_error_is_deterministic():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("include_server_in_tool_names", [False, True])
+async def test_get_all_function_tools_rejects_duplicates_from_one_server(
+    include_server_in_tool_names: bool,
+):
+    server = FakeMCPServer(server_name="duplicate_server")
+    server.add_tool("lookup", {})
+    server.add_tool("lookup", {})
+
+    with pytest.raises(UserError, match="Duplicate tool names found on MCP server") as exc_info:
+        await MCPUtil.get_all_function_tools(
+            [server],
+            False,
+            RunContextWrapper(context=None),
+            Agent(name="test_agent"),
+            include_server_in_tool_names=include_server_in_tool_names,
+        )
+
+    assert str(exc_info.value) == (
+        "Duplicate tool names found on MCP server `duplicate_server`: lookup"
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_all_function_tools_duplicate_error_without_hint_when_prefixed():
     """When include_server_in_tool_names is already enabled, duplicates should
     not suggest enabling the same option again.


### PR DESCRIPTION
### Summary

This pull request fixes MCP tool discovery accepting duplicate tool names returned by a single server. Because both definitions share the same invocation identity, discovery now raises a deterministic `UserError` before conversion in both prefixed and unprefixed listing paths.

### Test plan

- Added deterministic coverage for same-server duplicates with server-name prefixing both disabled and enabled.
- Preserved existing cross-server collision and prefix behavior.
- Ran `.agents/skills/code-change-verification/scripts/run.sh` after `make sync`; formatting, lint, type checking, and the full test suite passed.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
