### PR TITLE
fix(chat-completions): validate non-streaming choices

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -62,11 +62,6 @@ from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
 from .reasoning_content_replay import _CHAT_COMPLETIONS_REASONING_FIELD_KEY
 
-_UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE = (
-    "Chat Completions with multiple choices or nonzero choice indexes is not fully "
-    "supported; only one primary choice can be processed."
-)
-
 
 # Define a Part class for internal use
 class Part:
@@ -669,14 +664,18 @@ class ChatCmplStreamHandler:
                 choice.index for choice in chunk.choices if choice.index != 0
             ]
             if len(chunk.choices) > 1 or unsupported_choice_indexes:
+                message = (
+                    "Chat Completions streaming with multiple choices or nonzero choice indexes "
+                    "is not fully supported; only choice index 0 can be processed."
+                )
                 if strict_feature_validation:
-                    raise UserError(_UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE)
+                    raise UserError(message)
 
                 if not state.has_warned_unsupported_choice:
                     logger.warning(
                         "%s Ignoring the other choices; enable strict feature validation to "
                         "raise an error instead.",
-                        _UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE,
+                        message,
                     )
                     state.has_warned_unsupported_choice = True
 

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -62,6 +62,11 @@ from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
 from .reasoning_content_replay import _CHAT_COMPLETIONS_REASONING_FIELD_KEY
 
+_UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE = (
+    "Chat Completions with multiple choices or nonzero choice indexes is not fully "
+    "supported; only one primary choice can be processed."
+)
+
 
 # Define a Part class for internal use
 class Part:
@@ -664,18 +669,14 @@ class ChatCmplStreamHandler:
                 choice.index for choice in chunk.choices if choice.index != 0
             ]
             if len(chunk.choices) > 1 or unsupported_choice_indexes:
-                message = (
-                    "Chat Completions streaming with multiple choices or nonzero choice indexes "
-                    "is not fully supported; only choice index 0 can be processed."
-                )
                 if strict_feature_validation:
-                    raise UserError(message)
+                    raise UserError(_UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE)
 
                 if not state.has_warned_unsupported_choice:
                     logger.warning(
                         "%s Ignoring the other choices; enable strict feature validation to "
                         "raise an error instead.",
-                        message,
+                        _UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE,
                     )
                     state.has_warned_unsupported_choice = True
 

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -44,10 +44,7 @@ from ._retry_runtime import should_disable_provider_managed_retries
 from ._trace import model_config_for_trace
 from .chatcmpl_converter import Converter
 from .chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
-from .chatcmpl_stream_handler import (
-    _UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE,
-    ChatCmplStreamHandler,
-)
+from .chatcmpl_stream_handler import ChatCmplStreamHandler
 from .fake_id import FAKE_RESPONSES_ID
 from .interface import Model, ModelTracing
 from .openai_responses import Converter as OpenAIResponsesConverter
@@ -55,6 +52,11 @@ from .reasoning_content_replay import ShouldReplayReasoningContent
 
 if TYPE_CHECKING:
     from ..model_settings import ModelSettings
+
+_UNSUPPORTED_NONSTREAMING_CHOICES_MESSAGE = (
+    "Chat Completions with multiple choices or nonzero choice indexes is not fully "
+    "supported; only one primary choice can be processed."
+)
 
 
 class OpenAIChatCompletionsModel(Model):
@@ -139,13 +141,13 @@ class OpenAIChatCompletionsModel(Model):
             return
 
         if self._strict_feature_validation:
-            raise UserError(_UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE)
+            raise UserError(_UNSUPPORTED_NONSTREAMING_CHOICES_MESSAGE)
 
         if not self._has_warned_unsupported_choice:
             logger.warning(
                 "%s Using the first returned choice; enable strict feature validation to "
                 "raise an error instead.",
-                _UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE,
+                _UNSUPPORTED_NONSTREAMING_CHOICES_MESSAGE,
             )
             self._has_warned_unsupported_choice = True
 
@@ -287,8 +289,6 @@ class OpenAIChatCompletionsModel(Model):
                     f"{error_details}"
                 )
 
-            self._handle_unsupported_choices(response.choices)
-
             message: ChatCompletionMessage | None = None
             first_choice: Choice | None = None
             if response.choices and len(response.choices) > 0:
@@ -333,6 +333,8 @@ class OpenAIChatCompletionsModel(Model):
                 "input_tokens_details": usage.input_tokens_details.model_dump(),
                 "output_tokens_details": usage.output_tokens_details.model_dump(),
             }
+
+            self._handle_unsupported_choices(response.choices)
 
             # Some providers signal a filtered non-streaming completion only through
             # finish_reason="content_filter" and an otherwise empty message. Preserve

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -44,7 +44,10 @@ from ._retry_runtime import should_disable_provider_managed_retries
 from ._trace import model_config_for_trace
 from .chatcmpl_converter import Converter
 from .chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
