### PR TITLE
fix(voice): redact TTS instructions from speech spans

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -124,7 +124,11 @@ class StreamedAudioResult:
             input=text if self._voice_pipeline_config.trace_include_sensitive_data else "",
             model_config={
                 "voice": self.tts_settings.voice,
-                "instructions": self.instructions,
+                "instructions": (
+                    self.instructions
+                    if self._voice_pipeline_config.trace_include_sensitive_data
+                    else None
+                ),
                 "speed": self.tts_settings.speed,
             },
             output_format="pcm",

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -15,7 +15,7 @@ import pytest
 
 import agents._debug as _debug
 from agents import trace
-from tests.testing_processor import fetch_events, fetch_span_errors
+from tests.testing_processor import fetch_events, fetch_ordered_spans, fetch_span_errors
 
 try:
     from agents.voice import (
@@ -585,6 +585,46 @@ async def test_streamed_audio_error_respects_sensitive_data_setting(
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trace_include_sensitive_data", [True, False])
+async def test_speech_span_redacts_tts_instructions(
+    trace_include_sensitive_data: bool,
+) -> None:
+    """TTS instructions are author-written prompt text, so they follow the same gate as input."""
+    instructions = "sensitive-style-instructions"
+    received: list[str] = []
+
+    class RecordingTTS(ZeroPcmTTSModel):
+        async def run(self, text: str, settings: TTSModelSettings) -> AsyncIterator[bytes]:
+            received.append(settings.instructions)
+            yield np.zeros(2, dtype=np.int16).tobytes()
+
+    result = StreamedAudioResult(
+        RecordingTTS(),
+        TTSModelSettings(instructions=instructions),
+        VoicePipelineConfig(trace_include_sensitive_data=trace_include_sensitive_data),
+    )
+    local_queue: asyncio.Queue[VoiceStreamEvent | None] = asyncio.Queue()
+
+    with trace("tts-instructions"):
+        await result._stream_audio("spoken text", local_queue)
+
+    speech_spans = [span for span in fetch_ordered_spans() if span.span_data.type == "speech"]
+    assert len(speech_spans) == 1
+    model_config = cast(dict[str, Any], speech_spans[0].span_data.model_config)
+
+    if trace_include_sensitive_data:
+        assert model_config["instructions"] == instructions
+        assert speech_spans[0].span_data.input == "spoken text"
+    else:
+        assert model_config["instructions"] is None
+        assert speech_spans[0].span_data.input == ""
+
+    # Non-sensitive settings stay visible either way, and the model still gets the real value.
+    assert model_config["speed"] == TTSModelSettings().speed
+    assert received == [instructions]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`speech_span` gates the text being spoken on `trace_include_sensitive_data`, but emits `model_config["instructions"]` unconditionally:

```python
input=text if self._voice_pipeline_config.trace_include_sensitive_data else "",
model_config={
    "voice": self.tts_settings.voice,
    "instructions": self.instructions,   # not gated
    "speed": self.tts_settings.speed,
},
```

`TTSModelSettings.instructions` is author-written prompt text, documented as the knob for controlling the tone of the audio output. That is the same category as the STT `prompt` and `keywords`, which #4663 gated a few hours ago. The transcription span now draws the line clearly: `keywords` and `prompt` follow the flag, while `temperature`, `language`, `languages` and `turn_detection` stay visible because they are settings rather than prompt text. `instructions` is prompt text sitting on the settings side of that line.

Reproduced on `main` with a real `VoicePipeline` and a recording trace processor. With `trace_include_sensitive_data=False`:

```
SpeechSpanData.input              ''                              suppressed, correct
SpeechGroupSpanData.input         ''                              suppressed, correct
SpeechSpanData.model_config       instructions='SECRET-STYLE-...' still exported
```

So a caller who explicitly turned sensitive data off still ships their instructions prompt to every trace backend. After the change that field is `None` and nothing else about the span moves.

This is not a provider-behavior change. `voice` and `speed` stay visible either way, and the TTS model still receives the real instructions; only the exported span is redacted.

### Test plan

`tests/voice/test_pipeline.py::test_speech_span_redacts_tts_instructions`, parametrized over both values of the flag. It asserts the full matrix rather than just the redacted case: with the flag on, `instructions` and `input` both carry their real values; with it off, both are cleared; `speed` is asserted unchanged in both to show the settings fields are untouched; and the recording TTS model asserts it received the real instructions either way, so the redaction is trace-only.

Verified it fails without the source change by resetting `src/` to `main` and rerunning: the `False` case fails, the `True` case passes, which is the expected split for a test that also pins existing behavior.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full suite.

### Issue number

None. Found while sibling-checking #4663.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

I went looking for this straight after #4663 landed, on the theory that a redaction fix usually has a sibling field somewhere that nobody checked. Happy to be told that instructions are considered configuration rather than user content here, in which case the fix is wrong and the docs are the thing worth changing instead. I'm a freshman in college and this is the part of the codebase I have spent the most time in, so I would rather ask than assume.
