### PR TITLE
fix(items): preserve empty approval params

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -648,13 +648,15 @@ class ToolApprovalItem(RunItemBase[Any]):
         if isinstance(self.raw_item, dict):
             candidate = self.raw_item.get("arguments")
             if candidate is None:
-                candidate = self.raw_item.get("params") or self.raw_item.get("input")
-        elif hasattr(self.raw_item, "arguments"):
-            candidate = self.raw_item.arguments
-        elif hasattr(self.raw_item, "params") or hasattr(self.raw_item, "input"):
-            candidate = getattr(self.raw_item, "params", None) or getattr(
-                self.raw_item, "input", None
-            )
+                candidate = self.raw_item.get("params")
+                if candidate is None:
+                    candidate = self.raw_item.get("input")
+        else:
+            candidate = getattr(self.raw_item, "arguments", None)
+            if candidate is None:
+                candidate = getattr(self.raw_item, "params", None)
+            if candidate is None:
+                candidate = getattr(self.raw_item, "input", None)
         if candidate is None:
             return None
         if isinstance(candidate, str):

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -10739,6 +10739,19 @@ class TestToolApprovalItem:
         approval_item4 = ToolApprovalItem(agent=agent, raw_item=raw_item4)
         assert approval_item4.arguments is None
 
+        # Empty params are present arguments and must not fall through to input.
+        approval_item5 = ToolApprovalItem(
+            agent=agent,
+            raw_item={"params": {}, "input": {"wrong": "value"}},
+        )
+        assert approval_item5.arguments == "{}"
+
+        approval_item6 = ToolApprovalItem(
+            agent=agent,
+            raw_item=SimpleNamespace(arguments=None, params={}, input={"wrong": "value"}),
+        )
+        assert approval_item6.arguments == "{}"
+
     def test_tool_approval_item_tracks_namespace(self):
         """Test that ToolApprovalItem keeps namespace metadata from Responses tool calls."""
         agent = Agent(name="TestAgent")


### PR DESCRIPTION
### Summary

This pull request fixes `ToolApprovalItem.arguments` treating empty `params` as absent and falling through to a different `input` payload. Explicit `None` checks now preserve present falsey argument values consistently for mapping-backed and attribute-backed provider items.

### Test plan

- Added mapping coverage for `params={}` alongside a different `input` value.
- Added attribute-backed coverage with `arguments=None` and empty `params`.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`; formatting, lint, type checking, and the full test suite passed.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
