### PR TITLE
Tracing: wait on an event instead of polling in the batch worker

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -568,6 +568,9 @@ class BatchTraceProcessor(TracingProcessor):
         self._max_batch_size = max_batch_size
         self._schedule_delay = schedule_delay
         self._shutdown_event = threading.Event()
+        # Set when the worker has something to do before its next scheduled export: the queue
+        # reached the trigger size, or we are shutting down.
+        self._wake_event = threading.Event()
 
         # The queue size threshold at which we export immediately.
         self._export_trigger_size = max(1, int(max_queue_size * export_trigger_ratio))
@@ -602,6 +605,8 @@ class BatchTraceProcessor(TracingProcessor):
             self._queue.put_nowait(trace)
         except queue.Full:
             logger.warning("Queue is full, dropping trace.")
+            return
+        self._wake_worker_if_queue_is_full_enough()
 
     def on_trace_end(self, trace: Trace) -> None:
         # We send traces via on_trace_start, so we don't need to do anything here.
@@ -619,12 +624,20 @@ class BatchTraceProcessor(TracingProcessor):
             self._queue.put_nowait(span)
         except queue.Full:
             logger.warning("Queue is full, dropping span.")
+            return
+        self._wake_worker_if_queue_is_full_enough()
+
+    def _wake_worker_if_queue_is_full_enough(self) -> None:
+        """Wake the worker early when the queue reaches the export trigger size."""
+        if self._queue.qsize() >= self._export_trigger_size:
+            self._wake_event.set()
 
     def shutdown(self, timeout: float | None = None):
         """
         Called when the application stops. We signal our thread to stop, then join it.
         """
         self._shutdown_event.set()
+        self._wake_event.set()
         if timeout is not None:
             request_exporter_shutdown = getattr(self._exporter, "_request_shutdown", None)
             if callable(request_exporter_shutdown):
@@ -660,9 +673,14 @@ class BatchTraceProcessor(TracingProcessor):
                 self._export_batches()
                 # Reset the next scheduled flush time
                 self._next_export_time = time.monotonic() + self._schedule_delay
-            else:
-                # Sleep a short interval so we don't busy-wait.
-                time.sleep(0.2)
+                continue
+
+            # Block until the next scheduled flush rather than polling. Producers set the
+            # event once the queue reaches the trigger size and shutdown() sets it to break
+            # out immediately, so an idle process wakes once per schedule_delay instead of
+            # five times a second.
+            self._wake_event.wait(max(0.0, self._next_export_time - time.monotonic()))
+            self._wake_event.clear()
 
         # Final drain after shutdown
         self._export_batches(deadline=self._shutdown_deadline)

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -282,6 +282,52 @@ def test_batch_trace_processor_survives_exporter_exception():
     assert exporter.call_count >= 3
 
 
