### PR TITLE
fix: strip empty provider data from Responses input

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1052,7 +1052,7 @@ class OpenAIResponsesModel(Model):
         # independently of it.
         needs_cleaning = any(
             isinstance(item, dict)
-            and (item.get("provider_data") or item.get("id") == FAKE_RESPONSES_ID)
+            and ("provider_data" in item or item.get("id") == FAKE_RESPONSES_ID)
             for item in list_input
         )
         if not needs_cleaning:

--- a/tests/models/test_remove_openai_responses_api_incompatible_fields.py
+++ b/tests/models/test_remove_openai_responses_api_incompatible_fields.py
@@ -111,8 +111,10 @@ class TestRemoveOpenAIResponsesAPIIncompatibleFields:
         assert "id" not in result[1]
         assert result[1]["content"] == "hello"
 
-    def test_preserves_real_ids(self, model: OpenAIResponsesModel):
-        """Real IDs (not FAKE_RESPONSES_ID) should be preserved."""
+    def test_removes_empty_provider_data_and_preserves_real_ids(
+        self, model: OpenAIResponsesModel
+    ) -> None:
+        """Empty provider metadata is stripped without removing a real item ID."""
         list_input = [
             {
                 "type": "message",
@@ -125,6 +127,7 @@ class TestRemoveOpenAIResponsesAPIIncompatibleFields:
         result = model._remove_openai_responses_api_incompatible_fields(list_input)
 
         assert result[0]["id"] == "msg_real123"
+        assert "provider_data" not in result[0]
 
     def test_handles_empty_list(self, model: OpenAIResponsesModel):
         """Empty list should be returned unchanged."""
@@ -203,3 +206,36 @@ class TestRemoveOpenAIResponsesAPIIncompatibleFields:
 
         assert message.id == FAKE_RESPONSES_ID
         assert "id" not in create_kwargs["input"][1]
+
+    def test_request_payload_drops_empty_provider_data_without_mutating_input(
+        self, model: OpenAIResponsesModel
+    ) -> None:
+        """Request construction strips SDK metadata from a copy of caller-owned input."""
+        message: dict[str, Any] = {
+            "type": "message",
+            "id": "msg_real123",
+            "role": "assistant",
+            "status": "completed",
+            "content": [],
+            "provider_data": {},
+        }
+
+        create_kwargs = model._build_response_create_kwargs(
+            system_instructions=None,
+            input=[cast(TResponseInputItem, message)],
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+        )
+
+        assert create_kwargs["input"] == [
+            {
+                "type": "message",
+                "id": "msg_real123",
+                "role": "assistant",
+                "status": "completed",
+                "content": [],
+            }
+        ]
+        assert message["provider_data"] == {}


### PR DESCRIPTION
### Summary

Fix Responses input sanitization so an empty SDK-only `provider_data` field cannot reach the OpenAI wire payload.

The sanitizer now detects the field by key presence instead of value truthiness. This preserves real response IDs, keeps the existing placeholder-ID and provider-specific reasoning behavior, and sanitizes only the request copy rather than caller-owned input.

### Test plan

- `uv run pytest -q tests/models/test_remove_openai_responses_api_incompatible_fields.py` (`11 passed`)
- `make format`
- `make lint`
- `make typecheck`
- `make tests-review` (`9258 passed, 35 skipped` across parallel and serial suites)
- `.agents/skills/code-change-verification/scripts/run.sh` reached `9200 passed, 30 skipped` before five unrelated failures: four SQLite multiprocessing timing cases passed on focused sequential rerun, while one `review_optional` UnixLocal sandbox test still fails because this host resets `PATH` inside `sh -lc` and cannot see the fixture-provided mock `rclone`. The failure occurs during sandbox mount setup before the Responses code path is exercised.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
