### PR TITLE
fix(models): reject unpaired function calls in Chat Completions

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -790,10 +790,17 @@ class Converter:
             elif func_call := cls.maybe_function_tool_call(item):
                 asst = ensure_assistant_message()
 
+                call_id = func_call.get("call_id")
+                if call_id is None:
+                    raise UserError(
+                        "Unpaired function calls are supported by Responses but cannot be "
+                        "converted to Chat Completions tool calls. "
+                        "Use a Responses model to preserve this input."
+                    )
                 tool_calls = list(asst.get("tool_calls", []))
                 arguments = func_call["arguments"] if func_call["arguments"] else "{}"
                 new_tool_call = ChatCompletionMessageFunctionToolCallParam(
-                    id=func_call["call_id"],
+                    id=call_id,
                     type="function",
                     function={
                         "name": func_call["name"],

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -797,6 +797,58 @@ async def test_unpaired_function_output_rejected_before_chat_request(
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+@pytest.mark.parametrize("call_id_fields", [{}, {"call_id": None}], ids=["omitted", "null"])
+@pytest.mark.parametrize("stream", [False, True], ids=["non_streaming", "streaming"])
+@pytest.mark.parametrize("strict_feature_validation", [False, True], ids=["default", "strict"])
+async def test_unpaired_function_call_rejected_before_chat_request(
+    call_id_fields: dict[str, None], stream: bool, strict_feature_validation: bool
+) -> None:
+    """A function call without a call ID cannot become a Chat Completions tool call."""
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        raise AssertionError("Unpaired function calls must not reach Chat Completions")
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as http_client:
+        model = OpenAIChatCompletionsModel(
+            model="gpt-4",
+            openai_client=AsyncOpenAI(api_key="test-key", http_client=http_client),
+            strict_feature_validation=strict_feature_validation,
+        )
+        request_kwargs: dict[str, Any] = {
+            "system_instructions": None,
+            "input": [
+                {
+                    "type": "function_call",
+                    "name": "notifications",
+                    "namespace": "slack",
+                    "arguments": "{}",
+                    **call_id_fields,
+                }
+            ],
+            "model_settings": ModelSettings(),
+            "tools": [],
+            "output_schema": None,
+            "handoffs": [],
+            "tracing": ModelTracing.DISABLED,
+        }
+
+        with pytest.raises(
+            UserError,
+            match="Unpaired function calls.*Chat Completions.*Use a Responses model",
+        ):
+            if stream:
+                async for _ in model.stream_response(**request_kwargs):
+                    pass
+            else:
+                await model.get_response(**request_kwargs)
+
+    assert requests == []
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_get_response_rejects_non_text_tool_output_in_strict_mode() -> None:
     class DummyCompletions:
         async def create(self, **kwargs: Any) -> Any:


### PR DESCRIPTION
### Summary

#4699 made an unpaired `function_call_output` raise an actionable `UserError`, because Chat Completions has no way to represent it. The branch immediately above it has the same shape and was not covered:

```python
elif func_call := cls.maybe_function_tool_call(item):
    ...
    new_tool_call = ChatCompletionMessageFunctionToolCallParam(
        id=func_call["call_id"],      # direct subscript, no guard
```

`call_id` is optional on both `ResponseFunctionToolCallParam` and `FunctionCallOutput`, so a function call without one is exactly as constructible as the output that #4699 now rejects. Today the two halves of the same pair fail differently:

```
output without call_id   UserError: Unpaired function outputs are supported by Responses ...
call   without call_id   KeyError: 'call_id'
```

This is reachable from an ordinary hand-built input list, and it fails in conversion before anything is sent:

```python
await Runner.run(agent, [
    {"role": "user", "content": "hi"},
    {"type": "function_call", "name": "f", "arguments": "{}"},
])
# Chat Completions model -> KeyError: 'call_id'
```

It is also the same capability difference #4699 described, not invalid input. Running that identical input against a Responses model converts cleanly and reaches the transport, failing only on the connection. So Responses preserves the item and Chat Completions cannot, which is exactly the case the existing message is worded for.

The change raises the parallel `UserError` so both halves of the pair fail the same actionable way. Provenance for the two sides: the output guard landed one commit ago in #4699, while the call-side subscript has been unguarded since #522 extracted this converter, so the asymmetry is an uncovered branch rather than a deliberate split.

### Test plan

`tests/models/test_openai_chatcompletions.py::test_unpaired_function_call_rejected_before_chat_request`, written to mirror the #4699 test directly: same `MockTransport` handler that fails if a request is ever issued, and the same parametrization over an omitted versus explicitly null `call_id`, streaming versus non streaming, and default versus strict feature validation. Eight cases, and it asserts no request reached the wire.

Verified it fails without the source change by reverting `src/`: all eight fail, each with `KeyError: 'call_id'`.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full suite.

### Issue number

None. Found while sibling-checking #4699.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

This is just the other half of #4699, so the wording and the test structure are deliberately copied from it rather than reinvented. If you would rather the two branches shared one guard instead of two parallel messages, say so and I will fold them together. I'm a freshman in college and I found this by checking whether the fix you just merged had a sibling one branch up.
