### PR TITLE
fix(sandbox): keep unbounded UnixLocal workspace I/O off the event loop

### DIFF
--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -62,6 +62,7 @@ from ..session.sandbox_client import BaseSandboxClient, BaseSandboxClientOptions
 from ..session.workspace_payloads import coerce_write_payload
 from ..snapshot import SnapshotBase, SnapshotSpec, resolve_snapshot
 from ..types import ExecResult, ExposedPortEndpoint, Permissions, User
+from ..util.blocking_io import run_blocking_workspace_io
 from ..util.tar_utils import (
     UnsafeTarMemberError,
     safe_extract_tarfile,
@@ -962,7 +963,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         try:
             if normalized.is_dir() and not normalized.is_symlink():
                 if recursive:
-                    shutil.rmtree(normalized)
+                    await run_blocking_workspace_io(shutil.rmtree, normalized)
                 else:
                     normalized.rmdir()
             else:
@@ -1083,7 +1084,8 @@ class UnixLocalSandboxSession(BaseSandboxSession):
 
         skip = self._persist_workspace_skip_relpaths()
         buf = io.BytesIO()
-        try:
+
+        def _archive_workspace() -> None:
             with tarfile.open(fileobj=buf, mode="w") as tar:
                 tar.add(
                     root,
@@ -1098,6 +1100,9 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                         else ti
                     ),
                 )
+
+        try:
+            await run_blocking_workspace_io(_archive_workspace)
         except (tarfile.TarError, OSError) as e:
             raise WorkspaceArchiveReadError(path=root, cause=e) from e
 
@@ -1106,7 +1111,8 @@ class UnixLocalSandboxSession(BaseSandboxSession):
 
     async def hydrate_workspace(self, data: io.IOBase) -> None:
         root = Path(self.state.manifest.root)
-        try:
+
+        def _extract_workspace() -> None:
             root.mkdir(parents=True, exist_ok=True)
             with tarfile.open(fileobj=data, mode="r:*") as tar:
                 safe_extract_tarfile(
@@ -1114,6 +1120,9 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                     root=root,
                     allow_external_symlink_targets=False,
                 )