-from .chatcmpl_stream_handler import ChatCmplStreamHandler
+from .chatcmpl_stream_handler import (
+    _UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE,
+    ChatCmplStreamHandler,
+)
 from .fake_id import FAKE_RESPONSES_ID
 from .interface import Model, ModelTracing
 from .openai_responses import Converter as OpenAIResponsesConverter
@@ -75,6 +78,7 @@ class OpenAIChatCompletionsModel(Model):
         self._has_warned_unsupported_prompt = False
         self._has_warned_unsupported_conversation_state = False
         self._has_warned_unsupported_reasoning_settings = False
+        self._has_warned_unsupported_choice = False
 
     def _non_null_or_omit(self, value: Any) -> Any:
         return value if value is not None else omit
@@ -128,6 +132,22 @@ class OpenAIChatCompletionsModel(Model):
                 message,
             )
             self._has_warned_unsupported_reasoning_settings = True
+
+    def _handle_unsupported_choices(self, choices: list[Choice]) -> None:
+        unsupported_choice_indexes = [choice.index for choice in choices if choice.index != 0]
+        if len(choices) <= 1 and not unsupported_choice_indexes:
+            return
+
+        if self._strict_feature_validation:
+            raise UserError(_UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE)
+
+        if not self._has_warned_unsupported_choice:
+            logger.warning(
+                "%s Using the first returned choice; enable strict feature validation to "
+                "raise an error instead.",
+                _UNSUPPORTED_MULTIPLE_CHOICES_MESSAGE,
+            )
+            self._has_warned_unsupported_choice = True
 
     def get_retry_advice(self, request: ModelRetryAdviceRequest) -> ModelRetryAdvice | None:
         return get_openai_retry_advice(request)
@@ -266,6 +286,8 @@ class OpenAIChatCompletionsModel(Model):
                     f"ChatCompletion response has no choices (possible provider error payload)"
                     f"{error_details}"
                 )
+
+            self._handle_unsupported_choices(response.choices)
 
             message: ChatCompletionMessage | None = None
             first_choice: Choice | None = None

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -24,6 +24,7 @@ from openai.types.chat.chat_completion_token_logprob import (
     TopLogprob,
 )
 from openai.types.completion_usage import (
+    CompletionTokensDetails,
     CompletionUsage,
     PromptTokensDetails,
 )
@@ -231,7 +232,11 @@ async def test_get_response_rejects_unsupported_choices_in_strict_mode(
         strict_feature_validation=True,
     ).get_model("gpt-4")
 
