### PR TITLE
docs: add SteadIO to external tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -232,3 +232,4 @@ The following community and vendor integrations support the tracing API surface 
 -   [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
 -   [DProvenanceKit](https://dprovenance.dev/openai-agents/)
 -   [Tuning Engines](https://github.com/cerebrixos-org/tuning-engines-cli/tree/main/packages/tuning-agents#openai-agents-sdk)
+-   [SteadIO](https://www.steadio.ai/docs/sdk-integrations)


### PR DESCRIPTION
Adds [SteadIO](https://www.steadio.ai/docs/sdk-integrations) to the external tracing processors list in `docs/tracing.md`.

SteadIO provides per-customer LLM cost visibility, hard spend caps, and usage rebilling. The `TracingProcessor` aggregates token usage across agent runs and reports cost and cap state per customer.

Setup docs: https://www.steadio.ai/docs/sdk-integrations