### PR TITLE
fix: keep demo loop responsive during input

### DIFF
--- a/src/agents/repl.py
+++ b/src/agents/repl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
@@ -37,7 +38,7 @@ async def run_demo_loop(
     input_items: list[TResponseInputItem] = []
     while True:
         try:
-            user_input = input(" > ")
+            user_input = await asyncio.to_thread(input, " > ")
         except (EOFError, KeyboardInterrupt):
             print()
             break

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,3 +1,6 @@
+import asyncio
+import threading
+
 import pytest
 
 from agents import Agent, run_demo_loop
@@ -98,3 +101,32 @@ async def test_run_demo_loop_skips_empty_input(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "hello" in output
     assert model.calls[-1].input == [get_text_input_item("Hi")]
+
+
+@pytest.mark.asyncio
+async def test_run_demo_loop_does_not_block_event_loop(monkeypatch, capsys):
+    model = ScriptedModel()
+    agent = Agent(name="test", model=model)
+    input_started = threading.Event()
+    release_input = threading.Event()
+    heartbeat_ran = asyncio.Event()
+
+    def blocking_input(_=" > ") -> str:
+        input_started.set()
+        release_input.wait()
+        return "quit"
+
+    async def heartbeat() -> None:
+        heartbeat_ran.set()
+        await asyncio.to_thread(release_input.wait)
+
+    monkeypatch.setattr("builtins.input", blocking_input)
+    loop_task = asyncio.create_task(run_demo_loop(agent, stream=False))
+    heartbeat_task = asyncio.create_task(heartbeat())
+    await asyncio.to_thread(input_started.wait)
+    await asyncio.wait_for(heartbeat_ran.wait(), timeout=1)
+    release_input.set()
+    await loop_task
+    await heartbeat_task
+
+    assert not model.calls


### PR DESCRIPTION
This pull request resolves #4670.

`run_demo_loop` currently calls the blocking builtin `input()` directly from its async loop, freezing background tasks and MCP stream activity while the user is typing. It now runs input collection in a worker thread while preserving the existing input, exit, EOF, and interrupt behavior.

The regression test runs the public `run_demo_loop` entry point with a deliberately blocked input function and verifies that a concurrent async task still runs before input is released.

Validation: focused REPL tests, Ruff, optional-truthiness check, mypy, pyright, formatting, and diff checks pass. The repository verification wrapper could not run on this Windows host because `make` is unavailable; its underlying commands were run directly.