### PR TITLE
fix(sessions): checkpoint a resumed handoff before the Session append

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1135,7 +1135,12 @@ class AgentRunner:
                                     generated_items=generated_items,
                                     session_items=session_items,
                                 )
-                                if isinstance(turn_result.next_step, NextStepInterruption):
+                                if isinstance(
+                                    turn_result.next_step,
+                                    NextStepInterruption | NextStepHandoff,
+                                ):
+                                    # Publish before the fallible append so a retry does not
+                                    # lose guardrail results for work that already ran.
                                     run_state._tool_input_guardrail_results = [
                                         *tool_input_guardrail_results,
                                         *turn_result.tool_input_guardrail_results,

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1405,6 +1405,15 @@ async def start_streaming(
                         break
 
                     if isinstance(turn_result.next_step, NextStepHandoff):
+                        if run_state is not None:
+                            # `_accumulate_tool_guardrail_results` already folded this turn's
+                            # results in; publish them before the fallible append.
+                            run_state._tool_input_guardrail_results = list(
+                                accepted_tool_input_guardrail_results
+                            )
+                            run_state._tool_output_guardrail_results = list(
+                                accepted_tool_output_guardrail_results
+                            )
                         await _save_resumed_items(
                             list(turn_session_items),
                             turn_result.model_response.response_id,
@@ -1421,7 +1430,6 @@ async def start_streaming(
                         streamed_result._event_queue.put_nowait(
                             AgentUpdatedStreamEvent(new_agent=current_agent)
                         )
-                        run_state._current_step = NextStepRunAgain()
                         if await _wait_for_streamed_turn_events_and_stop_if_cancelled(
                             streamed_result
                         ):

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -61,7 +61,13 @@ from .items import (
     strip_internal_input_item_metadata,
 )
 from .oai_conversation import OpenAIServerConversationTracker
-from .run_steps import NextStepInterruption, NextStepRunAgain, ProcessedResponse, SingleStepResult
+from .run_steps import (
+    NextStepHandoff,
+    NextStepInterruption,
+    NextStepRunAgain,
+    ProcessedResponse,
+    SingleStepResult,
+)
 
 __all__ = [
     "admit_pending_input",
@@ -541,7 +547,13 @@ def update_run_state_after_resume(
     run_state._generated_items = generated_items
     if session_items is not None:
         run_state._session_items = list(session_items)
-    run_state._current_step = turn_result.next_step  # type: ignore[assignment]
+    next_step = turn_result.next_step
+    if isinstance(next_step, NextStepHandoff):
+        # The target agent is already committed, so the rest of the turn is an ordinary
+        # "run again". Normalizing here, before the fallible Session append, lets the existing
+        # pending-write checkpoint carry the handoff batch without a new persisted step type.
+        next_step = NextStepRunAgain()
+    run_state._current_step = next_step  # type: ignore[assignment]
 
 
 async def save_result_to_session(

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -567,15 +567,6 @@ class BatchTraceProcessor(TracingProcessor):
             export_trigger_ratio: The ratio of the queue size at which we will trigger an export.
         """
         self._exporter = exporter
-        # A processor that shut down earlier may have asked this exporter to abandon retry
-        # backoff. That request is one-way, and `default_exporter()` hands the same instance
-        # to every processor, so clear it as this one attaches: otherwise the first transient
-        # failure exported here gives up without retrying, blaming a shutdown that is over.
-        # Duck-typed like the `_request_shutdown` call in `shutdown()`, since the exporter
-        # interface does not require either.
-        reset_exporter_shutdown = getattr(exporter, "_reset_shutdown", None)
-        if callable(reset_exporter_shutdown):
-            reset_exporter_shutdown()
         self._queue: queue.Queue[Trace | Span[Any]] = queue.Queue(maxsize=max_queue_size)
         self._max_queue_size = max_queue_size
         self._max_batch_size = max_batch_size
@@ -593,6 +584,7 @@ class BatchTraceProcessor(TracingProcessor):
         self._thread_start_lock = threading.Lock()
         self._export_lock = threading.Lock()
         self._shutdown_deadline: float | None = None
+        self._requested_exporter_shutdown = False
 
     def _ensure_thread_started(self) -> None:
         # Fast path without holding the lock
@@ -637,11 +629,15 @@ class BatchTraceProcessor(TracingProcessor):
         """
         Called when the application stops. We signal our thread to stop, then join it.
         """
-        self._shutdown_event.set()
         if timeout is not None:
             request_exporter_shutdown = getattr(self._exporter, "_request_shutdown", None)
             if callable(request_exporter_shutdown):
+                # Flagged before the request so the worker, which may exit as soon as the
+                # event below is set, always sees that the request is ours to release.
+                self._requested_exporter_shutdown = True
                 request_exporter_shutdown()
+
+        self._shutdown_event.set()
 
         deadline = None if timeout is None else time.monotonic() + timeout
         self._shutdown_deadline = deadline
@@ -653,9 +649,29 @@ class BatchTraceProcessor(TracingProcessor):
                 logger.warning(
                     "[non-fatal] Tracing: shutdown timeout reached; dropping queued traces."
                 )
+            # A worker that stopped released the request itself, at the end of `_run`. One
+            # that outlived this timeout still owns it and releases it when it does stop.
         else:
             # No background thread: process any remaining items synchronously.
             self._export_batches(deadline=deadline)
+            self._release_exporter_shutdown()
+
+    def _release_exporter_shutdown(self) -> None:
+        """Give a shutdown request we made back to the exporter, now that our worker is done.
+
+        The request is one-way and `default_exporter()` hands the same exporter to every
+        processor, so leaving it set makes the next processor give up on the first transient
+        failure instead of retrying -- blaming a shutdown that is long over. It is released
+        only by the processor that made it, and only once that processor's worker has
+        stopped: while the worker is still exporting it owns the cancellation and must keep
+        abandoning its retries, including when `shutdown` timed out and returned without it.
+        """
+        if not self._requested_exporter_shutdown:
+            return
+        self._requested_exporter_shutdown = False
+        reset_exporter_shutdown = getattr(self._exporter, "_reset_shutdown", None)
+        if callable(reset_exporter_shutdown):
+            reset_exporter_shutdown()
 
     def force_flush(self):
         """
@@ -679,6 +695,9 @@ class BatchTraceProcessor(TracingProcessor):
 
         # Final drain after shutdown
         self._export_batches(deadline=self._shutdown_deadline)
+
+        # This worker is done exporting, so it no longer needs the exporter cancelled.
+        self._release_exporter_shutdown()
 
     def _export_batches(self, deadline: float | None = None):
         """Drains the queue and exports in batches of up to `max_batch_size` until the queue

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -537,6 +537,10 @@ class BackendSpanExporter(TracingExporter):
     def _request_shutdown(self) -> None:
         self._shutdown_event.set()
 
+    def _reset_shutdown(self) -> None:
+        """Undo a previous shutdown request so this exporter can retry exports again."""
+        self._shutdown_event.clear()
+
 
 class BatchTraceProcessor(TracingProcessor):
     """Some implementation notes:
@@ -563,6 +567,15 @@ class BatchTraceProcessor(TracingProcessor):
             export_trigger_ratio: The ratio of the queue size at which we will trigger an export.
         """
         self._exporter = exporter
+        # A processor that shut down earlier may have asked this exporter to abandon retry
+        # backoff. That request is one-way, and `default_exporter()` hands the same instance
+        # to every processor, so clear it as this one attaches: otherwise the first transient
+        # failure exported here gives up without retrying, blaming a shutdown that is over.
+        # Duck-typed like the `_request_shutdown` call in `shutdown()`, since the exporter
+        # interface does not require either.
+        reset_exporter_shutdown = getattr(exporter, "_reset_shutdown", None)
+        if callable(reset_exporter_shutdown):
+            reset_exporter_shutdown()
         self._queue: queue.Queue[Trace | Span[Any]] = queue.Queue(maxsize=max_queue_size)
         self._max_queue_size = max_queue_size
         self._max_batch_size = max_batch_size

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -85,6 +85,8 @@ class BackendSpanExporter(TracingExporter):
         self.base_delay = base_delay
         self.max_delay = max_delay
         self._shutdown_event = threading.Event()
+        self._shutdown_lock = threading.Lock()
+        self._shutdown_requests = 0
 
         # Keep a client open for connection pooling across multiple export calls
         self._client = httpx2.Client(timeout=httpx2.Timeout(timeout=60, connect=5.0))
@@ -535,11 +537,24 @@ class BackendSpanExporter(TracingExporter):
         self._client.close()
 
     def _request_shutdown(self) -> None:
-        self._shutdown_event.set()
+        with self._shutdown_lock:
+            self._shutdown_requests += 1
+            self._shutdown_event.set()
 
     def _reset_shutdown(self) -> None:
-        """Undo a previous shutdown request so this exporter can retry exports again."""
-        self._shutdown_event.clear()
+        """Drop one shutdown request, restoring retries once the last one is released.
+
+        Processors share an exporter -- `default_exporter()` hands the same instance to
+        every one of them -- so more than one can have a shutdown in flight. Retries come
+        back only when every request has been released; clearing on the first release would
+        resurrect the retry backoff of a worker still exporting under a shutdown of its own.
+        """
+        with self._shutdown_lock:
+            if self._shutdown_requests == 0:
+                return
+            self._shutdown_requests -= 1
+            if self._shutdown_requests == 0:
+                self._shutdown_event.clear()
 
 
 class BatchTraceProcessor(TracingProcessor):
@@ -629,11 +644,12 @@ class BatchTraceProcessor(TracingProcessor):
         """
         Called when the application stops. We signal our thread to stop, then join it.
         """
-        if timeout is not None:
+        if timeout is not None and not self._requested_exporter_shutdown:
             request_exporter_shutdown = getattr(self._exporter, "_request_shutdown", None)
             if callable(request_exporter_shutdown):
                 # Flagged before the request so the worker, which may exit as soon as the
-                # event below is set, always sees that the request is ours to release.
+                # event below is set, always sees that the request is ours to release. Only
+                # ever requested once, so that our single release balances it.
                 self._requested_exporter_shutdown = True
                 request_exporter_shutdown()
 
@@ -659,12 +675,14 @@ class BatchTraceProcessor(TracingProcessor):
     def _release_exporter_shutdown(self) -> None:
         """Give a shutdown request we made back to the exporter, now that our worker is done.
 
-        The request is one-way and `default_exporter()` hands the same exporter to every
-        processor, so leaving it set makes the next processor give up on the first transient
-        failure instead of retrying -- blaming a shutdown that is long over. It is released
-        only by the processor that made it, and only once that processor's worker has
-        stopped: while the worker is still exporting it owns the cancellation and must keep
-        abandoning its retries, including when `shutdown` timed out and returned without it.
+        `default_exporter()` hands the same exporter to every processor, so leaving the
+        request outstanding makes the next processor give up on the first transient failure
+        instead of retrying -- blaming a shutdown that is long over. It is released only by
+        the processor that made it, and only once that processor's worker has stopped: while
+        the worker is still exporting it needs the cancellation to keep abandoning its
+        retries, including when `shutdown` timed out and returned without it. Other
+        processors' requests are counted separately by the exporter, so releasing ours never
+        takes the cancellation away from theirs.
         """
         if not self._requested_exporter_shutdown:
             return

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -600,6 +600,7 @@ class BatchTraceProcessor(TracingProcessor):
         self._export_lock = threading.Lock()
         self._shutdown_deadline: float | None = None
         self._requested_exporter_shutdown = False
+        self._exporter_shutdown_lock = threading.Lock()
 
     def _ensure_thread_started(self) -> None:
         # Fast path without holding the lock
@@ -644,14 +645,8 @@ class BatchTraceProcessor(TracingProcessor):
         """
         Called when the application stops. We signal our thread to stop, then join it.
         """
-        if timeout is not None and not self._requested_exporter_shutdown:
-            request_exporter_shutdown = getattr(self._exporter, "_request_shutdown", None)
-            if callable(request_exporter_shutdown):
-                # Flagged before the request so the worker, which may exit as soon as the
-                # event below is set, always sees that the request is ours to release. Only
-                # ever requested once, so that our single release balances it.
-                self._requested_exporter_shutdown = True
-                request_exporter_shutdown()
+        if timeout is not None:
+            self._request_exporter_shutdown()
 
         self._shutdown_event.set()
 
@@ -662,15 +657,37 @@ class BatchTraceProcessor(TracingProcessor):
         if self._worker_thread and self._worker_thread.is_alive():
             self._worker_thread.join(timeout=timeout)
             if self._worker_thread.is_alive():
+                # The worker outlived this shutdown, so it keeps the request until it stops.
                 logger.warning(
                     "[non-fatal] Tracing: shutdown timeout reached; dropping queued traces."
                 )
-            # A worker that stopped released the request itself, at the end of `_run`. One
-            # that outlived this timeout still owns it and releases it when it does stop.
+            else:
+                # The worker released the request as it exited, unless it had already
+                # exited when we made it -- in which case this is the only release.
+                self._release_exporter_shutdown()
         else:
             # No background thread: process any remaining items synchronously.
             self._export_batches(deadline=deadline)
             self._release_exporter_shutdown()
+
+    def _request_exporter_shutdown(self) -> None:
+        """Ask the exporter to abandon its retry backoff, at most once for this processor.
+
+        Under the lock so that concurrent `shutdown` calls make a single request between
+        them: the exporter counts requests, and this processor has exactly one release to
+        balance it with.
+        """
+        with self._exporter_shutdown_lock:
+            if self._requested_exporter_shutdown:
+                return
+            request_exporter_shutdown = getattr(self._exporter, "_request_shutdown", None)
+            if not callable(request_exporter_shutdown):
+                return
+            # Flagged before the request so a worker exiting concurrently either waits here
+            # and then releases what we asked for, or finds nothing to release yet and
+            # leaves it to the caller below, which releases once the worker has stopped.
+            self._requested_exporter_shutdown = True
+            request_exporter_shutdown()
 
     def _release_exporter_shutdown(self) -> None:
         """Give a shutdown request we made back to the exporter, now that our worker is done.
@@ -684,12 +701,13 @@ class BatchTraceProcessor(TracingProcessor):
         processors' requests are counted separately by the exporter, so releasing ours never
         takes the cancellation away from theirs.
         """
-        if not self._requested_exporter_shutdown:
-            return
-        self._requested_exporter_shutdown = False
-        reset_exporter_shutdown = getattr(self._exporter, "_reset_shutdown", None)
-        if callable(reset_exporter_shutdown):
-            reset_exporter_shutdown()
+        with self._exporter_shutdown_lock:
+            if not self._requested_exporter_shutdown:
+                return
+            self._requested_exporter_shutdown = False
+            reset_exporter_shutdown = getattr(self._exporter, "_reset_shutdown", None)
+            if callable(reset_exporter_shutdown):
+                reset_exporter_shutdown()
 
     def force_flush(self):
         """

--- a/tests/test_run_impl_resume_paths.py
+++ b/tests/test_run_impl_resume_paths.py
@@ -1049,3 +1049,73 @@ async def test_resolve_interrupted_turn_only_uses_name_fallback_for_legacy_appro
             isinstance(item, ToolCallOutputItem) and item.output == "one"
             for item in result.new_step_items
         )
+
+
+async def _approved_handoff_session_state(streamed: bool):
+    """Pause on an approval-gated call that shares its response with a handoff."""
+    effects: list[int] = []
+
+    @tool(needs_approval=True)
+    async def charge(amount: int) -> str:
+        effects.append(amount)
+        return "receipt-7"
+
+    model = ScriptedModel(
+        [
+            [
+                get_function_tool_call("charge", '{"amount":7}', call_id="charge-1"),
+                get_function_tool_call("transfer_to_delegate", "{}", call_id="handoff-1"),
+            ],
+            [get_text_message("done")],
+            [get_text_message("fresh")],
+        ]
+    )
+    delegate = Agent(name="delegate", model=model)
+    agent = Agent(name="triage", model=model, tools=[charge], handoffs=[delegate])
+    session = _FailingResumeSession()
+    paused = await _run_session_resume(agent, "charge 7 then hand off", session, streamed)
+    state = paused.to_state()
+    state.approve(state.get_interruptions()[0])
+    return agent, model, session, state, effects
+
+
+def _call_pair(items: list[TResponseInputItem], call_id: str) -> list[str]:
+    return [
+        str(item.get("type"))
+        for item in items
+        if isinstance(item, dict) and item.get("call_id") == call_id
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failing_streamed,retry_streamed", [(False, False), (False, True), (True, False), (True, True)]
+)
+@pytest.mark.parametrize("round_trip", [False, True], ids=["live", "json"])
+@pytest.mark.parametrize("failure", ["before", "after"], ids=["atomic-failure", "lost-ack"])
+async def test_resumed_handoff_session_append_is_recovered_before_next_model(
+    failing_streamed: bool, retry_streamed: bool, round_trip: bool, failure: str
+) -> None:
+    agent, model, session, state, effects = await _approved_handoff_session_state(failing_streamed)
+    session.failure = failure
+    with pytest.raises(RuntimeError) as error:
+        await _run_session_resume(agent, state, session, failing_streamed)
+    assert error.value is session.error
+    assert effects == [7]
+    assert len(model.calls) == 1
+    if round_trip:
+        state = await RunState.from_json(agent, state.to_json())
+    assert state._current_agent is not None and state._current_agent.name == "delegate"
+
+    result = await _run_session_resume(agent, state, session, retry_streamed)
+    assert result.final_output == "done"
+    assert result.last_agent.name == "delegate"
+    assert effects == [7]
+    assert len(model.calls) == 2
+    expected_pair = ["function_call", "function_call_output"]
+    stored = await session.get_items()
+    assert _call_pair(stored, "charge-1") == expected_pair
+    assert _call_pair(stored, "handoff-1") == expected_pair
+    assert _call_pair(result.to_input_list(), "charge-1") == expected_pair
+    assert _call_pair(result.to_input_list(), "handoff-1") == expected_pair
+    assert "pending_session_write" not in result.to_state().to_json()

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -612,6 +612,40 @@ def test_batch_trace_processor_shutdown_without_timeout_preserves_export_retries
     exporter.close()
 
 
+@patch("httpx2.Client")
+def test_new_processor_restores_exporter_retries_after_a_previous_shutdown(mock_client):
+    """A shutdown request must not disable retries for the exporter's next processor.
+
+    ``_request_shutdown`` is one-way and ``default_exporter()`` hands the same instance to
+    every processor, so a stale request turned the first transient failure of the next
+    processor into an immediate give-up -- warning about a shutdown that was long over.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 504
+    mock_client.return_value.post.return_value = mock_response
+
+    exporter = BackendSpanExporter(
+        api_key="test_key",
+        max_retries=3,
+        base_delay=0.01,
+        max_delay=0.02,
+    )
+
+    first = BatchTraceProcessor(exporter=exporter)
+    first.shutdown(timeout=1.0)
+    assert exporter._shutdown_event.is_set()
+
+    second = BatchTraceProcessor(exporter=exporter)
+    assert not exporter._shutdown_event.is_set()
+
+    second._queue.put_nowait(get_span(second))
+    second.force_flush()
+
+    assert mock_client.return_value.post.call_count == 3
+
+    exporter.close()
+
+
 @pytest.mark.serial
 @pytest.mark.review_optional
 def test_tracing_atexit_cleanup_timeout_preserves_process_exit_code_on_504() -> None:

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -614,7 +614,7 @@ def test_batch_trace_processor_shutdown_without_timeout_preserves_export_retries
 
 @patch("httpx2.Client")
 def test_new_processor_restores_exporter_retries_after_a_previous_shutdown(mock_client):
-    """A shutdown request must not disable retries for the exporter's next processor.
+    """A finished shutdown must not disable retries for the exporter's next processor.
 
     ``_request_shutdown`` is one-way and ``default_exporter()`` hands the same instance to
     every processor, so a stale request turned the first transient failure of the next
@@ -633,16 +633,77 @@ def test_new_processor_restores_exporter_retries_after_a_previous_shutdown(mock_
 
     first = BatchTraceProcessor(exporter=exporter)
     first.shutdown(timeout=1.0)
-    assert exporter._shutdown_event.is_set()
-
-    second = BatchTraceProcessor(exporter=exporter)
     assert not exporter._shutdown_event.is_set()
 
+    second = BatchTraceProcessor(exporter=exporter)
     second._queue.put_nowait(get_span(second))
     second.force_flush()
 
     assert mock_client.return_value.post.call_count == 3
 
+    exporter.close()
+
+
+@patch("httpx2.Client")
+def test_worker_that_outlives_shutdown_keeps_the_exporter_cancelled(mock_client):
+    """A worker abandoned by a timed-out shutdown owns the cancellation until it exits.
+
+    Releasing the request when the next processor attaches would hand it back while that
+    worker is still exporting, so it would sleep through its backoff and keep retrying after
+    the shutdown that was supposed to stop it had already returned.
+    """
+    post_called = threading.Event()
+    release_post = threading.Event()
+    mock_response = MagicMock()
+    mock_response.status_code = 504
+
+    def post(**kwargs: Any) -> Any:
+        post_called.set()
+        release_post.wait(timeout=5.0)
+        return mock_response
+
+    mock_client.return_value.post.side_effect = post
+
+    exporter = BackendSpanExporter(
+        api_key="test_key",
+        max_retries=100,
+        base_delay=10.0,
+        max_delay=10.0,
+    )
+    processor = BatchTraceProcessor(
+        exporter=exporter,
+        max_queue_size=1,
+        max_batch_size=1,
+        schedule_delay=60.0,
+        export_trigger_ratio=1.0,
+    )
+
+    processor.on_span_end(get_span(processor))
+    assert post_called.wait(timeout=2.0)
+
+    # The worker is stuck inside the request, so the join times out and shutdown returns
+    # with the worker still running and the exporter still cancelled.
+    processor.shutdown(timeout=0.05)
+    worker = processor._worker_thread
+    assert worker is not None and worker.is_alive()
+    assert exporter._shutdown_event.is_set()
+
+    # A replacement processor attaching must not take the cancellation away from it.
+    replacement = BatchTraceProcessor(exporter=exporter)
+    assert exporter._shutdown_event.is_set()
+
+    release_post.set()
+
+    # Still cancelled, so the abandoned worker abandons its backoff instead of sleeping
+    # through base_delay and retrying.
+    worker.join(timeout=2.0)
+    assert not worker.is_alive()
+    assert mock_client.return_value.post.call_count == 1
+
+    # And once it is gone it hands the exporter back, so the replacement can retry again.
+    assert not exporter._shutdown_event.is_set()
+
+    replacement.shutdown()
     exporter.close()
 
 

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -707,6 +707,66 @@ def test_worker_that_outlives_shutdown_keeps_the_exporter_cancelled(mock_client)
     exporter.close()
 
 
+@patch("httpx2.Client")
+def test_shared_exporter_stays_cancelled_until_every_shutdown_releases(mock_client):
+    """Two processors can share one exporter, so one release must not speak for both.
+
+    A provider shuts its processors down in turn: the first times out with its worker still
+    inside a request, the second exits cleanly. If that second release cleared the shared
+    cancellation, the first worker would find it gone when its request finally returns a 5xx
+    and retry, after its own shutdown had already returned.
+    """
+    post_called = threading.Event()
+    release_post = threading.Event()
+    mock_response = MagicMock()
+    mock_response.status_code = 504
+
+    def post(**kwargs: Any) -> Any:
+        post_called.set()
+        release_post.wait(timeout=5.0)
+        return mock_response
+
+    mock_client.return_value.post.side_effect = post
+
+    exporter = BackendSpanExporter(
+        api_key="test_key",
+        max_retries=100,
+        base_delay=10.0,
+        max_delay=10.0,
+    )
+    blocked = BatchTraceProcessor(
+        exporter=exporter,
+        max_queue_size=1,
+        max_batch_size=1,
+        schedule_delay=60.0,
+        export_trigger_ratio=1.0,
+    )
+    other = BatchTraceProcessor(exporter=exporter)
+
+    blocked.on_span_end(get_span(blocked))
+    assert post_called.wait(timeout=2.0)
+
+    blocked.shutdown(timeout=0.05)
+    blocked_worker = blocked._worker_thread
+    assert blocked_worker is not None and blocked_worker.is_alive()
+
+    # The second processor never started a worker, so its shutdown finishes and releases
+    # right away -- while the first processor's request is still outstanding.
+    other.shutdown(timeout=1.0)
+    assert exporter._shutdown_event.is_set()
+
+    release_post.set()
+
+    blocked_worker.join(timeout=2.0)
+    assert not blocked_worker.is_alive()
+    assert mock_client.return_value.post.call_count == 1
+
+    # Both requests released now, so the exporter is usable again.
+    assert not exporter._shutdown_event.is_set()
+
+    exporter.close()
+
+
 @pytest.mark.serial
 @pytest.mark.review_optional
 def test_tracing_atexit_cleanup_timeout_preserves_process_exit_code_on_504() -> None:

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import os
 import subprocess
@@ -762,6 +763,61 @@ def test_shared_exporter_stays_cancelled_until_every_shutdown_releases(mock_clie
     assert mock_client.return_value.post.call_count == 1
 
     # Both requests released now, so the exporter is usable again.
+    assert not exporter._shutdown_event.is_set()
+
+    exporter.close()
+
+
+@patch("httpx2.Client")
+def test_concurrent_shutdowns_leave_the_exporter_request_balanced(mock_client):
+    """`shutdown` is safe to call from several threads, so it must request only once.
+
+    The exporter counts outstanding requests and the worker releases one as it exits, so two
+    callers racing through the request path would leave a request outstanding forever -- and
+    every later processor giving up on its first transient failure instead of retrying.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_client.return_value.post.return_value = mock_response
+
+    class RendezvousExporter(BackendSpanExporter):
+        """Blocks inside the window between the request check and the request itself.
+
+        `shutdown` reaches the exporter by looking `_request_shutdown` up on it, which
+        happens after a processor has decided to make the request and before it has recorded
+        that it did. Holding two callers here is what an unsynchronized decision would let
+        happen; serialized, only one of them ever arrives and the rendezvous times out.
+        """
+
+        def __init__(self, arrived: threading.Barrier, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self._arrived = arrived
+
+        @property
+        def _request_shutdown(self):
+            with contextlib.suppress(threading.BrokenBarrierError):
+                self._arrived.wait(timeout=0.5)
+            return super()._request_shutdown
+
+    exporter = RendezvousExporter(threading.Barrier(2), api_key="test_key")
+    processor = BatchTraceProcessor(exporter=exporter, schedule_delay=60.0)
+
+    # Start the worker, so the single release on its way out has to balance every request.
+    processor.on_span_end(get_span(processor))
+    assert processor._worker_thread is not None
+    assert processor._worker_thread.is_alive()
+
+    threads = [
+        threading.Thread(target=processor.shutdown, kwargs={"timeout": 2.0}) for _ in range(2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5.0)
+        assert not thread.is_alive()
+
+    assert not processor._worker_thread.is_alive()
+    assert exporter._shutdown_requests == 0
     assert not exporter._shutdown_event.is_set()
 
     exporter.close()


### PR DESCRIPTION
Fixes #4685.

### Problem

When a resumed `RunState` resolves an approved local function tool and a queued handoff from the same model response, the handoff target is committed before the resumed turn is persisted. If the client-managed `Session.add_items()` call then fails, the error propagates but no `pending_session_write` is retained.

Retrying the same live or JSON-restored state correctly continues with the target agent and does not re-execute the tool or the handoff, but it never repairs the missing outputs either. The result is two durable conversation views that never converge:

- the `Session` holds the `charge` and handoff `function_call` items with neither output;
- `RunState` and `RunResult.to_input_list()` hold both complete call/output pairs.

### Cause

`update_run_state_after_resume()` stores the raw transition, so `_current_step` becomes `NextStepHandoff`. `save_resumed_turn_items()` only supplies `resumed_write_state` for `NextStepRunAgain` or `NextStepInterruption`, so the handoff append bypasses the pending-write checkpoint introduced in #4630 and extended in #4650. `NextStepHandoff` is also outside the `NextStepInterruption | NextStepRunAgain | None` type `RunState` declares and serializes, so the failed state carries no resumable step at all.

The same boundary drops the turn's tool input/output guardrail results: both runners publish them to `RunState` only for `NextStepInterruption`.

### Fix

Treat the handoff as committed once the target agent is recorded, then normalize the remaining resumable transition to the existing `NextStepRunAgain` checkpoint before the fallible append. The current `pending_session_write` mechanism then carries the exact function-tool and handoff output batch, and `resume_pending_session_write()` settles it on the next resume — before any further model call or local side effect. No new persisted step type and no `RunState` schema change.

At the same boundary, both runners now publish the completed tool guardrail results to `RunState` before the append can raise, so a retry reports them through the existing pre-model reconciliation instead of losing them.

The streaming loop already set `NextStepRunAgain` after its handoff append; that assignment is now redundant and removed, since the shared helper normalizes it before the append.

### Behavior

- The first Session exception still propagates unchanged.
- The approved tool side effect, its guardrails, its hooks, and the handoff callback each run exactly once.
- The target agent is committed once and stays current across live and JSON-restored recovery.
- Retry reconciles both the atomic-failure and the commit-then-raise outcome without duplicating either output.
- Session, `RunResult.to_input_list()`, the restored `RunState`, and the next model input each contain exactly one ordered call/output pair for `charge-1` and `handoff-1`.
- A missing, different, or changed Session still fails closed through the existing `resume_pending_session_write()` checks.

### Tests

`test_resumed_handoff_session_append_is_recovered_before_next_model` covers the full sync/stream, same-mode/cross-mode, live/JSON, fail-before-commit/commit-then-raise matrix (16 rows). It fails on `main` and passes here.
