### PR TITLE
Fix strict schema default handling

### DIFF
--- a/.agents/references/function-and-output-schema.md
+++ b/.agents/references/function-and-output-schema.md
@@ -16,7 +16,7 @@ Schema behavior is a compatibility boundary shared by Python callables, Pydantic
 
 - Strict conversion closes object schemas with `additionalProperties: false` and marks their declared properties required. Reject an explicit `additionalProperties: true` instead of silently changing its meaning.
 - Preserve the meaning of unions, intersections, definitions, and references. Normalize `oneOf` where required, process `allOf`, retain chained references, and merge a referenced schema with sibling keys without discarding the siblings.
-- Remove defaults that only encode Python `None`; a nullable type must remain represented by its type schema rather than by an unsupported default.
+- Remove every `default` keyword from strict schemas while preserving Python invocation defaults outside the provider-facing schema. Strip `default: null` before expanding `$ref` siblings so recursive references stay finite, then remove remaining defaults after reference normalization.
 - `ensure_strict_json_schema()` may mutate a non-empty input dictionary. Copy caller-owned schemas at public boundaries before conversion. Empty-schema conversion must return a fresh object rather than shared mutable state.
 - Keep strictness explicit. If a tool or output schema opts out of strict mode, preserve that choice through provider conversion instead of partially applying strict normalization.
 

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -359,6 +359,11 @@ def _ensure_strict_json_schema(
                 for i, entry in enumerate(all_of)
             ]
 
+    # Strip null defaults before `$ref` expansion. A recursive `$ref` with only a null default
+    # sibling must remain a bare reference instead of being inlined into itself indefinitely.
+    if "default" in json_schema and json_schema["default"] is None:
+        json_schema.pop("default")
+
     # we can't use `$ref`s if there are also other properties defined, e.g.
     # `{"$ref": "...", "description": "my description"}`
     #
@@ -391,9 +396,8 @@ def _ensure_strict_json_schema(
             inside_nested_resource=inside_nested_resource,
         )
 
-    # Strict-mode schemas must not include defaults because they are rejected by the Structured
-    # Outputs API. Keep this after `$ref` expansion so an allowed default sibling does not prevent
-    # the existing reference normalization from running.
+    # Strip remaining non-null defaults after `$ref` expansion so they cannot suppress the existing
+    # reference normalization and do not reach the Structured Outputs API.
     json_schema.pop("default", None)
 
     if budget.reject_open_objects and "$ref" in json_schema:

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import copy
 from typing import Any, TypeGuard, cast
 
