### PR TITLE
fix(core): strictify schemas inside tuple prefixItems

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -273,6 +273,23 @@ def _ensure_strict_json_schema(
             inside_nested_resource=inside_nested_resource,
         )
 
+    # tuples: { 'type': 'array', 'prefixItems': [{...}, ...] }
+    # pydantic emits prefixItems for fixed-length tuple type hints. Each element
+    # is an independent subschema that must be strictified just like array items.
+    prefix_items = json_schema.get("prefixItems")
+    if is_list(prefix_items):
+        json_schema["prefixItems"] = [
+            _ensure_strict_json_schema(
+                entry,
+                path=(*path, "prefixItems", str(i)),
+                root=root,
+                budget=budget,
+                depth=next_depth,
+                inside_nested_resource=inside_nested_resource,
+            )
+            for i, entry in enumerate(prefix_items)
+        ]
+
     # unions
     any_of = json_schema.get("anyOf")
     if is_list(any_of):

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -990,3 +990,47 @@ def test_ref_with_anchor_is_still_expanded():
         "$anchor": "value",
         "type": "string",
     }
+
+
+def test_prefix_items_entries_are_strictified():
+    # pydantic emits prefixItems for fixed-length tuple type hints. Each element
+    # is an independent subschema that must be strictified just like array items.
+    schema = {
+        "type": "object",
+        "properties": {
+            "point": {
+                "type": "array",
+                "prefixItems": [
+                    {"type": "object", "properties": {"x": {"type": "integer"}}},
+                    {"type": "string"},
+                ],
+            }
+        },
+    }
+
+    result = ensure_strict_json_schema(copy.deepcopy(schema))
+
+    object_entry = result["properties"]["point"]["prefixItems"][0]
+    assert object_entry["additionalProperties"] is False
+    assert object_entry["required"] == ["x"]
+
+
+def test_open_object_inside_prefix_items_is_rejected_like_top_level():
+    # A dict[str, int] at the top level is rejected because additionalProperties
+    # is a schema rather than false. The same schema hidden inside a tuple
+    # element must be rejected identically.
+    schema = {
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "array",
+                "prefixItems": [
+                    {"type": "object", "additionalProperties": {"type": "integer"}},
+                    {"type": "string"},
+                ],
+            }
+        },
+    }
+
+    with pytest.raises(UserError, match="additionalProperties should not be set"):
+        ensure_strict_json_schema(schema)


### PR DESCRIPTION
### Summary

`ensure_strict_json_schema` recursed into `items`, `anyOf`, `oneOf`, `allOf`, `properties`, and `$defs`, but it never visited `prefixItems`. pydantic emits `prefixItems` for fixed-length tuple type hints, so a non-strict subschema hidden inside a tuple element was passed through unchanged.

Concretely, a `dict[str, int]` parameter is rejected at the top level because its `additionalProperties` is a schema rather than `false`:

```
additionalProperties should not be set for object types. This could be because you're using an older version of Pydantic
```

But the same type wrapped in a tuple — `def f(data: tuple[dict[str, int], str])` — silently produced:

```json
"prefixItems": [
  { "type": "object", "additionalProperties": { "type": "integer" } },
  { "type": "string" }
]
```

That schema is not valid for OpenAI Structured Outputs, so the tool/structured-output call is rejected by the API at request time.

### Fix

Recurse into each `prefixItems` entry exactly like array `items`, so tuple elements are strictified consistently. `$defs` are still strictified at the root, variable-length tuples (`tuple[int, ...]`) already use `items` and were already handled, and primitive/model tuples remain valid.

### Test plan

Added two tests to `tests/test_strict_schema.py`:
- `test_prefix_items_entries_are_strictified` — an object entry inside `prefixItems` gets `additionalProperties: false` and a `required` list.
- `test_open_object_inside_prefix_items_is_rejected_like_top_level` — an `additionalProperties` schema inside a tuple element raises the same `UserError` as the top-level case.

Verified directly with `function_schema`:
- `tuple[dict[str, int], str]` now raises the same `UserError` (before: silently non-strict).
- `tuple[Coord, str]`, `tuple[str, int, bool]`, `tuple[Pt, Pt]`, and `tuple[int, ...]` all produce valid strict schemas.

- `pytest tests/test_strict_schema.py tests/test_function_schema.py tests/test_function_tool.py` — 172 passed
- `pytest tests/models/test_openai_responses.py tests/models/test_openai_chatcompletions.py tests/models/test_openai_chatcompletions_stream.py` — 317 passed
- `ruff format --check` and `ruff check` clean on changed files.

No issue number; self-contained strict-schema correctness fix.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` — could not run the bash script end-to-end on this Windows/Git-Bash host (POSIX process-group management via `setsid`/`kill -PID`); I ran its constituent steps directly (ruff format, ruff check, and the relevant pytest suites above).
- [x] I've confirmed all verification steps pass