-    with pytest.raises(UserError, match="multiple choices or nonzero choice indexes"):
+    expected_message = (
+        "Chat Completions with multiple choices or nonzero choice indexes is not fully "
+        "supported; only one primary choice can be processed."
+    )
+    with pytest.raises(UserError) as exc_info:
         await model.get_response(
             system_instructions=None,
             input="",
@@ -244,16 +249,115 @@ async def test_get_response_rejects_unsupported_choices_in_strict_mode(
             conversation_id=None,
             prompt=None,
         )
+    assert str(exc_info.value) == expected_message
 
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
-async def test_get_response_warns_once_and_uses_first_choice(
+async def test_get_response_accepts_single_primary_choice_in_strict_mode(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     async def patched_fetch_response(self, *args, **kwargs):
-        return _chat_completion_with_choice_indexes(0, 1)
+        return _chat_completion_with_choice_indexes(0)
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(
+        use_responses=False,
+        strict_feature_validation=True,
+    ).get_model("gpt-4")
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    response = await model.get_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert isinstance(response.output[0], ResponseOutputMessage)
+    assert isinstance(response.output[0].content[0], ResponseOutputText)
+    assert response.output[0].content[0].text == "choice-0"
+    assert not any(
+        "multiple choices or nonzero choice indexes" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_traces_usage_before_rejecting_unsupported_choices(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    chat = _chat_completion_with_choice_indexes(0, 1)
+    chat.usage = CompletionUsage(
+        completion_tokens=3,
+        prompt_tokens=7,
+        total_tokens=10,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=2),
+        completion_tokens_details=CompletionTokensDetails(reasoning_tokens=1),
+    )
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return chat
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(
+        use_responses=False,
+        strict_feature_validation=True,
+    ).get_model("gpt-4")
+    caplog.set_level(logging.DEBUG, logger="openai.agents")
+
+    with trace(workflow_name="unsupported-choices-usage"):
+        with pytest.raises(UserError, match="multiple choices or nonzero choice indexes"):
+            await model.get_response(
+                system_instructions=None,
+                input="",
+                model_settings=ModelSettings(),
+                tools=[],
+                output_schema=None,
+                handoffs=[],
+                tracing=ModelTracing.ENABLED,
+                previous_response_id=None,
+                conversation_id=None,
+                prompt=None,
+            )
+
+    generation = next(span for span in fetch_ordered_spans() if span.span_data.type == "generation")
+    assert generation.span_data.usage is not None
+    assert generation.span_data.usage["requests"] == 1
+    assert generation.span_data.usage["input_tokens"] == 7
+    assert generation.span_data.usage["output_tokens"] == 3
+    assert generation.span_data.usage["total_tokens"] == 10
+    assert generation.span_data.usage["input_tokens_details"]["cached_tokens"] == 2
+    assert generation.span_data.usage["output_tokens_details"]["reasoning_tokens"] == 1
+    assert generation.span_data.output is None
+    exported_span = generation.export()
+    assert exported_span is not None
+    assert exported_span["error"] is not None
+    assert any(
+        message == "Received model response" or "LLM resp:" in message
+        for message in (record.getMessage() for record in caplog.records)
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("choice_indexes", [(0, 1), (1,)])
+async def test_get_response_warns_once_and_uses_first_choice(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    choice_indexes: tuple[int, ...],
+) -> None:
+    async def patched_fetch_response(self, *args, **kwargs):
+        return _chat_completion_with_choice_indexes(*choice_indexes)
 
     monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
     model = OpenAIProvider(use_responses=False).get_model("gpt-4")
@@ -278,7 +382,7 @@ async def test_get_response_warns_once_and_uses_first_choice(
     for response in responses:
         assert isinstance(response.output[0], ResponseOutputMessage)
         assert isinstance(response.output[0].content[0], ResponseOutputText)
-        assert response.output[0].content[0].text == "choice-0"
+        assert response.output[0].content[0].text == f"choice-{choice_indexes[0]}"
     warnings = [
         record
         for record in caplog.records

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -74,6 +74,23 @@ def _minimal_chat_completion(content: str = "ok") -> ChatCompletion:
     )
 
 
+def _chat_completion_with_choice_indexes(*indexes: int) -> ChatCompletion:
+    return ChatCompletion(
+        id="resp-id",
+        created=0,
+        model="fake",
+        object="chat.completion",
+        choices=[
+            Choice(
+                index=index,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content=f"choice-{index}"),
+            )
+            for index in indexes
+        ],
+    )
+
+
 async def _run_chat_completions_model_with_custom_base_url(
     model_settings: ModelSettings | dict[str, Any] | None = None,
     tools: list[Tool] | None = None,
@@ -196,6 +213,78 @@ async def test_get_response_with_text_message(monkeypatch) -> None:
     assert resp.usage.output_tokens_details.reasoning_tokens == 0
     assert resp.response_id is None
     assert resp.raw_usage is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("choice_indexes", [(0, 1), (1,)])
+async def test_get_response_rejects_unsupported_choices_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    choice_indexes: tuple[int, ...],
+) -> None:
+    async def patched_fetch_response(self, *args, **kwargs):
+        return _chat_completion_with_choice_indexes(*choice_indexes)
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(
+        use_responses=False,
+        strict_feature_validation=True,
+    ).get_model("gpt-4")
+
+    with pytest.raises(UserError, match="multiple choices or nonzero choice indexes"):
+        await model.get_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_warns_once_and_uses_first_choice(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def patched_fetch_response(self, *args, **kwargs):
+        return _chat_completion_with_choice_indexes(0, 1)
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    responses = [
+        await model.get_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+        for _ in range(2)
+    ]
+
+    for response in responses:
+        assert isinstance(response.output[0], ResponseOutputMessage)
+        assert isinstance(response.output[0].content[0], ResponseOutputText)
+        assert response.output[0].content[0].text == "choice-0"
+    warnings = [
+        record
+        for record in caplog.records
+        if "multiple choices or nonzero choice indexes" in record.getMessage()
+    ]
+    assert len(warnings) == 1
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

This pull request fixes non-streaming Chat Completions handling for provider responses that contain multiple choices or nonzero choice indexes.

- align strict feature validation with the existing streaming guard by raising `UserError`
- preserve the released default behavior of using the first returned choice while warning once per model instance
- record the completed request and provider-reported token usage on the generation span before strict validation raises
- keep the existing streaming diagnostic and non-streaming response logging unchanged

### Test plan

- `PYTEST_XDIST_AUTO_NUM_WORKERS=1 bash .agents/skills/code-change-verification/scripts/run.sh`
- `uv run pytest -q tests/models/test_openai_chatcompletions.py tests/models/test_openai_chatcompletions_stream.py -k "unsupported_choices or multiple_choices or nonzero_choice or warns_once_and_uses_first_choice or accepts_single_primary_choice"`

### Issue number

Follow-up to #3314.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
