### PR TITLE
fix(core): fix streamed response span losing response/input when consumer stops at completed event

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -710,6 +710,12 @@ class OpenAIResponsesModel(Model):
                                 # Record before yielding the terminal event because consumers may
                                 # close the generator immediately after receiving it.
                                 span_response.span_data.usage = model_usage_to_span_usage(usage)
+                            if tracing.include_data():
+                                # Same reason as usage: a consumer that stops at the terminal
+                                # event closes the generator and never reaches the post-loop
+                                # assignment, so record the model I/O before yielding.
+                                span_response.span_data.response = chunk.response
+                                span_response.span_data.input = input
                         elif chunk_type in {
                             "response.failed",
                             "response.incomplete",

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -753,6 +753,76 @@ async def test_stream_response_close_closes_inner_http_stream_with_async_close(m
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_stream_span_records_io_when_consumer_stops_at_completed(monkeypatch):
+    """A consumer that stops at `response.completed` closes the generator.
+
+    The SDK's own run loop does this (it wraps the model stream in `aclosing()` and
+    breaks once it sees the terminal event). Anything recorded only after the yield
+    loop therefore never runs for such a consumer, so the response and input must be
+    attached to the span before the terminal event is yielded, mirroring the existing
+    usage handling and the non-streamed `get_response` path.
+    """
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    class DummyHTTPStream:
+        def __init__(self, response):
+            self._response = response
+            self._yielded = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return ResponseCompletedEvent(
+                type="response.completed",
+                response=self._response,
+                sequence_number=0,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    response = get_response_obj(
+        [],
+        response_id="resp-stream-early-close",
+        usage=Usage(requests=1, input_tokens=10, output_tokens=4, total_tokens=14),
+    )
+    inner_stream = DummyHTTPStream(response)
+
+    async def fake_fetch_response(*args: Any, **kwargs: Any) -> DummyHTTPStream:
+        return inner_stream
+
+    monkeypatch.setattr(model, "_fetch_response", fake_fetch_response)
+
+    with trace(workflow_name="test"):
+        stream = model.stream_response(
+            system_instructions=None,
+            input="the user prompt",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.ENABLED,
+        )
+        stream_agen = cast(Any, stream)
+        async for event in stream_agen:
+            if event.type == "response.completed":
+                break  # stop consuming, as a caller watching for the terminal event would
+        await stream_agen.aclose()
+
+    response_spans = [span for span in fetch_ordered_spans() if span.span_data.type == "response"]
+    assert len(response_spans) == 1
+    assert response_spans[0].span_data.response is not None
+    assert response_spans[0].span_data.input is not None
+    assert response_spans[0].span_data.usage is not None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_stream_response_normal_exhaustion_closes_inner_http_stream(monkeypatch):
     client = DummyWSClient()
     model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]


### PR DESCRIPTION
### Summary

When streaming with `OpenAIResponsesModel`, the model response and input were attached to the `response_span` only **after** the yield loop finished (lines 769-771). A consumer that stops iterating at the terminal `response.completed` event closes the generator at the `yield`, so that post-loop assignment never runs. The span is then exported with `response` and `input` set to `None`, even when sensitive-data capture is enabled (`ModelTracing.ENABLED`).

The SDK's own run loop consumes the stream exactly this way — `run_single_turn_streamed` wraps the model stream in `aclosing(...)` and breaks once it sees `ResponseCompletedEvent` — so the **common streamed path** silently lost the model I/O on the span.

This is asymmetric with three places that already populate the span before yielding for exactly this reason:
- the non-streamed `get_response` path sets `response`/`input` inside the span (lines 612-614);
- the sibling Chat Completions adapter populates its generation span before yielding the terminal event;
- the failure path in this same method records the error before yielding (with a comment about the GeneratorExit hazard).

The `usage` field was already handled correctly before the yield; only `response`/`input` were deferred.

### Fix

Attach `response` and `input` to the span inside the `ResponseCompletedEvent` branch, gated on `tracing.include_data()`, before the terminal event is yielded — mirroring the existing `usage` assignment right above it. Redaction when data capture is disabled is unchanged.

### Test plan

Added `test_stream_span_records_io_when_consumer_stops_at_completed`, which mirrors the existing chatcompletions test `test_stream_span_is_recorded_for_a_consumer_that_stops_at_the_terminal_event`. It monkeypatches `_fetch_response` to emit a single `response.completed`, stops iterating at that event (as the run loop does), closes the generator, and asserts the `response` span carries non-None `response`, `input`, and `usage`.

- Without the fix: `response`/`input` are `None` (reproduced).
- With the fix: all three are populated.
- Also verified that with `ModelTracing.ENABLED_WITHOUT_DATA`, `response`/`input` remain `None` (redaction preserved).
- `pytest tests/models/test_openai_responses.py` — 156 passed
- `pytest tests/models/test_openai_chatcompletions_stream.py tests/test_provider_span_errors.py tests/tracing/ tests/test_agent_runner_streamed.py` — 389 passed, 7 skipped
- `ruff format --check` and `ruff check` clean on changed files.

No issue number; this is a self-contained observability correctness fix found while reading the span code.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` — could not run the bash script end-to-end on this Windows/Git-Bash host (it manages POSIX process groups via `setsid`/`kill -TERM -PID`); I ran its constituent steps directly (ruff format, ruff check, and the full relevant pytest suites above).
- [x] I've confirmed all verification steps pass