### PR TITLE
fix(core): preserve fixed tuple annotations for variadic tool arguments

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -397,16 +397,16 @@ def function_schema(
 
         # Handle different parameter kinds
         if param.kind == param.VAR_POSITIONAL:
-            # e.g. *args: extend positional args
             if get_origin(ann) is tuple:
-                # Preserve a homogeneous tuple as the type of each positional argument.
                 args_of_tuple = get_args(ann)
-                if len(args_of_tuple) == 2 and args_of_tuple[1] is Ellipsis:
-                    ann = list[ann]  # type: ignore
-                else:
+                if not args_of_tuple or args_of_tuple == ((),):
+                    # Preserve the permissive behavior for bare and empty tuple annotations.
                     ann = list[Any]
+                else:
+                    # Preserve a parameterized tuple as the type of each positional argument.
+                    ann = list[ann]  # type: ignore
             else:
-                # If user wrote *args: int, treat as List[int]
+                # If user wrote *args: T, treat it as list[T].
                 ann = list[ann]  # type: ignore
 
             # Default factory to empty list

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -273,6 +273,20 @@ def _ensure_strict_json_schema(
             inside_nested_resource=inside_nested_resource,
         )
 
+    prefix_items = json_schema.get("prefixItems")
+    if is_list(prefix_items):
+        json_schema["prefixItems"] = [
+            _ensure_strict_json_schema(
+                item,
+                path=(*path, "prefixItems", str(i)),
+                root=root,
+                budget=budget,
+                depth=next_depth,
+                inside_nested_resource=inside_nested_resource,
+            )
+            for i, item in enumerate(prefix_items)
+        ]
+
     # unions
     any_of = json_schema.get("anyOf")
     if is_list(any_of):

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1,3 +1,4 @@
+import typing
 from collections.abc import Callable, Mapping
 from enum import Enum
 from typing import Annotated, Any, Literal
@@ -460,6 +461,54 @@ def test_var_positional_tuple_annotation():
 
     with pytest.raises(ValidationError):
         fs.params_pydantic_model.model_validate({"args": [1, 2, 3]})
+
+
+def test_var_positional_fixed_tuple_annotation():
+    def func(*args: tuple[int, str]) -> tuple[tuple[int, str], ...]:
+        return args
+
+    fs = function_schema(func, use_docstring_info=False)
+
+    args_schema = fs.params_json_schema["properties"]["args"]
+    assert args_schema["type"] == "array"
+    assert args_schema["items"]["type"] == "array"
+    assert args_schema["items"]["prefixItems"] == [
+        {"type": "integer"},
+        {"type": "string"},
+    ]
+    assert args_schema["items"]["minItems"] == 2
+    assert args_schema["items"]["maxItems"] == 2
+
+    parsed = fs.params_pydantic_model.model_validate({"args": [[1, "one"], [2, "two"]]})
+    args, kwargs = fs.to_call_args(parsed)
+    assert func(*args, **kwargs) == ((1, "one"), (2, "two"))
+
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model.model_validate({"args": [[1, "one", "extra"]]})
+
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model.model_validate({"args": [[1]]})
+
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model.model_validate({"args": [["wrong", 1]]})
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [tuple[()], typing.Tuple[()]],  # noqa: UP006
+    ids=["builtin", "typing"],
+)
+def test_var_positional_empty_tuple_annotation_remains_permissive(annotation):
+    def func(*args):
+        return args
+
+    func.__annotations__["args"] = annotation
+    fs = function_schema(func, use_docstring_info=False)
+
+    assert fs.params_json_schema["properties"]["args"]["items"] == {}
+    parsed = fs.params_pydantic_model.model_validate({"args": [1, "two"]})
+    args, kwargs = fs.to_call_args(parsed)
+    assert func(*args, **kwargs) == (1, "two")
 
 
 def test_var_keyword_dict_annotation():

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -493,6 +493,14 @@ def test_var_positional_fixed_tuple_annotation():
         fs.params_pydantic_model.model_validate({"args": [["wrong", 1]]})
 
 
+def test_var_positional_fixed_tuple_rejects_open_dict_item():
+    def func(*args: tuple[dict[str, int], str]) -> None:
+        pass
+
+    with pytest.raises(UserError, match="additionalProperties"):
+        function_schema(func, use_docstring_info=False)
+
+
 @pytest.mark.parametrize(
     "annotation",
     [tuple[()], typing.Tuple[()]],  # noqa: UP006

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -71,6 +71,31 @@ def test_reasonably_nested_schema_remains_supported():
     assert result["additionalProperties"] is False
 
 
+def test_prefix_items_are_made_strict():
+    schema = {
+        "type": "array",
+        "prefixItems": [
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            },
+            {"type": "string"},
+        ],
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["prefixItems"] == [
+        {
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        {"type": "string"},
+    ]
+
+
 def test_deeply_chained_refs_are_rejected_before_recursive_conversion():
     with pytest.raises(UserError, match="too deeply nested"):
         ensure_strict_json_schema(_chained_ref_schema(1_000))


### PR DESCRIPTION
### Summary

This pull request fixes schema generation for fixed-length tuple annotations used on variadic tool parameters.

A signature such as `*args: tuple[int, str]` currently degrades to `list[Any]`, so the generated JSON Schema accepts invalid arity and element types. This change preserves any parameterized tuple as the type of each positional argument while retaining the existing permissive behavior for bare and empty tuple annotations, including the Python 3.10 `typing.Tuple[()]` representation.

Fixed tuples are represented with `prefixItems`. Strict schema conversion now traverses those entries, closing nested object schemas and rejecting free-form mappings during tool construction instead of sending a non-strict schema to the provider.

Regression coverage verifies schema constraints, nested strictness, invalid open mappings, validation failures, and reconstruction of validated positional arguments into tuples.

### Test plan

- `uv run pytest -q tests/test_function_schema.py tests/test_strict_schema.py` (113 passed)
- Repository verification script on Linux / Python 3.12: format, Ruff, Mypy, Pyright, and the full test target all passed

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