-from openai import NOT_GIVEN
-
 from .exceptions import UserError
 
 _EMPTY_SCHEMA = {
@@ -361,12 +359,6 @@ def _ensure_strict_json_schema(
                 for i, entry in enumerate(all_of)
             ]
 
-    # strip `None` defaults as there's no meaningful distinction here
-    # the schema will still be `nullable` and the model will default
-    # to using `None` anyway
-    if json_schema.get("default", NOT_GIVEN) is None:
-        json_schema.pop("default")
-
     # we can't use `$ref`s if there are also other properties defined, e.g.
     # `{"$ref": "...", "description": "my description"}`
     #
@@ -398,6 +390,11 @@ def _ensure_strict_json_schema(
             depth=next_depth,
             inside_nested_resource=inside_nested_resource,
         )
+
+    # Strict schemas require every property, so defaults are not used by the model and are
+    # rejected by the Structured Outputs API. Keep this after `$ref` expansion so an allowed
+    # default sibling does not prevent the existing reference normalization from running.
+    json_schema.pop("default", None)
 
     if budget.reject_open_objects and "$ref" in json_schema:
         raise UserError(_UNVALIDATED_REF_ERROR)

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -391,9 +391,9 @@ def _ensure_strict_json_schema(
             inside_nested_resource=inside_nested_resource,
         )
 
-    # Strict schemas require every property, so defaults are not used by the model and are
-    # rejected by the Structured Outputs API. Keep this after `$ref` expansion so an allowed
-    # default sibling does not prevent the existing reference normalization from running.
+    # Strict-mode schemas must not include defaults because they are rejected by the Structured
+    # Outputs API. Keep this after `$ref` expansion so an allowed default sibling does not prevent
+    # the existing reference normalization from running.
     json_schema.pop("default", None)
 
     if budget.reject_open_objects and "$ref" in json_schema:

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -539,7 +539,7 @@ def test_function_with_field_optional_with_default():
     optional_schema = properties.get("optional_param", {})
     assert optional_schema.get("type") == "number"
     assert optional_schema.get("minimum") == 0.0  # ge=0.0
-    assert optional_schema.get("default") == 5.0
+    assert "default" not in optional_schema
 
     # Valid input with default
     valid_input = {"required_param": "test"}
@@ -713,13 +713,13 @@ def test_function_with_field_multiple_constraints():
     assert name_schema.get("type") == "string"
     assert name_schema.get("minLength") == 1
     assert name_schema.get("maxLength") == 50
-    assert name_schema.get("default") == "Unknown"
+    assert "default" not in name_schema
 
     # Check factor field
     factor_schema = properties.get("factor", {})
     assert factor_schema.get("type") == "number"
     assert factor_schema.get("exclusiveMinimum") == 0.0
-    assert factor_schema.get("default") == 1.0
+    assert "default" not in factor_schema
     assert factor_schema.get("description") == "Positive multiplier"
 
     # Valid input with defaults
@@ -799,7 +799,7 @@ def test_function_with_annotated_field_optional_with_default():
     optional_schema = properties.get("optional_param", {})
     assert optional_schema.get("type") == "number"
     assert optional_schema.get("minimum") == 0.0  # ge=0.0
-    assert optional_schema.get("default") == 5.0
+    assert "default" not in optional_schema
 
     # Valid input with default
     valid_input = {"required_param": "test"}
@@ -892,13 +892,13 @@ def test_function_with_annotated_field_multiple_constraints():
     assert name_schema.get("type") == "string"
     assert name_schema.get("minLength") == 1
     assert name_schema.get("maxLength") == 50
-    assert name_schema.get("default") == "Unknown"
+    assert "default" not in name_schema
 
     # Check factor field
     factor_schema = properties.get("factor", {})
     assert factor_schema.get("type") == "number"
     assert factor_schema.get("exclusiveMinimum") == 0.0
-    assert factor_schema.get("default") == 1.0
+    assert "default" not in factor_schema
     assert factor_schema.get("description") == "Positive multiplier"
 
     # Valid input with defaults

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -303,6 +303,39 @@ def test_non_decorator_function_tools_have_no_wrapped_callable() -> None:
         assert inspect.unwrap(cast(Callable[..., Any], non_decorator_tool)) is non_decorator_tool
 
 
+def test_strict_function_tool_preserves_recursive_ref_with_null_default() -> None:
+    async def manual_invoker(ctx: ToolContext[Any], input_json: str) -> str:
+        return input_json
+
+    recursive_schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "child": {"$ref": "#/$defs/Node", "default": None},
+                },
+            }
+        },
+        "type": "object",
+        "properties": {
+            "root": {"$ref": "#/$defs/Node", "default": None},
+        },
+    }
+
+    tool = FunctionTool(
+        name="recursive",
+        description="",
+        params_json_schema=recursive_schema,
+        on_invoke_tool=manual_invoker,
+    )
+
+    node_schema = tool.params_json_schema["$defs"]["Node"]
+    assert node_schema["additionalProperties"] is False
+    assert node_schema["required"] == ["child"]
+    assert node_schema["properties"]["child"] == {"$ref": "#/$defs/Node"}
+    assert tool.params_json_schema["properties"]["root"] == {"$ref": "#/$defs/Node"}
+
+
 def test_replacing_invoker_removes_wrapped_callable() -> None:
     def original(value: int) -> int:
         return value

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -360,6 +360,8 @@ async def test_all_optional_params_function():
     assert tool.strict_json_schema is False, "strict_json_schema should be False"
 
     assert tool.params_json_schema.get("required") is None, "required should be empty"
+    assert tool.params_json_schema["properties"]["x"]["default"] == 42
+    assert tool.params_json_schema["properties"]["y"]["default"] == "hello"
 
     input_data: dict[str, Any] = {}
     output = await tool.on_invoke_tool(ctx_wrapper(), json.dumps(input_data))
