### PR TITLE
fix(voice): redact STT prompts from traces

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -177,7 +177,11 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                     if self._trace_include_sensitive_data
                     else None
                 ),
-                "prompt": transcription_config.get("prompt"),
+                "prompt": (
+                    transcription_config.get("prompt")
+                    if self._trace_include_sensitive_data
+                    else None
+                ),
                 "turn_detection": self._turn_detection,
             },
         )
@@ -553,7 +557,11 @@ class OpenAISTTModel(STTModel):
             model_config={
                 "temperature": self._non_null_or_not_given(settings.temperature),
                 "language": self._non_null_or_not_given(settings.language),
-                "prompt": self._non_null_or_not_given(settings.prompt),
+                "prompt": (
+                    self._non_null_or_not_given(settings.prompt)
+                    if trace_include_sensitive_data
+                    else None
+                ),
             },
         ) as span:
             try:

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -5,6 +5,7 @@ import base64
 import json
 import logging
 from collections.abc import AsyncGenerator
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -395,6 +396,33 @@ async def test_transcribe_error_respects_sensitive_data_setting(
             )
 
     assert fetch_span_errors("transcription") == [{"message": expected_error, "data": {}}]
+
+
+@pytest.mark.asyncio
+async def test_transcribe_redacts_prompt_without_changing_request() -> None:
+    client = AsyncMock()
+    client.audio.transcriptions.create.return_value = SimpleNamespace(text="transcript")
+    model = OpenAISTTModel(model="whisper-1", openai_client=client)
+    span = MagicMock()
+    span_context = MagicMock()
+    span_context.__enter__.return_value = span
+
+    with patch(
+        "agents.voice.models.openai_stt.transcription_span",
+        return_value=span_context,
+    ) as create_span:
+        result = await model.transcribe(
+            AudioInput(buffer=np.zeros(2, dtype=np.int16)),
+            STTModelSettings(prompt="customer account vocabulary"),
+            trace_include_sensitive_data=False,
+            trace_include_sensitive_audio_data=False,
+        )
+
+    assert result == "transcript"
+    assert create_span.call_args.kwargs["model_config"]["prompt"] is None
+    assert client.audio.transcriptions.create.await_args.kwargs["prompt"] == (
+        "customer account vocabulary"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/voice/test_openai_stt_session_config.py
+++ b/tests/voice/test_openai_stt_session_config.py
@@ -189,13 +189,14 @@ async def test_streaming_stt_trace_records_transcription_options_with_sensitive_
 
 
 @pytest.mark.asyncio
-async def test_streaming_stt_trace_redacts_keywords_without_sensitive_data() -> None:
+async def test_streaming_stt_trace_redacts_text_options_without_sensitive_data() -> None:
     sensitive_keywords = ["CUSTOMER_SECRET_NAME"]
+    sensitive_prompt = "customer account vocabulary"
     session = OpenAISTTTranscriptionSession(
         input=StreamedAudioInput(),
         client=AsyncMock(api_key="FAKE_KEY"),
         model="gpt-live-transcribe",
-        settings=STTModelSettings(keywords=sensitive_keywords),
+        settings=STTModelSettings(prompt=sensitive_prompt, keywords=sensitive_keywords),
         trace_include_sensitive_data=False,
         trace_include_sensitive_audio_data=False,
     )
@@ -213,6 +214,7 @@ async def test_streaming_stt_trace_redacts_keywords_without_sensitive_data() -> 
 
     model_config = create_span.call_args.kwargs["model_config"]
     assert model_config["keywords"] is None
+    assert model_config["prompt"] is None
     assert all(value is not sensitive_keywords for value in model_config.values())
     span.start.assert_called_once_with()
     span.finish.assert_called_once_with()


### PR DESCRIPTION
### Summary

This pull request fixes OpenAI STT prompts appearing in trace metadata when `trace_include_sensitive_data` is disabled. Both static and streamed transcription paths now redact the prompt from `model_config` while continuing to send the original prompt to the provider.

### Test plan

- Added static transcription coverage proving the provider receives the prompt while the trace does not.
- Extended streamed transcription coverage to verify prompt and keyword redaction together.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`; formatting, lint, type checking, and the full test suite passed.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