+
+        try:
+            await run_blocking_workspace_io(_extract_workspace)
         except UnsafeTarMemberError as e:
             raise WorkspaceArchiveWriteError(
                 path=root, context={"reason": e.reason, "member": e.member}, cause=e

--- a/src/agents/sandbox/util/blocking_io.py
+++ b/src/agents/sandbox/util/blocking_io.py
@@ -1,0 +1,40 @@
+"""Run unbounded blocking workspace I/O off the event loop without abandoning it.
+
+`asyncio.to_thread()` does not stop its worker when the awaiting task is cancelled, so a
+cancelled caller can return while the thread is still writing. Snapshot resume closes the
+archive stream and clears the workspace root as soon as its await returns, which would let a
+surviving worker extract into a workspace that is being deleted.
+
+Callers therefore keep waiting for the worker even while cancelled, matching the mutation
+semantics the session backends already rely on in `agents.memory.sqlite_session`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+
+async def run_blocking_workspace_io(function: Callable[..., _T], /, *args: Any) -> _T:
+    """Run `function` in a worker thread and keep ownership until that worker finishes."""
+    task = asyncio.ensure_future(asyncio.to_thread(function, *args))
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.wait({task})
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+
+    try:
+        result = task.result()
+    except BaseException:
+        if cancellation is not None:
+            raise cancellation from None
+        raise
+    if cancellation is not None:
+        raise cancellation from None
+    return result

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import signal
+import tarfile
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -464,3 +468,48 @@ class TestUnixLocalUserScopedFilesystem:
         assert session.exec_commands[0][4:6] == ("sh", "-lc")
         assert session.exec_commands[0][-2:] == (str(target), "0")
         assert not any(part.startswith("rm ") for part in session.exec_commands[0])
+
+
+@pytest.mark.asyncio
+async def test_hydrate_workspace_cancellation_waits_for_the_extracting_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled hydrate must not leave a worker writing into the workspace.
+
+    `restore_snapshot_into_workspace_on_resume` closes the archive stream in a `finally` as
+    soon as its await returns, so if cancellation propagated while the extractor was still
+    running it would read a closed stream and write into a workspace resume then clears.
+    """
+    workspace = tmp_path / "workspace"
+    session = _RecordingUnixLocalSession(workspace)
+
+    started = threading.Event()
+    events: list[str] = []
+
+    def _slow_extract(tar: object, **kwargs: object) -> None:
+        _ = tar, kwargs
+        events.append("extract-start")
+        started.set()
+        time.sleep(0.2)
+        events.append("extract-end")
+
+    monkeypatch.setattr(unix_local_module, "safe_extract_tarfile", _slow_extract)
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w"):
+        pass
+    buf.seek(0)
+
+    task = asyncio.create_task(session.hydrate_workspace(buf))
+    while not started.is_set():
+        await asyncio.sleep(0.005)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The worker finished before the caller observed cancellation, so the archive stream and
+    # the workspace root are only released once nothing is still writing to them.
+    assert events == ["extract-start", "extract-end"]
+    assert not buf.closed


### PR DESCRIPTION
### Summary

`UnixLocalSandboxSession` does three pieces of unbounded filesystem work synchronously inside `async def` methods: `persist_workspace` tars the whole workspace, `hydrate_workspace` extracts it, and `rm(recursive=True)` removes it. All three sit on the snapshot path, so the event loop is blocked for the full duration of a workspace-sized archive or extract.

The blocking is severe enough that a resume cannot be cancelled at all. Without this change, the regression test below fails with `DID NOT RAISE CancelledError`: the loop never gets a chance to deliver the cancellation, so the task runs to completion instead.

Moving that work to a thread is not sufficient on its own, which is what closed #4678. `asyncio.to_thread()` does not stop its worker when the awaiting task is cancelled, and `restore_snapshot_into_workspace_on_resume` closes the archive stream in a `finally` as soon as its await returns:

```python
try:
    await session.hydrate_workspace(workspace_archive)
finally:
    _close_best_effort(workspace_archive)
```

So a cancelled hydrate that returns early leaves a live extractor reading a closed stream and writing into a workspace that resume then clears.

This change runs the work in a worker thread and keeps waiting for that worker even while cancelled, so ownership of the archive and the workspace root is never released while something is still writing. That is the same mutation semantic the session backends already depend on: `agents.memory.sqlite_session._await_mutation` is used by the SQLite, SQLAlchemy, MongoDB and Redis sessions for exactly this reason, and the helper here follows it rather than inventing a second answer.

Scope is the lifecycle boundary rather than a lint rule. Only the three unbounded sites that own shared workspace state are moved. The bounded `mkdir`, `exists` and `resolve` calls are deliberately left alone, since being on the loop is not a demonstrated defect for them and they sit on the exec confinement path.

Tradeoff worth stating plainly: cancellation is not made prompt, only safe. A caller that cancels mid-extract still waits for the extract to finish. That is not a regression, because today the loop is blocked for that same work and cancellation cannot be delivered at all. Making cancellation prompt needs a cooperative stop inside `safe_extract_tarfile` and `shutil.rmtree`, which is a larger change and a separate one.

### Test plan

`tests/sandbox/test_unix_local.py::test_hydrate_workspace_cancellation_waits_for_the_extracting_worker` covers the ordering that was missing: it starts a hydrate whose extractor blocks, cancels the awaiting task once the worker has actually started, and asserts that `CancelledError` reaches the caller only after the worker recorded completion, with the archive stream still open at that point.

Verified it fails without the source change by reverting `src/`: it fails with `DID NOT RAISE CancelledError`, which is the blocked-loop symptom itself.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full suite, including all 1447 sandbox tests.

### Issue number

Fixes #4675

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

I picked this up after #4678 was closed, and I tried to build to the shape you described there rather than re-slice the same patch. The part I would most like checked is the decision to wait for the worker instead of trying to interrupt it. Waiting seemed like the only honest option given a thread cannot be stopped, and it matches what the session backends already do, but it does mean a cancel can block for as long as the extract takes. I'm a freshman in college, so if you would rather see cooperative stopping inside the tar and rmtree paths before this lands, I'm glad to take that direction instead.
