### PR TITLE
fix(core): preserve tuple annotations for variadic tool arguments

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -399,10 +399,10 @@ def function_schema(
         if param.kind == param.VAR_POSITIONAL:
             # e.g. *args: extend positional args
             if get_origin(ann) is tuple:
-                # e.g. def foo(*args: tuple[int, ...]) -> treat as List[int]
+                # Preserve a homogeneous tuple as the type of each positional argument.
                 args_of_tuple = get_args(ann)
                 if len(args_of_tuple) == 2 and args_of_tuple[1] is Ellipsis:
-                    ann = list[args_of_tuple[0]]  # type: ignore
+                    ann = list[ann]  # type: ignore
                 else:
                     ann = list[Any]
             else:

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -439,8 +439,7 @@ def test_run_context_in_non_first_position_raises_value_error():
 
 
 def test_var_positional_tuple_annotation():
-    # When a function has a var-positional parameter annotated with a tuple type,
-    # function_schema() should convert it into a field with type List[<tuple-element>].
+    # A variadic tuple annotation applies to each positional argument.
     def func(*args: tuple[int, ...]) -> int:
         total = 0
         for arg in args:
@@ -450,8 +449,17 @@ def test_var_positional_tuple_annotation():
     fs = function_schema(func, use_docstring_info=False)
 
     properties = fs.params_json_schema.get("properties", {})
-    assert properties.get("args").get("type") == "array"
-    assert properties.get("args").get("items").get("type") == "integer"
+    args_schema = properties.get("args", {})
+    assert args_schema.get("type") == "array"
+    assert args_schema.get("items", {}).get("type") == "array"
+    assert args_schema.get("items", {}).get("items", {}).get("type") == "integer"
+
+    parsed = fs.params_pydantic_model.model_validate({"args": [[1, 2], [3]]})
+    args, kwargs = fs.to_call_args(parsed)
+    assert func(*args, **kwargs) == 6
+
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model.model_validate({"args": [1, 2, 3]})
 
 
 def test_var_keyword_dict_annotation():


### PR DESCRIPTION
### Summary

This pull request fixes function-tool schema generation for callables annotated with `*args: tuple[T, ...]`.

The current implementation flattens the tuple annotation to `list[T]`. As a result, the generated schema rejects correctly nested JSON, accepts flat scalar values, and then reconstructs positional arguments that violate the callable's annotation.

The fix preserves the complete homogeneous tuple annotation as each variadic element type. Existing behavior for ordinary variadics and fixed-length tuple annotations remains unchanged. The regression test covers schema generation, validation, argument reconstruction, successful invocation, and rejection of the old flat input shape.

### Test plan

- `.venv/bin/pytest -q tests/test_function_schema.py tests/test_function_tool.py`: 101 passed
- `make format`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make tests-review`: 9,257 passed, 35 skipped
- `.agents/skills/code-change-verification/scripts/run.sh`: full `make tests` reached 9,201 passed and 30 skipped, with three unrelated failures. Both SQLite multiprocessing timeouts passed on focused rerun. The remaining review-optional sandbox integration test is blocked locally because `/etc/profile` resets the fixture-injected `PATH`, hiding its mock `rclone`. This pull request does not change sandbox or session code.

### Issue number

None — this was an unreported bug.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
