### PR TITLE
fix(core): honor End of File hunks when the file ends in a newline

### DIFF
--- a/src/agents/apply_diff.py
+++ b/src/agents/apply_diff.py
@@ -333,13 +333,24 @@ class ContextMatch:
 
 def _find_context(lines: list[str], context: list[str], start: int, eof: bool) -> ContextMatch:
     if eof:
-        end_start = max(0, len(lines) - len(context))
-        end_match = _find_context_core(lines, context, end_start)
+        # `str.split("\n")` keeps a trailing empty element for text that ends in a
+        # newline. Treat that as the file terminator, not as a line, so EOF hunks
+        # append after the last real line instead of after a phantom blank.
+        search_lines = _eof_search_lines(lines)
+        end_start = max(0, len(search_lines) - len(context))
+        end_match = _find_context_core(search_lines, context, end_start)
         if end_match.new_index != -1:
             return end_match
-        fallback = _find_context_core(lines, context, start)
+        fallback_start = min(start, len(search_lines))
+        fallback = _find_context_core(search_lines, context, fallback_start)
         return ContextMatch(new_index=fallback.new_index, fuzz=fallback.fuzz + 10000)
     return _find_context_core(lines, context, start)
+
+
+def _eof_search_lines(lines: list[str]) -> list[str]:
+    if lines and lines[-1] == "":
+        return lines[:-1]
+    return lines
 
 
 def _find_context_core(lines: list[str], context: list[str], start: int) -> ContextMatch:

--- a/tests/test_apply_diff.py
+++ b/tests/test_apply_diff.py
@@ -264,3 +264,21 @@ def test_apply_diff_with_crlf_input_and_crlf_diff_preserves_crlf() -> None:
 def test_apply_diff_create_mode_preserves_crlf_newlines() -> None:
     diff = "\r\n".join(["+hello", "+world", "+"])
     assert apply_diff("", diff, mode="create") == "hello\r\nworld\r\n"
+
+
+def test_apply_diff_eof_hunk_appends_without_a_blank_line() -> None:
+    # Files that end in a newline must not grow a phantom blank line at EOF.
+    assert apply_diff("a\nb\n", "@@\n+c\n*** End of File") == "a\nb\nc\n"
+    assert apply_diff("a\nb", "@@\n+c\n*** End of File") == "a\nb\nc"
+
+
+def test_apply_diff_eof_hunk_matches_the_last_context_occurrence() -> None:
+    original = "x\nfoo\ny\nfoo\n"
+    diff = " foo\n+added\n*** End of File"
+    assert apply_diff(original, diff) == "x\nfoo\ny\nfoo\nadded\n"
+
+
+def test_apply_diff_eof_hunk_preserves_crlf() -> None:
+    original = "a\r\nb\r\n"
+    diff = "@@\n+c\n*** End of File"
+    assert apply_diff(original, diff) == "a\r\nb\r\nc\r\n"

--- a/tests/test_apply_diff_helpers.py
+++ b/tests/test_apply_diff_helpers.py
@@ -53,6 +53,16 @@ def test_find_context_eof_fallbacks() -> None:
     assert match.fuzz >= 10000
 
 
+def test_find_context_eof_ignores_trailing_empty_split_element() -> None:
+    match = _find_context(["a", "b", ""], [], start=0, eof=True)
+    assert match.new_index == 2
+    assert match.fuzz == 0
+
+    last_foo = _find_context(["x", "foo", "y", "foo", ""], ["foo"], start=0, eof=True)
+    assert last_foo.new_index == 3
+    assert last_foo.fuzz == 0
+
+
 def test_find_context_core_stripped_matches() -> None:
     match = _find_context_core([" line "], ["line"], start=0)
     assert match.new_index == 0


### PR DESCRIPTION
## Summary

`apply_diff` is how sandbox agents edit files. `*** End of File` hunks were silently wrong on almost every real source file because those files end in a newline.

`str.split("\n")` keeps a trailing empty element for newline-terminated text. EOF matching treated that phantom as a real line, so:

1. An append at EOF inserted a blank line and dropped the trailing newline (`"a\nb\n"` + `+c` became `"a\nb\n\nc"` instead of `"a\nb\nc\n"`).
2. Repeated context with an EOF marker matched the first occurrence, not the last.

The same locator is used by sandbox `apply_patch`, so this is not a helper-only issue. Agents could apply a plausible patch and leave the wrong code in the workspace with no error.

The locator now ignores that terminator when `eof=True`. Existing non-EOF and CRLF behavior is unchanged.

Fixes #4660

## Test plan

- [x] `python -m pytest tests/test_apply_diff.py tests/test_apply_diff_helpers.py`
  - 31 passed, including EOF append, last-occurrence context, CRLF, and helper coverage for the phantom split element