+def test_batch_trace_processor_queue_trigger_wakes_the_idle_worker() -> None:
+    """The worker parks until its next scheduled export, so producers have to wake it."""
+    exported = threading.Event()
+
+    class SignalingExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            exported.set()
+
+    processor = BatchTraceProcessor(
+        exporter=SignalingExporter(),
+        max_queue_size=4,
+        schedule_delay=60.0,
+        export_trigger_ratio=0.5,
+    )
+
+    processor.on_span_end(get_span(processor))
+    # One span is below the two-item trigger, so the worker has no reason to wake yet.
+    assert not exported.wait(timeout=0.2)
+
+    processor.on_span_end(get_span(processor))
+    assert exported.wait(timeout=2.0), "reaching the trigger size must wake the worker"
+
+    processor.shutdown(timeout=2.0)
+
+
+def test_batch_trace_processor_shutdown_wakes_the_idle_worker() -> None:
+    """shutdown() must not wait out the schedule delay before the final drain."""
+    exported: list[Trace | Span[Any]] = []
+
+    class RecordingExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            exported.extend(items)
+
+    processor = BatchTraceProcessor(exporter=RecordingExporter(), schedule_delay=60.0)
+    processor.on_span_end(get_span(processor))
+
+    start = time.monotonic()
+    processor.shutdown(timeout=2.0)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0
+    assert processor._worker_thread is not None
+    assert not processor._worker_thread.is_alive()
+    assert len(exported) == 1
+
+
 @pytest.mark.parametrize(
     ("adjusted_wall_time", "adjusted_monotonic_time", "expected_scheduled_exports"),
     [
@@ -300,7 +346,6 @@ def test_batch_trace_processor_schedule_uses_monotonic_clock(
         def __init__(self) -> None:
             self.wall_time = 1000.0
             self.monotonic_time = 100.0
-            self.sleep_calls = 0
 
         def time(self) -> float:
             return self.wall_time
@@ -309,12 +354,25 @@ def test_batch_trace_processor_schedule_uses_monotonic_clock(
             return self.monotonic_time
 
         def sleep(self, _seconds: float) -> None:
-            self.sleep_calls += 1
-            if self.sleep_calls == 1:
-                self.wall_time = adjusted_wall_time
-                self.monotonic_time = adjusted_monotonic_time
+            raise AssertionError("the worker must wait on its event, not poll with sleep")
+
+    class ControlledWakeEvent:
+        """Stands in for the worker's wake event and drives the loop from its waits."""
+
+        def __init__(self) -> None:
+            self.wait_calls = 0
+
+        def wait(self, _timeout: float | None = None) -> bool:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                controlled_time.wall_time = adjusted_wall_time
+                controlled_time.monotonic_time = adjusted_monotonic_time
             else:
                 processor._shutdown_event.set()
+            return False
+
+        def clear(self) -> None:
+            pass
 
     controlled_time = ControlledTime()
     monkeypatch.setattr("agents.tracing.processors.time", controlled_time)
@@ -324,6 +382,7 @@ def test_batch_trace_processor_schedule_uses_monotonic_clock(
         schedule_delay=1.0,
         export_trigger_ratio=1.0,
     )
+    monkeypatch.setattr(processor, "_wake_event", ControlledWakeEvent())
     processor._queue.put_nowait(get_span(processor))
     scheduled_export = object()
     export_deadlines: list[float | None | object] = []


### PR DESCRIPTION
Fixes #4688.

### Problem

`BatchTraceProcessor`'s export thread polled in a fixed 200 ms loop:

```python
if current_time >= self._next_export_time or queue_size >= self._export_trigger_size:
    self._export_batches()
    self._next_export_time = time.monotonic() + self._schedule_delay
else:
    # Sleep a short interval so we don't busy-wait.
    time.sleep(0.2)
```

The thread starts lazily on the first trace/span and never stops, so for the rest of the process lifetime it woke five times a second and did nothing. With the default `schedule_delay = 5.0`, 24 of every 25 wakeups were pure overhead — constant background CPU in profiles of an idle agent service, and timer wakeups on battery-powered hosts.

`time.sleep()` is also not interruptible by the shutdown event, so `shutdown()` waited out the rest of the interval before the final drain even with an empty queue.

### Fix

The worker now blocks until it actually has something to do. It waits on a `threading.Event` with a timeout of "time until the next scheduled export", so an idle process wakes once per `schedule_delay` instead of 25 times.

Both of the things that previously needed polling to be noticed now signal the event explicitly:

- **the queue-size trigger** — `on_trace_start`/`on_span_end` set the event once the queue reaches `_export_trigger_size`, so the immediate-export path is as responsive as before (more so: it no longer waits for the next poll tick);
- **shutdown** — `shutdown()` sets it alongside `_shutdown_event`, so the worker leaves the loop and drains immediately.

This is the second shape offered in the issue rather than the `min(0.2, ...)` one-liner: capping the wait at 200 ms would have fixed the shutdown latency but left the idle wakeups — the main complaint — in place. It keeps the existing drain logic untouched, unlike blocking on `queue.Queue.get`.

There is no lost-wakeup window. A `set()` that lands while the worker is exporting, or between its `wait()` returning and its `clear()`, is covered by the queue-size check at the top of the next iteration — the condition that caused the `set()` is re-read there, not assumed.

As the issue notes, `BackendSpanExporter._sleep_before_retry` in this same file already waits on its shutdown event, so this brings the worker in line with it.

### Tests

- `test_batch_trace_processor_queue_trigger_wakes_the_idle_worker` — with `schedule_delay=60`, a sub-trigger queue leaves the worker parked and reaching the trigger wakes it. Hangs to failure if the producer-side signal is dropped.
- `test_batch_trace_processor_shutdown_wakes_the_idle_worker` — `shutdown()` on a parked worker joins promptly and still drains the queued span, instead of timing out and warning.
- `test_batch_trace_processor_schedule_uses_monotonic_clock` drove `_run` through its `time.sleep` calls, so it now drives it through the wake event's `wait` instead. Its `ControlledTime.sleep` raises, which makes the test fail if polling is ever reintroduced into the loop.

Each was verified to fail against a deliberately broken version of the corresponding change.
