### PR TITLE
Voice: preserve emitted whitespace in the sentence splitter

### DIFF
--- a/src/agents/voice/utils.py
+++ b/src/agents/voice/utils.py
@@ -26,17 +26,21 @@ def get_sentence_based_splitter(
         Returns:
             A tuple of the text to process and the remaining text buffer.
         """
-        sentences = re.split(r"(?<=[.!?])\s+", text_buffer.strip())
-        if len(sentences) >= 1:
-            combined_sentences = " ".join(sentences[:-1])
+        # Capture the separators instead of discarding them, and split the raw buffer
+        # rather than a stripped copy: the whitespace the model emitted is what a TTS
+        # engine renders as a pause, so collapsing "\n\n" to a single space runs
+        # paragraphs together in the audio.
+        parts = re.split(r"((?<=[.!?])\s+)", text_buffer)
+        # parts alternates sentence, separator, ..., sentence, so the last entry is the
+        # incomplete sentence and at least three entries mean a sentence has completed.
+        if len(parts) >= 3:
+            combined_sentences = "".join(parts[:-2])
             if len(combined_sentences) >= min_sentence_length:
-                # Carry any trailing whitespace over to the remainder. It separates the text
+                # Any trailing whitespace stays on the remainder. It separates the text
                 # held back from the next streamed delta, and stripping it concatenates the
                 # next word onto the last one, so "He " followed by "arrived" is spoken as
                 # "Hearrived".
-                trailing_whitespace = text_buffer[len(text_buffer.rstrip()) :]
-                remaining_text_buffer = sentences[-1] + trailing_whitespace
-                return combined_sentences, remaining_text_buffer
+                return combined_sentences, parts[-1]
         return "", text_buffer
 
     return sentence_based_text_splitter

--- a/tests/voice/test_utils.py
+++ b/tests/voice/test_utils.py
@@ -69,3 +69,50 @@ def test_split_without_trailing_whitespace_is_unchanged() -> None:
         "This sentence is long enough to flush.",
         "He",
     )
+
+
+@pytest.mark.parametrize(
+    "text,spoken,remaining",
+    [
+        (
+            "Line one is long enough.\nLine two here.\nrest",
+            "Line one is long enough.\nLine two here.",
+            "rest",
+        ),
+        (
+            "First point.\n\nSecond point is long. tail",
+            "First point.\n\nSecond point is long.",
+            "tail",
+        ),
+        (
+            "   Leading spaces here are kept? Yes indeed. tail",
+            "   Leading spaces here are kept? Yes indeed.",
+            "tail",
+        ),
+        (
+            "Hello world this is one.  Double space kept?  tail",
+            "Hello world this is one.  Double space kept?",
+            "tail",
+        ),
+    ],
+    ids=["newline", "paragraph_break", "leading_whitespace", "double_space"],
+)
+def test_split_preserves_the_whitespace_the_model_emitted(
+    text: str, spoken: str, remaining: str
+) -> None:
+    """Separators are what a TTS engine renders as a pause, so they must survive.
+
+    Splitting a stripped buffer on a non-capturing pattern normalized every
+    inter-sentence whitespace run to a single space and dropped leading whitespace.
+    """
+    split = get_sentence_based_splitter(20)
+
+    assert split(text) == (spoken, remaining)
+
+
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 5, 7, 11, 15])
+def test_streamed_paragraph_breaks_survive_any_delta_boundary(chunk_size: int) -> None:
+    """Short sentences accumulate into one chunk, so their breaks must be kept."""
+    text = "First point.\n\nSecond point.\n\nThird point is the last one here."
+
+    assert any("\n\n" in chunk for chunk in _stream(text, chunk_size))


### PR DESCRIPTION
Fixes #4687.

### Problem

`get_sentence_based_splitter` — the default `TTSModelSettings.text_splitter`, applied to every streamed chunk in `StreamedAudioResult` — split a *stripped* buffer on a *non-capturing* pattern:

```python
sentences = re.split(r"(?<=[.!?])\s+", text_buffer.strip())
combined_sentences = " ".join(sentences[:-1])
```

`re.split` discards the matched separator, so every inter-sentence whitespace run — `\n`, `\n\n`, multiple spaces — was normalized to a single space before the text reached the TTS model, and `.strip()` dropped the buffer's leading whitespace.

The symptom only exists in the audio: an agent that formats spoken output as list items or paragraphs loses the pause the engine renders for a line or paragraph break, so the speech runs together.

The function already guarded the *trailing* side of this class of bug (the `"He "` + `"arrived"` → `"Hearrived"` comment); the leading and inter-sentence sides were missed.

### Fix

Capture the separators and split the raw buffer, then rebuild the flushed text from the alternating parts, as suggested in the issue:

```python
parts = re.split(r"((?<=[.!?])\s+)", text_buffer)
if len(parts) >= 3:
    combined_sentences = "".join(parts[:-2])
```

`parts` alternates sentence, separator, …, sentence, so the last entry is the incomplete sentence and three or more entries mean a sentence has completed — which replaces the old `len(sentences) >= 1` check that was always true.

The trailing whitespace handling is now implicit rather than reconstructed: `parts[-1]` is the incomplete sentence with whatever whitespace followed it, so the remainder still ends with the separator that keeps the next delta from being glued onto the last word.

All four cases from the issue now round-trip:

| buffer | before | after |
|---|---|---|
| `"Line one is long enough.\nLine two here.\nrest"` | `'Line one is long enough. Line two here.'` | `'Line one is long enough.\nLine two here.'` |
| `"First point.\n\nSecond point is long. tail"` | `'First point. Second point is long.'` | `'First point.\n\nSecond point is long.'` |
| `"   Leading spaces here are kept? Yes indeed. tail"` | `'Leading spaces here are kept? Yes indeed.'` | `'   Leading spaces here are kept? Yes indeed.'` |
| `"Hello world this is one.  Double space kept?  tail"` | `'Hello world this is one. Double space kept?'` | `'Hello world this is one.  Double space kept?'` |

### Scope

The separator that falls exactly on a flush boundary is still not carried over, as before: the text on either side of it becomes a separate TTS utterance, so there is nothing for the engine to render it into. What this restores is every separator *inside* a flushed chunk — which is the case that matters, since short sentences (bullets, list items) accumulate until they clear `min_sentence_length` and are spoken together.

### Tests

- `test_split_preserves_the_whitespace_the_model_emitted` — the four cases above.
- `test_streamed_paragraph_breaks_survive_any_delta_boundary` — feeds short sentences through the splitter one delta at a time, parametrized over delta sizes, and asserts a `\n\n` reaches a spoken chunk regardless of where the model's deltas happen to break.

Both fail on `main`. The existing splitter tests are unchanged and still pass.