@@ -372,6 +374,22 @@ async def test_all_optional_params_function():
     input_data = {"x": 10, "y": "world", "z": 99}
     output = await tool.on_invoke_tool(ctx_wrapper(), json.dumps(input_data))
     assert output == "10_world_99"
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_strips_non_null_defaults_but_keeps_python_defaults():
+    def function_with_defaults(value: int = 42, label: str = "default") -> str:
+        return f"{value}_{label}"
+
+    tool = function_tool(function_with_defaults)
+
+    assert tool.strict_json_schema is True
+    assert tool.params_json_schema["required"] == ["value", "label"]
+    assert "default" not in tool.params_json_schema["properties"]["value"]
+    assert "default" not in tool.params_json_schema["properties"]["label"]
+
+    output = await tool.on_invoke_tool(ctx_wrapper(), "{}")
+    assert output == "42_default"
 
 
 @function_tool

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -701,12 +701,19 @@ def test_allOf_single_entry_cannot_overwrite_strict_object(additional_properties
         ensure_strict_json_schema(schema)
 
 
-@pytest.mark.parametrize("default", [None, 0, "EUR", False])
-def test_default_removal_on_non_object(default):
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"type": "null", "default": None},
+        {"type": "integer", "default": 0},
+        {"type": "string", "default": "EUR"},
+        {"type": "boolean", "default": False},
+    ],
+)
+def test_default_removal_on_non_object(schema):
     # Test that defaults are stripped from schemas that are not objects.
-    schema = {"type": "string", "default": default}
     result = ensure_strict_json_schema(schema)
-    assert result["type"] == "string"
+    assert result["type"] == schema["type"]
     assert "default" not in result
 
 

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -701,9 +701,10 @@ def test_allOf_single_entry_cannot_overwrite_strict_object(additional_properties
         ensure_strict_json_schema(schema)
 
 
-def test_default_removal_on_non_object():
-    # Test that "default": None is stripped from schemas that are not objects.
-    schema = {"type": "string", "default": None}
+@pytest.mark.parametrize("default", [None, 0, "EUR", False])
+def test_default_removal_on_non_object(default):
+    # Test that defaults are stripped from schemas that are not objects.
+    schema = {"type": "string", "default": default}
     result = ensure_strict_json_schema(schema)
     assert result["type"] == "string"
     assert "default" not in result
@@ -722,6 +723,27 @@ def test_ref_expansion():
     # the description from the original takes precedence, and default is removed.
     assert a_schema["type"] == "string"
     assert a_schema["description"] == "desc"
+    assert "default" not in a_schema
+
+
+def test_ref_with_non_null_default_is_expanded_before_default_removal():
+    schema = {
+        "$defs": {
+            "refObj": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            }
+        },
+        "type": "object",
+        "properties": {"a": {"$ref": "#/$defs/refObj", "default": {}}},
+    }
+
+    result = ensure_strict_json_schema(schema, _reject_open_objects=True)
+    a_schema = result["properties"]["a"]
+
+    assert a_schema["type"] == "object"
+    assert a_schema["additionalProperties"] is False
+    assert a_schema["required"] == ["value"]
     assert "default" not in a_schema
 
 


### PR DESCRIPTION
### Summary

- Remove every `default` keyword from strict JSON Schema conversion, including non-null Pydantic defaults rejected by Structured Outputs.
- Preserve existing `$ref` sibling expansion and keep non-strict schema defaults unchanged.

### Test plan

- `make format` — passed.
- `make lint` — passed.
- `uv run mypy src` — passed (`Success: no issues found in 307 source files`).
- `uv run pyright --project pyrightconfig.json --threads 4` — passed (`0 errors`).
- Focused schema and tool tests — passed (`174 passed, 2 skipped`).
- Filtered non-serial suite excluding Windows symlink and local-encoding cases — passed (`7250 passed, 44 skipped`).
- Serial test runner — passed.
- The unfiltered suite could not complete on this Windows host because symlink tests require `SeCreateSymbolicLinkPrivilege` and two example tests use UTF-8 files through the host GBK locale; these failures are unrelated to the changed files.

### Issue number

Closes #4390

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR