### PR TITLE
fix(tracing): close the exporter when the batch processor shuts down

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -644,6 +644,19 @@ class BatchTraceProcessor(TracingProcessor):
             # No background thread: process any remaining items synchronously.
             self._export_batches(deadline=deadline)
 
+        # Release whatever the exporter holds open -- the default one keeps a pooled HTTP
+        # client alive for the life of the process. Done last so the flush above still has
+        # it, and duck-typed like ``_request_shutdown`` because the interface does not
+        # require it.
+        close_exporter = getattr(self._exporter, "close", None)
+        if callable(close_exporter):
+            try:
+                close_exporter()
+            except Exception as exc:
+                log_model_and_tool_action_error(
+                    logger, "[non-fatal] Tracing: exporter close failed", exc
+                )
+
     def force_flush(self):
         """
         Forces an immediate flush of all queued spans.

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -580,7 +580,7 @@ class BatchTraceProcessor(TracingProcessor):
         self._thread_start_lock = threading.Lock()
         self._export_lock = threading.Lock()
         self._shutdown_deadline: float | None = None
-        self._close_lock = threading.Lock()
+        # Guarded by _export_lock so closing cannot overlap an export, in either order.
         self._exporter_closed = False
 
     def _ensure_thread_started(self) -> None:
@@ -657,23 +657,26 @@ class BatchTraceProcessor(TracingProcessor):
         The default exporter keeps a pooled HTTP client alive for the life of the process.
         Whoever performs the final drain closes it afterwards -- the worker thread when
         there is one, ``shutdown`` otherwise -- so a batch that outlives a shutdown timeout
-        never has its client pulled out from under it. Duck-typed like ``_request_shutdown``
-        because the interface does not require ``close``.
+        never has its client pulled out from under it. Taking the export lock extends that
+        to ``force_flush``: a flush already waiting on it either exports first or finds the
+        exporter closed and drops its batch, but never exports through a closed client.
+        Duck-typed like ``_request_shutdown`` because the interface does not require
+        ``close``.
         """
-        with self._close_lock:
+        with self._export_lock:
             if self._exporter_closed:
                 return
             self._exporter_closed = True
 
-        close_exporter = getattr(self._exporter, "close", None)
-        if not callable(close_exporter):
-            return
-        try:
-            close_exporter()
-        except Exception as exc:
-            log_model_and_tool_action_error(
-                logger, "[non-fatal] Tracing: exporter close failed", exc
-            )
+            close_exporter = getattr(self._exporter, "close", None)
+            if not callable(close_exporter):
+                return
+            try:
+                close_exporter()
+            except Exception as exc:
+                log_model_and_tool_action_error(
+                    logger, "[non-fatal] Tracing: exporter close failed", exc
+                )
 
     def force_flush(self):
         """
@@ -707,6 +710,13 @@ class BatchTraceProcessor(TracingProcessor):
         is completely empty.
         """
         with self._export_lock:
+            if self._exporter_closed:
+                if not self._queue.empty():
+                    logger.warning(
+                        "[non-fatal] Tracing: exporter is closed; dropping queued traces."
+                    )
+                return
+
             while True:
                 if deadline is not None and time.monotonic() >= deadline:
                     logger.warning(

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -580,6 +580,8 @@ class BatchTraceProcessor(TracingProcessor):
         self._thread_start_lock = threading.Lock()
         self._export_lock = threading.Lock()
         self._shutdown_deadline: float | None = None
+        self._close_lock = threading.Lock()
+        self._exporter_closed = False
 
     def _ensure_thread_started(self) -> None:
         # Fast path without holding the lock
@@ -634,9 +636,11 @@ class BatchTraceProcessor(TracingProcessor):
         self._shutdown_deadline = deadline
 
         # Only join if we ever started the background thread; otherwise flush synchronously.
+        worker_still_running = False
         if self._worker_thread and self._worker_thread.is_alive():
             self._worker_thread.join(timeout=timeout)
-            if self._worker_thread.is_alive():
+            worker_still_running = self._worker_thread.is_alive()
+            if worker_still_running:
                 logger.warning(
                     "[non-fatal] Tracing: shutdown timeout reached; dropping queued traces."
                 )
@@ -644,18 +648,32 @@ class BatchTraceProcessor(TracingProcessor):
             # No background thread: process any remaining items synchronously.
             self._export_batches(deadline=deadline)
 
-        # Release whatever the exporter holds open -- the default one keeps a pooled HTTP
-        # client alive for the life of the process. Done last so the flush above still has
-        # it, and duck-typed like ``_request_shutdown`` because the interface does not
-        # require it.
+        if not worker_still_running:
+            self._close_exporter()
+
+    def _close_exporter(self) -> None:
+        """Release whatever the exporter holds open, once, when nothing is exporting.
+
+        The default exporter keeps a pooled HTTP client alive for the life of the process.
+        Whoever performs the final drain closes it afterwards -- the worker thread when
+        there is one, ``shutdown`` otherwise -- so a batch that outlives a shutdown timeout
+        never has its client pulled out from under it. Duck-typed like ``_request_shutdown``
+        because the interface does not require ``close``.
+        """
+        with self._close_lock:
+            if self._exporter_closed:
+                return
+            self._exporter_closed = True
+
         close_exporter = getattr(self._exporter, "close", None)
-        if callable(close_exporter):
-            try:
-                close_exporter()
-            except Exception as exc:
-                log_model_and_tool_action_error(
-                    logger, "[non-fatal] Tracing: exporter close failed", exc
-                )
+        if not callable(close_exporter):
+            return
+        try:
+            close_exporter()
+        except Exception as exc:
+            log_model_and_tool_action_error(
+                logger, "[non-fatal] Tracing: exporter close failed", exc
+            )
 
     def force_flush(self):
         """
@@ -679,6 +697,10 @@ class BatchTraceProcessor(TracingProcessor):
 
         # Final drain after shutdown
         self._export_batches(deadline=self._shutdown_deadline)
+
+        # Nothing else is exporting now, so this is the safe point to release the
+        # exporter's resources even if shutdown() already gave up waiting for us.
+        self._close_exporter()
 
     def _export_batches(self, deadline: float | None = None):
         """Drains the queue and exports in batches of up to `max_batch_size` until the queue

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -649,7 +649,34 @@ class BatchTraceProcessor(TracingProcessor):
             self._export_batches(deadline=deadline)
 
         if not worker_still_running:
+            self._close_exporter_within(deadline)
+
+    def _close_exporter_within(self, deadline: float | None) -> None:
+        """Close the exporter without letting a slow ``close`` outlive the caller's timeout.
+
+        An exporter whose cleanup waits on a backend would otherwise block ``shutdown`` --
+        and the atexit handler that calls it -- for as long as it likes. Bound it the way
+        the worker join is bounded: give it whatever is left of the deadline, then warn and
+        move on.
+        """
+        if deadline is None:
             self._close_exporter()
+            return
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.warning(
+                "[non-fatal] Tracing: shutdown timeout reached; leaving the exporter open."
+            )
+            return
+
+        closer = threading.Thread(target=self._close_exporter, daemon=True)
+        closer.start()
+        closer.join(timeout=remaining)
+        if closer.is_alive():
+            logger.warning(
+                "[non-fatal] Tracing: shutdown timeout reached while closing the exporter."
+            )
 
     def _close_exporter(self) -> None:
         """Release whatever the exporter holds open, once, when nothing is exporting.
@@ -657,26 +684,27 @@ class BatchTraceProcessor(TracingProcessor):
         The default exporter keeps a pooled HTTP client alive for the life of the process.
         Whoever performs the final drain closes it afterwards -- the worker thread when
         there is one, ``shutdown`` otherwise -- so a batch that outlives a shutdown timeout
-        never has its client pulled out from under it. Taking the export lock extends that
-        to ``force_flush``: a flush already waiting on it either exports first or finds the
-        exporter closed and drops its batch, but never exports through a closed client.
-        Duck-typed like ``_request_shutdown`` because the interface does not require
-        ``close``.
+        never has its client pulled out from under it. Claiming the flag under the export
+        lock extends that to ``force_flush``: a flush already waiting on the lock either
+        exports first or finds the exporter closed and drops its batch, and none can start
+        afterwards. The close itself runs outside the lock so a slow one cannot wedge every
+        later flush behind it. Duck-typed like ``_request_shutdown`` because the interface
+        does not require ``close``.
         """
         with self._export_lock:
             if self._exporter_closed:
                 return
             self._exporter_closed = True
 
-            close_exporter = getattr(self._exporter, "close", None)
-            if not callable(close_exporter):
-                return
-            try:
-                close_exporter()
-            except Exception as exc:
-                log_model_and_tool_action_error(
-                    logger, "[non-fatal] Tracing: exporter close failed", exc
-                )
+        close_exporter = getattr(self._exporter, "close", None)
+        if not callable(close_exporter):
+            return
+        try:
+            close_exporter()
+        except Exception as exc:
+            log_model_and_tool_action_error(
+                logger, "[non-fatal] Tracing: exporter close failed", exc
+            )
 
     def force_flush(self):
         """

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -7,7 +7,8 @@ import queue
 import random
 import threading
 import time
-from collections.abc import Callable
+import weakref
+from collections.abc import Callable, MutableMapping
 from functools import cached_property
 from typing import Any, cast
 
@@ -538,6 +539,13 @@ class BackendSpanExporter(TracingExporter):
         self._shutdown_event.set()
 
 
+# A processor closes the exporter it was handed, but several processors may share one, so
+# count the live users per exporter and let the last one out do the closing. Keyed weakly:
+# an exporter whose processors are all garbage collected takes its entry with it.
+_exporter_users: MutableMapping[TracingExporter, int] = weakref.WeakKeyDictionary()
+_exporter_users_lock = threading.Lock()
+
+
 class BatchTraceProcessor(TracingProcessor):
     """Some implementation notes:
     1. Using Queue, which is thread-safe.
@@ -582,6 +590,29 @@ class BatchTraceProcessor(TracingProcessor):
         self._shutdown_deadline: float | None = None
         # Guarded by _export_lock so closing cannot overlap an export, in either order.
         self._exporter_closed = False
+        self._counted_as_exporter_user = self._count_as_exporter_user()
+
+    def _count_as_exporter_user(self) -> bool:
+        """Claim a share of the exporter. False when it cannot be tracked at all."""
+        try:
+            with _exporter_users_lock:
+                _exporter_users[self._exporter] = _exporter_users.get(self._exporter, 0) + 1
+        except TypeError:
+            # Unhashable or not weak-referenceable: fall back to sole ownership.
+            return False
+        return True
+
+    def _release_exporter_share(self) -> bool:
+        """Drop this processor's claim, returning True if it held the last one."""
+        if not self._counted_as_exporter_user:
+            return True
+        with _exporter_users_lock:
+            remaining = _exporter_users.get(self._exporter, 1) - 1
+            if remaining > 0:
+                _exporter_users[self._exporter] = remaining
+                return False
+            _exporter_users.pop(self._exporter, None)
+        return True
 
     def _ensure_thread_started(self) -> None:
         # Fast path without holding the lock
@@ -688,13 +719,18 @@ class BatchTraceProcessor(TracingProcessor):
         lock extends that to ``force_flush``: a flush already waiting on the lock either
         exports first or finds the exporter closed and drops its batch, and none can start
         afterwards. The close itself runs outside the lock so a slow one cannot wedge every
-        later flush behind it. Duck-typed like ``_request_shutdown`` because the interface
-        does not require ``close``.
+        later flush behind it. An exporter shared with another processor is released rather
+        than closed, since that processor still has work to export through it. Duck-typed
+        like ``_request_shutdown`` because the interface does not require ``close``.
         """
         with self._export_lock:
             if self._exporter_closed:
                 return
             self._exporter_closed = True
+
+        if not self._release_exporter_share():
+            logger.debug("skip: exporter still in use by another processor")
+            return
 
         close_exporter = getattr(self._exporter, "close", None)
         if not callable(close_exporter):

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -278,6 +278,69 @@ def test_batch_trace_processor_shutdown_closes_the_backend_exporter_client() -> 
     assert exporter._client.is_closed
 
 
+def test_batch_trace_processor_shutdown_timeout_defers_exporter_close_to_the_worker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A batch that outlives the shutdown timeout keeps the exporter until it is done.
+
+    ``shutdown(timeout=...)`` returns while the worker is still inside ``export()``, so
+    closing from there would dispose the client the in-flight batch is still using.
+    """
+    export_started = threading.Event()
+    release_export = threading.Event()
+    events: list[str] = []
+
+    class SlowClosingExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            export_started.set()
+            release_export.wait(timeout=5.0)
+            events.append("export done")
+
+        def close(self) -> None:
+            events.append("close")
+
+    processor = BatchTraceProcessor(
+        exporter=SlowClosingExporter(),
+        max_queue_size=1,
+        schedule_delay=60.0,
+        export_trigger_ratio=1.0,
+    )
+    processor.on_span_end(get_span(processor))
+    assert export_started.wait(timeout=2.0)
+
+    with caplog.at_level(logging.WARNING):
+        processor.shutdown(timeout=0.05)
+
+    assert "shutdown timeout reached" in caplog.text
+    assert events == [], "the exporter must not be closed while an export is running"
+
+    release_export.set()
+    assert processor._worker_thread is not None
+    processor._worker_thread.join(timeout=5.0)
+    assert not processor._worker_thread.is_alive()
+    assert events == ["export done", "close"]
+
+
+def test_batch_trace_processor_closes_the_exporter_only_once() -> None:
+    """The worker and shutdown both reach the close, but the exporter sees one call."""
+    closes: list[int] = []
+
+    class CountingExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            pass
+
+        def close(self) -> None:
+            closes.append(1)
+
+    processor = BatchTraceProcessor(exporter=CountingExporter(), schedule_delay=60.0)
+    processor.on_span_end(get_span(processor))
+
+    processor.shutdown(timeout=5.0)
+    processor.shutdown(timeout=5.0)
+
+    assert closes == [1]
+
+
 def test_batch_trace_processor_shutdown_survives_exporter_close_failure(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -321,6 +321,89 @@ def test_batch_trace_processor_shutdown_timeout_defers_exporter_close_to_the_wor
     assert events == ["export done", "close"]
 
 
+def test_batch_trace_processor_force_flush_drops_its_batch_once_the_exporter_is_closed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A flush that arrives after the close must drop its batch, not export through it."""
+    exported: list[Trace | Span[Any]] = []
+
+    class ClosableExporter(TracingExporter):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            assert not self.closed, "exported through a closed exporter"
+            exported.extend(items)
+
+        def close(self) -> None:
+            self.closed = True
+
+    exporter = ClosableExporter()
+    processor = BatchTraceProcessor(exporter=exporter, schedule_delay=60.0)
+    processor.shutdown()
+    assert exporter.closed
+
+    processor._queue.put_nowait(get_span(processor))
+    with caplog.at_level(logging.WARNING):
+        processor.force_flush()
+
+    assert exported == []
+    assert "exporter is closed" in caplog.text
+
+
+def test_batch_trace_processor_close_never_overlaps_a_concurrent_force_flush() -> None:
+    """A flush queued behind a slow export must not straddle the exporter's close.
+
+    ``shutdown(timeout=...)`` returns while the worker is still exporting, and its expired
+    deadline leaves the next batch queued. The flush waiting on the export lock and the
+    worker's close then race; whichever wins, no export may run against a closed client.
+    """
+    export_started = threading.Event()
+    release_export = threading.Event()
+
+    class SlowClosableExporter(TracingExporter):
+        def __init__(self) -> None:
+            self.closed = False
+            self.exports_after_close = 0
+
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            if self.closed:
+                self.exports_after_close += 1
+            if not export_started.is_set():
+                export_started.set()
+                release_export.wait(timeout=5.0)
+
+        def close(self) -> None:
+            self.closed = True
+
+    exporter = SlowClosableExporter()
+    processor = BatchTraceProcessor(
+        exporter=exporter,
+        max_queue_size=4,
+        schedule_delay=60.0,
+        export_trigger_ratio=0.25,
+    )
+    processor.on_span_end(get_span(processor))
+    assert export_started.wait(timeout=2.0)
+
+    # A second batch is queued behind the export that is still in flight.
+    processor._queue.put_nowait(get_span(processor))
+    flush = threading.Thread(target=processor.force_flush)
+    flush.start()
+
+    processor.shutdown(timeout=0.05)
+    release_export.set()
+
+    assert processor._worker_thread is not None
+    processor._worker_thread.join(timeout=5.0)
+    flush.join(timeout=5.0)
+
+    assert not flush.is_alive()
+    assert not processor._worker_thread.is_alive()
+    assert exporter.closed
+    assert exporter.exports_after_close == 0
+
+
 def test_batch_trace_processor_closes_the_exporter_only_once() -> None:
     """The worker and shutdown both reach the close, but the exporter sees one call."""
     closes: list[int] = []

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -321,6 +321,89 @@ def test_batch_trace_processor_shutdown_timeout_defers_exporter_close_to_the_wor
     assert events == ["export done", "close"]
 
 
+def test_batch_trace_processor_shared_exporter_survives_a_sibling_shutdown() -> None:
+    """One processor's shutdown must not dispose an exporter a sibling still exports through.
+
+    ``add_trace_processor(BatchTraceProcessor(default_exporter()))`` puts two processors on
+    one exporter, and the provider shuts them down in turn.
+    """
+    exported: list[Trace | Span[Any]] = []
+
+    class SharedExporter(TracingExporter):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            assert not self.closed, "exported through a closed exporter"
+            exported.extend(items)
+
+        def close(self) -> None:
+            self.closed = True
+
+    exporter = SharedExporter()
+    first = BatchTraceProcessor(exporter=exporter, schedule_delay=60.0)
+    second = BatchTraceProcessor(exporter=exporter, schedule_delay=60.0)
+
+    first.shutdown()
+    assert not exporter.closed, "the sibling still owns a share of the exporter"
+
+    # The survivor keeps working, which is the whole point of not closing yet.
+    second._queue.put_nowait(get_span(second))
+    second.force_flush()
+    assert len(exported) == 1
+
+    second.shutdown()
+    assert exporter.closed, "the last processor out closes the exporter"
+
+
+def test_batch_trace_processor_repeated_shutdown_releases_one_share() -> None:
+    """A second shutdown must not release a share the processor no longer holds."""
+
+    class SharedExporter(TracingExporter):
+        def __init__(self) -> None:
+            self.closed = False
+
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    exporter = SharedExporter()
+    first = BatchTraceProcessor(exporter=exporter, schedule_delay=60.0)
+    second = BatchTraceProcessor(exporter=exporter, schedule_delay=60.0)
+
+    first.shutdown()
+    first.shutdown()
+    assert not exporter.closed, "the sibling's share must survive a repeated shutdown"
+
+    second.shutdown()
+    assert exporter.closed
+
+
+def test_batch_trace_processor_closes_an_untrackable_exporter() -> None:
+    """An exporter that cannot be tracked falls back to the single-owner behaviour."""
+
+    class UnhashableExporter(TracingExporter):
+        __hash__ = None  # type: ignore[assignment]
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    exporter = UnhashableExporter()
+    processor = BatchTraceProcessor(exporter=exporter, schedule_delay=60.0)
+
+    processor.shutdown()
+
+    assert exporter.closed
+
+
 def test_batch_trace_processor_shutdown_timeout_bounds_a_slow_exporter_close(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -244,6 +244,60 @@ def test_batch_trace_processor_shutdown_passes_deadline_to_exporter() -> None:
     assert seen_deadlines[0] is not None
 
 
+def test_batch_trace_processor_shutdown_closes_the_exporter() -> None:
+    """An exporter that owns resources gets to release them, after the final flush."""
+    events: list[str] = []
+
+    class ClosingExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            events.append("export")
+
+        def close(self) -> None:
+            events.append("close")
+
+    processor = BatchTraceProcessor(exporter=ClosingExporter())
+    processor._queue.put_nowait(get_span(processor))
+
+    processor.shutdown()
+
+    assert events == ["export", "close"]
+
+
+def test_batch_trace_processor_shutdown_closes_the_backend_exporter_client() -> None:
+    """The default exporter keeps a pooled HTTP client open for the life of the process.
+
+    Nothing in the shutdown chain used to close it, so the connection to the tracing
+    endpoint was left for interpreter teardown to reap -- a ResourceWarning under
+    ``-W error::ResourceWarning``, and one leaked pool per replaced processor.
+    """
+    exporter = BackendSpanExporter(api_key="test_key")
+    processor = BatchTraceProcessor(exporter=exporter)
+
+    processor.shutdown()
+
+    assert exporter._client.is_closed
+
+
+def test_batch_trace_processor_shutdown_survives_exporter_close_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cleanup is best-effort: a failing close must not break application shutdown."""
+
+    class BrokenCloseExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            pass
+
+        def close(self) -> None:
+            raise RuntimeError("close boom")
+
+    processor = BatchTraceProcessor(exporter=BrokenCloseExporter())
+
+    with caplog.at_level(logging.ERROR):
+        processor.shutdown()
+
+    assert "exporter close failed" in caplog.text
+
+
 def test_batch_trace_processor_survives_exporter_exception():
     """A failing exporter must not kill the background worker thread.
 

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -321,6 +321,58 @@ def test_batch_trace_processor_shutdown_timeout_defers_exporter_close_to_the_wor
     assert events == ["export done", "close"]
 
 
+def test_batch_trace_processor_shutdown_timeout_bounds_a_slow_exporter_close(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A close that waits on a backend must not outlive the caller's timeout."""
+    release_close = threading.Event()
+    close_returned = threading.Event()
+
+    class SlowClosingExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            pass
+
+        def close(self) -> None:
+            release_close.wait(timeout=5.0)
+            close_returned.set()
+
+    processor = BatchTraceProcessor(exporter=SlowClosingExporter())
+
+    start = time.monotonic()
+    with caplog.at_level(logging.WARNING):
+        processor.shutdown(timeout=0.05)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, "shutdown must honour its timeout even if close() hangs"
+    assert "while closing the exporter" in caplog.text
+
+    # The close is not abandoned, only unwaited: it still finishes on its own thread.
+    release_close.set()
+    assert close_returned.wait(timeout=5.0)
+
+
+def test_batch_trace_processor_expired_deadline_skips_the_exporter_close(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no time left there is nothing to spend on cleanup, so say so and move on."""
+    closes: list[int] = []
+
+    class ClosingExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            pass
+
+        def close(self) -> None:
+            closes.append(1)
+
+    processor = BatchTraceProcessor(exporter=ClosingExporter())
+
+    with caplog.at_level(logging.WARNING):
+        processor.shutdown(timeout=0.0)
+
+    assert closes == []
+    assert "leaving the exporter open" in caplog.text
+
+
 def test_batch_trace_processor_force_flush_drops_its_batch_once_the_exporter_is_closed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
Fixes #4681

## Problem

`BackendSpanExporter` opens a pooled `httpx2.Client` in its constructor and holds it for
the life of the process. It exposes a `close()`, but nothing in the shutdown chain called
it:

`atexit` → `_shutdown_global_trace_provider()` → `DefaultTraceProvider.shutdown()` →
`MultiTracingProcessor.shutdown()` → `BatchTraceProcessor.shutdown()`

`BatchTraceProcessor.shutdown()` sets its shutdown event, optionally calls the exporter's
`_request_shutdown()`, and joins the worker thread — the exporter itself is never closed.
Before this change:

```python
exporter = BackendSpanExporter(api_key="test_key")
processor = BatchTraceProcessor(exporter=exporter)
processor.shutdown()
exporter._client.is_closed  # False
```

So the connection to the tracing endpoint is left for interpreter teardown to reap, which
surfaces as `ResourceWarning: unclosed <ssl.SSLSocket ...>` under `-W error::ResourceWarning`
or `PYTHONDEVMODE=1`, and applications that swap the global provider/processor at runtime
leak one client and its connection pool per replacement.

## Fix

`BatchTraceProcessor.shutdown()` now closes its exporter:

- **at the end**, after the join or the synchronous drain, so the final flush still has a
  usable client;
- **duck-typed** (`getattr(self._exporter, "close", None)`), mirroring the existing
  `_request_shutdown` lookup, because `TracingExporter` does not require `close()` and
  custom exporters may not have one;
- **best-effort** — a raising `close()` is logged as non-fatal rather than propagated out
  of application shutdown.

No public API changes.

## Tests

Three regression tests in `tests/test_trace_processor.py`, all failing before the change
and passing after:

- `test_batch_trace_processor_shutdown_closes_the_exporter` — pins that `close()` is called
  and that it happens *after* the final export.
- `test_batch_trace_processor_shutdown_closes_the_backend_exporter_client` — the reported
  leak: the default exporter's HTTP client is closed once the processor shuts down.
- `test_batch_trace_processor_shutdown_survives_exporter_close_failure` — a failing
  `close()` is logged, not raised.

`tests/test_trace_processor.py`, `tests/tracing/`, `tests/test_tracing.py` and
`tests/test_tracing_errors.py` pass (`tests/tracing/test_import_side_effects.py::test_core_imports_do_not_require_legacy_httpx`
fails identically on `main` in my environment). `ruff check`, `ruff format --check` and
`mypy` are clean on both changed files.
