### PR TITLE
fix(core): make prompt input cancellable

### DIFF
--- a/src/agents/_repl_input_process.py
+++ b/src/agents/_repl_input_process.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+from typing import Any, BinaryIO, cast
+
+
+def _read_exactly(stream: BinaryIO, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = stream.read(remaining)
+        if not chunk:
+            raise EOFError
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _open_control(value: str) -> BinaryIO:
+    kind, raw_value = value.split(":", 1)
+    if kind == "fd":
+        descriptor = int(raw_value)
+    elif kind == "handle" and sys.platform == "win32":
+        import msvcrt
+
+        descriptor = msvcrt.open_osfhandle(int(raw_value), os.O_RDONLY | getattr(os, "O_BINARY", 0))
+    else:
+        raise ValueError("Invalid control channel.")
+    return cast(BinaryIO, os.fdopen(descriptor, "rb", buffering=0))
+
+
+def main() -> None:
+    terminal = sys.argv[3] == "terminal"
+    cast(Any, sys.stdin).reconfigure(encoding=sys.argv[1], errors=sys.argv[2], newline=None)
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    readline_module: Any = None
+    control = _open_control(sys.argv[4])
+    config_size = int.from_bytes(_read_exactly(control, 8), "big")
+    config = json.loads(_read_exactly(control, config_size))
+    if config["readline"]:
+        import readline
+
+        readline_module = readline
+        for item in config["history"]:
+            readline_module.add_history(item)
+    output = cast(Any, sys.stderr if terminal else sys.stdout).buffer
+    prompt = sys.argv[5] if terminal else ""
+
+    while True:
+        if control.read(1) != b"R":
+            break
+        history_length = (
+            readline_module.get_current_history_length() if readline_module is not None else 0
+        )
+        result: list[Any]
+        try:
+            if terminal and readline_module is None:
+                sys.stdout.write(prompt)
+                sys.stdout.flush()
+                value = input()
+            else:
+                value = input(prompt)
+        except EOFError:
+            result = ["eof", None, []]
+        except UnicodeDecodeError as exc:
+            result = [
+                "decode_error",
+                [exc.encoding, bytes(exc.object).hex(), exc.start, exc.end, exc.reason],
+                [],
+            ]
+        except BaseException as exc:
+            result = ["error", type(exc).__name__, []]
+        else:
+            history = (
+                [
+                    readline_module.get_history_item(index)
+                    for index in range(
+                        history_length + 1,
+                        readline_module.get_current_history_length() + 1,
+                    )
+                ]
+                if readline_module is not None
+                else []
+            )
+            result = ["line", value, history]
+
+        payload = json.dumps(result).encode()
+        output.write(len(payload).to_bytes(8, "big"))
+        output.write(payload)
+        output.flush()
+        if result[0] != "line":
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agents/repl.py
+++ b/src/agents/repl.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+import contextlib
+import functools
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+from collections.abc import Coroutine
+from pathlib import Path
+from typing import IO, Any, TextIO, cast
 
 from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
 
@@ -10,6 +21,474 @@ from .result import RunResultBase
 from .run import DEFAULT_MAX_TURNS, Runner
 from .run_context import TContext
 from .stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent, RunItemStreamEvent
+
+_INPUT_PROCESS_PATH = Path(__file__).with_name("_repl_input_process.py")
+_InputProcess = asyncio.subprocess.Process | subprocess.Popen[bytes]
+
+
+class _StdinReader:
+    def __init__(self, stream: TextIO) -> None:
+        self._stream = stream
+        self._terminal = sys.platform != "win32" and stream.isatty()
+        self._process: _InputProcess | None = None
+        self._spawn_task: asyncio.Task[_InputProcess] | None = None
+        self._control_socket: socket.socket | None = None
+        self._control_fd: int | None = None
+        self._protocol_reader: asyncio.StreamReader | None = None
+        self._blocking_protocol_task: asyncio.Task[bytes] | None = None
+        self._terminal_fd: int | None = None
+        self._terminal_attributes: list[Any] | None = None
+        self._prompt_interrupted: asyncio.Future[None] | None = None
+        self._previous_sigint_handler: Any = None
+        self._sigint_handler: Any = None
+        self._install_sigint_handler()
+
+    async def readline(self, prompt: str) -> str:
+        loop = asyncio.get_running_loop()
+        interrupted = loop.create_future()
+        read_task = asyncio.create_task(self._readline(prompt))
+        self._prompt_interrupted = interrupted
+        outer_exception: BaseException | None = None
+        try:
+            done, _ = await asyncio.wait(
+                (read_task, interrupted), return_when=asyncio.FIRST_COMPLETED
+            )
+            if interrupted in done:
+                raise KeyboardInterrupt
+            return read_task.result()
+        except BaseException as exc:
+            outer_exception = exc
+            raise
+        finally:
+            self._prompt_interrupted = None
+            interrupted.cancel()
+            if not read_task.done():
+                read_task.cancel()
+            if outer_exception is not None:
+                cancellation = await _finish_task(read_task)
+                if cancellation is not None and isinstance(outer_exception, KeyboardInterrupt):
+                    raise cancellation
+            else:
+                await read_task
+
+    async def _readline(self, prompt: str) -> str:
+        process = await self._get_process(prompt)
+        if not self._terminal:
+            sys.stdout.write(prompt)
+            sys.stdout.flush()
+        if self._control_socket is not None:
+            await asyncio.get_running_loop().sock_sendall(self._control_socket, b"R")
+        elif self._control_fd is not None:
+            _write_all(self._control_fd, b"R")
+        else:
+            raise RuntimeError("The stdin helper process has no control channel.")
+
+        if isinstance(process, subprocess.Popen):
+            if process.stdout is None:
+                raise RuntimeError("The stdin helper process has no output pipe.")
+            self._blocking_protocol_task = asyncio.create_task(
+                asyncio.to_thread(_read_blocking_response, process.stdout)
+            )
+        blocking_protocol_task = self._blocking_protocol_task
+        protocol_reader = self._protocol_reader
+        if blocking_protocol_task is None and protocol_reader is None:
+            raise RuntimeError("The stdin helper process has no output pipe.")
+
+        try:
+            if blocking_protocol_task is not None:
+                payload = await asyncio.shield(blocking_protocol_task)
+                self._blocking_protocol_task = None
+            else:
+                assert protocol_reader is not None
+                header = await protocol_reader.readexactly(8)
+                payload_size = int.from_bytes(header, "big")
+                if payload_size == 0:
+                    raise RuntimeError("The stdin helper process returned an invalid response.")
+                payload = await protocol_reader.readexactly(payload_size)
+        except (asyncio.IncompleteReadError, EOFError):
+            await _wait_for_process(process)
+            raise RuntimeError(
+                f"The stdin helper process exited unexpectedly with code {process.returncode}."
+            ) from None
+
+        kind, value, history = json.loads(payload)
+        if kind == "eof":
+            raise EOFError
+        if kind == "decode_error":
+            try:
+                encoding, object_hex, start, end, reason = value
+                error = UnicodeDecodeError(encoding, bytes.fromhex(object_hex), start, end, reason)
+            except (TypeError, ValueError):
+                raise RuntimeError(
+                    "The stdin helper process returned an invalid response."
+                ) from None
+            raise error
+        if kind == "error":
+            raise RuntimeError(f"The stdin helper process failed with {value}.")
+        if kind != "line" or not isinstance(value, str):
+            raise RuntimeError("The stdin helper process returned an invalid response.")
+        if self._terminal:
+            if not isinstance(history, list) or not all(isinstance(item, str) for item in history):
+                raise RuntimeError("The stdin helper process returned an invalid response.")
+            for item in history:
+                _record_readline_history(item)
+        return value
+
+    async def aclose(self) -> None:
+        cancellation: asyncio.CancelledError | None = None
+        process = self._process
+        if process is None and self._spawn_task is not None:
+            process, cancellation = await _finish_spawn(self._spawn_task)
+            self._spawn_task = None
+            self._process = process
+
+        if process is None:
+            self._restore_terminal()
+            self._restore_sigint_handler()
+            self._close_control()
+            if cancellation is not None:
+                raise cancellation
+            return
+
+        try:
+            if process.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+            wait_cancellation = await _wait_for_process(process)
+            if cancellation is None:
+                cancellation = wait_cancellation
+        finally:
+            self._restore_terminal()
+            self._restore_sigint_handler()
+            self._process = None
+            self._protocol_reader = None
+            blocking_protocol_task = self._blocking_protocol_task
+            self._blocking_protocol_task = None
+            if blocking_protocol_task is not None:
+                task_cancellation = await _finish_task(blocking_protocol_task)
+                if cancellation is None:
+                    cancellation = task_cancellation
+            if isinstance(process, subprocess.Popen) and process.stdout is not None:
+                process.stdout.close()
+            self._close_control()
+        if cancellation is not None:
+            raise cancellation
+
+    async def _get_process(self, prompt: str) -> _InputProcess:
+        if self._process is not None:
+            return self._process
+
+        if self._spawn_task is None:
+            encoding = self._stream.encoding
+            if not encoding:
+                raise RuntimeError("The stdin stream has no text encoding.")
+            self._spawn_task = asyncio.create_task(
+                self._spawn_process(prompt, encoding, self._stream.errors or "strict")
+            )
+
+        process = await asyncio.shield(self._spawn_task)
+        self._spawn_task = None
+        self._process = process
+        return process
+
+    async def _spawn_process(self, prompt: str, encoding: str, errors: str) -> _InputProcess:
+        if sys.platform == "win32":
+            return await self._spawn_blocking_process(encoding, errors)
+
+        parent_socket, child_socket = socket.socketpair()
+        parent_socket.setblocking(False)
+        if self._terminal:
+            import termios
+
+            self._terminal_fd = self._stream.fileno()
+            self._terminal_attributes = termios.tcgetattr(self._terminal_fd)
+        try:
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-I",
+                "-S",
+                str(_INPUT_PROCESS_PATH),
+                encoding,
+                errors,
+                "terminal" if self._terminal else "stream",
+                f"fd:{child_socket.fileno()}",
+                prompt,
+                stdin=self._stream,
+                stdout=None if self._terminal else asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE if self._terminal else None,
+                pass_fds=(child_socket.fileno(),),
+            )
+        except BaseException:
+            parent_socket.close()
+            raise
+        finally:
+            child_socket.close()
+
+        self._control_socket = parent_socket
+        self._protocol_reader = process.stderr if self._terminal else process.stdout
+        config = json.dumps(
+            _readline_config() if self._terminal else {"readline": False, "history": []}
+        ).encode()
+        try:
+            await asyncio.get_running_loop().sock_sendall(
+                parent_socket, len(config).to_bytes(8, "big") + config
+            )
+        except BaseException:
+            parent_socket.close()
+            self._control_socket = None
+            self._protocol_reader = None
+            if process.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+            await _wait_for_process(process)
+            raise
+        return process
+
+    async def _spawn_blocking_process(self, encoding: str, errors: str) -> subprocess.Popen[bytes]:
+        control_read_fd, control_write_fd = os.pipe()
+        control_handle: int | None = None
+        try:
+            popen_kwargs: dict[str, Any]
+            if sys.platform == "win32":
+                import msvcrt
+
+                control_handle = msvcrt.get_osfhandle(control_read_fd)
+                cast(Any, os).set_handle_inheritable(control_handle, True)
+                startup_info = subprocess.STARTUPINFO()
+                startup_info.lpAttributeList = {"handle_list": [control_handle]}
+                control_argument = f"handle:{control_handle}"
+                popen_kwargs = {"close_fds": True, "startupinfo": startup_info}
+            else:
+                control_argument = f"fd:{control_read_fd}"
+                popen_kwargs = {"pass_fds": (control_read_fd,)}
+
+            process = cast(
+                subprocess.Popen[bytes],
+                await asyncio.to_thread(
+                    cast(Any, subprocess.Popen),
+                    [
+                        sys.executable,
+                        "-I",
+                        "-S",
+                        str(_INPUT_PROCESS_PATH),
+                        encoding,
+                        errors,
+                        "stream",
+                        control_argument,
+                    ],
+                    stdin=self._stream,
+                    stdout=subprocess.PIPE,
+                    stderr=None,
+                    **popen_kwargs,
+                ),
+            )
+        except BaseException:
+            os.close(control_write_fd)
+            raise
+        finally:
+            if control_handle is not None:
+                with contextlib.suppress(OSError):
+                    cast(Any, os).set_handle_inheritable(control_handle, False)
+            os.close(control_read_fd)
+
+        if process.stdout is None:
+            os.close(control_write_fd)
+            process.kill()
+            await _wait_for_process(process)
+            raise RuntimeError("The stdin helper process has no output pipe.")
+        self._control_fd = control_write_fd
+        config = json.dumps({"readline": False, "history": []}).encode()
+        try:
+            _write_all(control_write_fd, len(config).to_bytes(8, "big") + config)
+        except BaseException:
+            self._close_control()
+            if process.returncode is None:
+                process.kill()
+            await _wait_for_process(process)
+            process.stdout.close()
+            raise
+        return process
+
+    def _close_control(self) -> None:
+        if self._control_socket is not None:
+            self._control_socket.close()
+            self._control_socket = None
+        if self._control_fd is not None:
+            os.close(self._control_fd)
+            self._control_fd = None
+
+    def _restore_terminal(self) -> None:
+        terminal_fd = self._terminal_fd
+        terminal_attributes = self._terminal_attributes
+        self._terminal_fd = None
+        self._terminal_attributes = None
+        if terminal_fd is None or terminal_attributes is None:
+            return
+        if sys.platform == "win32":
+            return
+
+        import termios
+
+        with contextlib.suppress(OSError):
+            termios.tcsetattr(terminal_fd, termios.TCSANOW, terminal_attributes)
+
+    def _install_sigint_handler(self) -> None:
+        previous_handler = signal.getsignal(signal.SIGINT)
+        if not callable(previous_handler):
+            return
+        handles_default_sigint = _handles_default_asyncio_sigint(previous_handler)
+
+        def handle_sigint(signum: int, frame: Any) -> None:
+            interrupted = self._prompt_interrupted
+            if handles_default_sigint and interrupted is not None and not interrupted.done():
+                interrupted.get_loop().call_soon_threadsafe(_interrupt_prompt, interrupted)
+                return
+            try:
+                previous_handler(signum, frame)
+            except KeyboardInterrupt:
+                if interrupted is None or interrupted.done():
+                    raise
+                interrupted.get_loop().call_soon_threadsafe(_interrupt_prompt, interrupted)
+
+        try:
+            signal.signal(signal.SIGINT, handle_sigint)
+        except ValueError:
+            return
+        self._previous_sigint_handler = previous_handler
+        self._sigint_handler = handle_sigint
+
+    def _restore_sigint_handler(self) -> None:
+        handler = self._sigint_handler
+        previous_handler = self._previous_sigint_handler
+        self._sigint_handler = None
+        self._previous_sigint_handler = None
+        if handler is None or signal.getsignal(signal.SIGINT) is not handler:
+            return
+        with contextlib.suppress(ValueError):
+            signal.signal(signal.SIGINT, previous_handler)
+
+
+def _readline_config() -> dict[str, bool | list[str]]:
+    readline: Any = sys.modules.get("readline")
+    if readline is None:
+        return {"readline": False, "history": []}
+
+    history = [
+        item
+        for index in range(1, readline.get_current_history_length() + 1)
+        if (item := readline.get_history_item(index)) is not None
+    ]
+    return {"readline": True, "history": history}
+
+
+def _record_readline_history(value: str) -> None:
+    readline: Any = sys.modules.get("readline")
+    if readline is not None:
+        readline.add_history(value)
+
+
+def _interrupt_prompt(interrupted: asyncio.Future[None]) -> None:
+    if not interrupted.done():
+        interrupted.set_result(None)
+
+
+def _handles_default_asyncio_sigint(handler: Any) -> bool:
+    if handler is signal.default_int_handler:
+        return True
+    if not isinstance(handler, functools.partial):
+        return False
+
+    runner_type = getattr(asyncio, "Runner", None)
+    runner_handler = getattr(runner_type, "_on_sigint", None)
+    handler_function = handler.func
+    return (
+        runner_type is not None
+        and getattr(handler_function, "__func__", None) is runner_handler
+        and isinstance(getattr(handler_function, "__self__", None), runner_type)
+    )
+
+
+def _read_blocking_response(stream: IO[bytes]) -> bytes:
+    header = _read_exactly(stream, 8)
+    payload_size = int.from_bytes(header, "big")
+    if payload_size == 0:
+        raise RuntimeError("The stdin helper process returned an invalid response.")
+    return _read_exactly(stream, payload_size)
+
+
+def _read_exactly(stream: IO[bytes], size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = stream.read(remaining)
+        if not chunk:
+            raise EOFError
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _write_all(descriptor: int, data: bytes) -> None:
+    while data:
+        written = os.write(descriptor, data)
+        if written == 0:
+            raise BrokenPipeError
+        data = data[written:]
+
+
+async def _finish_spawn(
+    task: asyncio.Task[_InputProcess],
+) -> tuple[_InputProcess | None, asyncio.CancelledError | None]:
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+        except BaseException:
+            break
+    try:
+        return task.result(), cancellation
+    except BaseException:
+        return None, cancellation
+
+
+async def _wait_for_process(
+    process: _InputProcess,
+) -> asyncio.CancelledError | None:
+    cancellation: asyncio.CancelledError | None = None
+    wait_awaitable: Coroutine[Any, Any, int]
+    if isinstance(process, subprocess.Popen):
+        wait_awaitable = asyncio.to_thread(process.wait)
+    else:
+        wait_awaitable = process.wait()
+    wait_task = asyncio.create_task(wait_awaitable)
+    while not wait_task.done():
+        try:
+            await asyncio.shield(wait_task)
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+    wait_task.result()
+    return cancellation
+
+
+async def _finish_task(task: asyncio.Task[Any]) -> asyncio.CancelledError | None:
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.wait((task,))
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+    with contextlib.suppress(BaseException):
+        task.result()
+    return cancellation
+
+
+def _create_stdin_reader() -> _StdinReader:
+    return _StdinReader(sys.stdin)
 
 
 async def run_demo_loop(
@@ -33,44 +512,56 @@ async def run_demo_loop(
             the turn limit.
     """
 
-    current_agent = agent
-    input_items: list[TResponseInputItem] = []
-    while True:
+    stdin_reader = _create_stdin_reader()
+    body_raised = False
+    try:
+        current_agent = agent
+        input_items: list[TResponseInputItem] = []
+        while True:
+            try:
+                user_input = await stdin_reader.readline(" > ")
+            except (EOFError, KeyboardInterrupt):
+                print()
+                break
+            if user_input.strip().lower() in {"exit", "quit"}:
+                break
+            if not user_input.strip():
+                continue
+
+            input_items.append({"role": "user", "content": user_input})
+
+            result: RunResultBase
+            if stream:
+                result = Runner.run_streamed(
+                    current_agent, input=input_items, context=context, max_turns=max_turns
+                )
+                async for event in result.stream_events():
+                    if isinstance(event, RawResponsesStreamEvent):
+                        if isinstance(event.data, ResponseTextDeltaEvent):
+                            print(event.data.delta, end="", flush=True)
+                    elif isinstance(event, RunItemStreamEvent):
+                        if event.item.type == "tool_call_item":
+                            print("\n[tool called]", flush=True)
+                        elif event.item.type == "tool_call_output_item":
+                            print(f"\n[tool output: {event.item.output}]", flush=True)
+                    elif isinstance(event, AgentUpdatedStreamEvent):
+                        print(f"\n[Agent updated: {event.new_agent.name}]", flush=True)
+                print()
+            else:
+                result = await Runner.run(
+                    current_agent, input_items, context=context, max_turns=max_turns
+                )
+                if result.final_output is not None:
+                    print(result.final_output)
+
+            current_agent = result.last_agent
+            input_items = result.to_input_list()
+    except BaseException:
+        body_raised = True
+        raise
+    finally:
         try:
-            user_input = input(" > ")
-        except (EOFError, KeyboardInterrupt):
-            print()
-            break
-        if user_input.strip().lower() in {"exit", "quit"}:
-            break
-        if not user_input.strip():
-            continue
-
-        input_items.append({"role": "user", "content": user_input})
-
-        result: RunResultBase
-        if stream:
-            result = Runner.run_streamed(
-                current_agent, input=input_items, context=context, max_turns=max_turns
-            )
-            async for event in result.stream_events():
-                if isinstance(event, RawResponsesStreamEvent):
-                    if isinstance(event.data, ResponseTextDeltaEvent):
-                        print(event.data.delta, end="", flush=True)
-                elif isinstance(event, RunItemStreamEvent):
-                    if event.item.type == "tool_call_item":
-                        print("\n[tool called]", flush=True)
-                    elif event.item.type == "tool_call_output_item":
-                        print(f"\n[tool output: {event.item.output}]", flush=True)
-                elif isinstance(event, AgentUpdatedStreamEvent):
-                    print(f"\n[Agent updated: {event.new_agent.name}]", flush=True)
-            print()
-        else:
-            result = await Runner.run(
-                current_agent, input_items, context=context, max_turns=max_turns
-            )
-            if result.final_output is not None:
-                print(result.final_output)
-
-        current_agent = result.last_agent
-        input_items = result.to_input_list()
+            await stdin_reader.aclose()
+        except asyncio.CancelledError:
+            if not body_raised:
+                raise

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,5 +1,16 @@
+import asyncio
+import contextlib
+import os
+import shutil
+import signal
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, cast
+
 import pytest
 
+import agents.repl as repl_module
 from agents import Agent, run_demo_loop
 from agents.testing import ScriptedModel
 
@@ -12,6 +23,29 @@ from .test_responses import (
 )
 
 
+class StubStdinReader:
+    def __init__(self, inputs: Iterator[str | BaseException]) -> None:
+        self.inputs = inputs
+        self.closed = False
+
+    async def readline(self, _prompt: str) -> str:
+        value = next(self.inputs)
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def patch_stdin_reader(
+    monkeypatch: pytest.MonkeyPatch, inputs: list[str | BaseException]
+) -> StubStdinReader:
+    reader = StubStdinReader(iter(inputs))
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+    return reader
+
+
 @pytest.mark.asyncio
 async def test_run_demo_loop_conversation(monkeypatch, capsys):
     model = ScriptedModel()
@@ -19,8 +53,7 @@ async def test_run_demo_loop_conversation(monkeypatch, capsys):
 
     agent = Agent(name="test", model=model)
 
-    inputs = iter(["Hi", "How are you?", "quit"])
-    monkeypatch.setattr("builtins.input", lambda _=" > ": next(inputs))
+    reader = patch_stdin_reader(monkeypatch, ["Hi", "How are you?", "quit"])
 
     await run_demo_loop(agent, stream=False)
 
@@ -32,6 +65,7 @@ async def test_run_demo_loop_conversation(monkeypatch, capsys):
         get_text_message("hello").model_dump(exclude_unset=True),
         get_text_input_item("How are you?"),
     ]
+    assert reader.closed
 
 
 @pytest.mark.asyncio
@@ -55,8 +89,7 @@ async def test_run_demo_loop_streaming(monkeypatch, capsys):
         ]
     )
 
-    inputs = iter(["Hello", "exit"])
-    monkeypatch.setattr("builtins.input", lambda _=" > ": next(inputs))
+    patch_stdin_reader(monkeypatch, ["Hello", "exit"])
 
     await run_demo_loop(agent, stream=True)
 
@@ -72,12 +105,11 @@ async def test_run_demo_loop_exits_on_eof(monkeypatch, capsys):
     model = ScriptedModel()
     agent = Agent(name="test", model=model)
 
-    def raise_eof(_=" > ") -> str:
-        raise EOFError
-
-    monkeypatch.setattr("builtins.input", raise_eof)
-
-    await run_demo_loop(agent, stream=False)
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    with os.fdopen(read_fd, encoding="utf-8") as stdin:
+        monkeypatch.setattr(sys, "stdin", stdin)
+        await run_demo_loop(agent, stream=False)
 
     # The loop should terminate cleanly without ever invoking the model.
     assert not model.calls
@@ -90,11 +122,885 @@ async def test_run_demo_loop_skips_empty_input(monkeypatch, capsys):
     agent = Agent(name="test", model=model)
 
     # Empty lines are ignored; only the non-empty input reaches the runner.
-    inputs = iter(["", "Hi", "quit"])
-    monkeypatch.setattr("builtins.input", lambda _=" > ": next(inputs))
+    patch_stdin_reader(monkeypatch, ["", "Hi", "quit"])
 
     await run_demo_loop(agent, stream=False)
 
     output = capsys.readouterr().out
     assert "hello" in output
     assert model.calls[-1].input == [get_text_input_item("Hi")]
+
+
+@pytest.mark.asyncio
+async def test_run_demo_loop_skips_whitespace_only_input(monkeypatch, capsys):
+    model = ScriptedModel()
+    agent = Agent(name="test", model=model)
+    patch_stdin_reader(monkeypatch, ["   ", "quit"])
+
+    await run_demo_loop(agent, stream=False)
+
+    assert not model.calls
+
+
+@pytest.mark.asyncio
+async def test_run_demo_loop_does_not_block_the_event_loop(monkeypatch):
+    model = ScriptedModel()
+    agent = Agent(name="test", model=model)
+
+    read_fd, write_fd = os.pipe()
+    with os.fdopen(read_fd, encoding="utf-8") as stdin:
+        monkeypatch.setattr(sys, "stdin", stdin)
+        os.write(write_fd, b"qu")
+
+        async def release_prompt() -> None:
+            await asyncio.sleep(0)
+            os.write(write_fd, b"it\n")
+
+        try:
+            await asyncio.gather(run_demo_loop(agent, stream=False), release_prompt())
+        finally:
+            os.close(write_fd)
+
+    assert not model.calls
+
+
+@pytest.mark.asyncio
+async def test_prompt_is_shown_after_input_helper_is_ready(monkeypatch, capsys):
+    model = ScriptedModel()
+    agent = Agent(name="test", model=model)
+    read_fd, write_fd = os.pipe()
+    spawn_started = asyncio.Event()
+    release_spawn = asyncio.Event()
+    real_spawn_process = repl_module._StdinReader._spawn_process
+
+    async def spawn_process(self, prompt, encoding, errors):
+        spawn_started.set()
+        await release_spawn.wait()
+        return await real_spawn_process(self, prompt, encoding, errors)
+
+    monkeypatch.setattr(repl_module._StdinReader, "_spawn_process", spawn_process)
+    os.write(write_fd, b"quit\n")
+    os.close(write_fd)
+    with os.fdopen(read_fd, encoding="utf-8") as stdin:
+        monkeypatch.setattr(sys, "stdin", stdin)
+        task = asyncio.create_task(run_demo_loop(agent, stream=False))
+        await asyncio.wait_for(spawn_started.wait(), timeout=5)
+        assert capsys.readouterr().out == ""
+        release_spawn.set()
+        await asyncio.wait_for(task, timeout=5)
+
+    assert capsys.readouterr().out == " > "
+    assert not model.calls
+
+
+@pytest.mark.asyncio
+async def test_run_demo_loop_handles_crlf_input(monkeypatch, capsys):
+    model = ScriptedModel()
+    model.extend([[get_text_message("ok")]])
+    agent = Agent(name="test", model=model)
+
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b"hello\r\nquit\r\n")
+    os.close(write_fd)
+    with os.fdopen(read_fd, encoding="utf-8", newline=None) as stdin:
+        monkeypatch.setattr(sys, "stdin", stdin)
+        await run_demo_loop(agent, stream=False)
+
+    assert model.calls[-1].input == [get_text_input_item("hello")]
+    assert capsys.readouterr().out.count(" > ") == 2
+
+
+@pytest.mark.asyncio
+async def test_run_demo_loop_works_without_asyncio_subprocess_transport(monkeypatch):
+    model = ScriptedModel()
+    agent = Agent(name="test", model=model)
+    read_fd, write_fd = os.pipe()
+
+    async def fail_create_subprocess_exec(*args, **kwargs):
+        raise AssertionError("The blocking subprocess path must not use the event loop transport.")
+
+    async def spawn_blocking_process(self, _prompt, encoding, errors):
+        return await self._spawn_blocking_process(encoding, errors)
+
+    monkeypatch.setattr(repl_module._StdinReader, "_spawn_process", spawn_blocking_process)
+    monkeypatch.setattr(repl_module.asyncio, "create_subprocess_exec", fail_create_subprocess_exec)
+    os.write(write_fd, b"quit\n")
+    os.close(write_fd)
+    with os.fdopen(read_fd, encoding="utf-8") as stdin:
+        monkeypatch.setattr(sys, "stdin", stdin)
+        await run_demo_loop(agent, stream=False)
+
+    assert not model.calls
+
+
+@pytest.mark.asyncio
+async def test_blocking_subprocess_preserves_preloaded_lines(monkeypatch):
+    model = ScriptedModel()
+    model.extend([[get_text_message("first response")], [get_text_message("second response")]])
+    agent = Agent(name="test", model=model)
+    read_fd, write_fd = os.pipe()
+
+    async def spawn_blocking_process(self, _prompt, encoding, errors):
+        return await self._spawn_blocking_process(encoding, errors)
+
+    monkeypatch.setattr(repl_module._StdinReader, "_spawn_process", spawn_blocking_process)
+    os.write(write_fd, b"first\nsecond\nquit\n")
+    os.close(write_fd)
+    with os.fdopen(read_fd, encoding="utf-8") as stdin:
+        monkeypatch.setattr(sys, "stdin", stdin)
+        await run_demo_loop(agent, stream=False)
+
+    assert len(model.calls) == 2
+    assert model.calls[0].input == [get_text_input_item("first")]
+    assert model.calls[1].input[-1] == get_text_input_item("second")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGINT behavior is under test")
+@pytest.mark.parametrize("composed", [False, True])
+@pytest.mark.asyncio
+async def test_run_demo_loop_ctrl_c_does_not_wait_for_stdin_worker(composed: bool):
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    python_path = str(repo_root / "src")
+    if existing_path := env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, existing_path])
+    env["PYTHONPATH"] = python_path
+
+    entrypoint = (
+        "async def main():\n"
+        "    task = asyncio.create_task(\n"
+        "        run_demo_loop(Agent(name='test'), stream=False)\n"
+        "    )\n"
+        "    await task\n"
+        "asyncio.run(main())\n"
+        if composed
+        else "asyncio.run(run_demo_loop(Agent(name='test'), stream=False))\n"
+    )
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        (
+            "import asyncio\n"
+            "from agents import Agent, run_demo_loop\n"
+            f"{entrypoint}"
+            "print('RETURNED', flush=True)\n"
+        ),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+    assert process.stdin is not None
+
+    try:
+        prompt = await asyncio.wait_for(process.stdout.readexactly(3), timeout=5)
+        assert prompt == b" > "
+
+        process.send_signal(signal.SIGINT)
+        await asyncio.wait_for(process.wait(), timeout=5)
+        stdout = await process.stdout.read()
+        stderr = await process.stderr.read()
+    finally:
+        process.stdin.close()
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            await process.stdin.wait_closed()
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+
+    assert process.returncode == 0
+    assert stdout == b"\nRETURNED\n"
+    assert stderr == b""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGINT behavior is under test")
+@pytest.mark.parametrize("raises_keyboard_interrupt", [False, True])
+@pytest.mark.asyncio
+async def test_run_demo_loop_preserves_custom_sigint_handler(raises_keyboard_interrupt: bool):
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    python_path = str(repo_root / "src")
+    if existing_path := env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, existing_path])
+    env["PYTHONPATH"] = python_path
+
+    handler_body = "    os.write(1, b'HANDLED\\n')\n"
+    if raises_keyboard_interrupt:
+        handler_body += "    raise KeyboardInterrupt\n"
+
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        (
+            "import asyncio, os, signal\n"
+            "from agents import Agent, run_demo_loop\n"
+            "def handle_sigint(signum, frame):\n"
+            f"{handler_body}"
+            "signal.signal(signal.SIGINT, handle_sigint)\n"
+            "asyncio.run(run_demo_loop(Agent(name='test'), stream=False))\n"
+            "print('RETURNED', flush=True)\n"
+        ),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+    assert process.stdin is not None
+
+    try:
+        prompt = await asyncio.wait_for(process.stdout.readexactly(3), timeout=5)
+        assert prompt == b" > "
+
+        process.send_signal(signal.SIGINT)
+        handled = await asyncio.wait_for(process.stdout.readline(), timeout=5)
+        assert handled == b"HANDLED\n"
+        if not raises_keyboard_interrupt:
+            assert process.returncode is None
+            process.stdin.write(b"quit\n")
+            await process.stdin.drain()
+        await asyncio.wait_for(process.wait(), timeout=5)
+        stdout = await process.stdout.read()
+        stderr = await process.stderr.read()
+    finally:
+        process.stdin.close()
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            await process.stdin.wait_closed()
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+
+    assert process.returncode == 0
+    assert stdout == (b"\nRETURNED\n" if raises_keyboard_interrupt else b"RETURNED\n")
+    assert stderr == b""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX terminal behavior is under test")
+@pytest.mark.asyncio
+async def test_run_demo_loop_preserves_readline_history():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    python_path = str(repo_root / "src")
+    if existing_path := env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, existing_path])
+    env["PYTHONPATH"] = python_path
+    expect = shutil.which("expect")
+    if expect is None:
+        pytest.skip("expect is required for the POSIX readline regression")
+    child_code = (
+        "import asyncio, readline\n"
+        "from agents import Agent, run_demo_loop\n"
+        "from agents.testing import ScriptedModel\n"
+        "from tests.test_responses import get_text_message\n"
+        "model = ScriptedModel()\n"
+        "model.extend([[get_text_message('ok')]])\n"
+        "readline.add_history('quit')\n"
+        "asyncio.run(run_demo_loop(Agent(name='test', model=model), stream=False))\n"
+        "print('CALLS=' + str(len(model.calls)), flush=True)\n"
+    )
+    expect_script = (
+        "log_user 1\n"
+        "set timeout 5\n"
+        f"spawn {{{sys.executable}}} -c {{{child_code}}}\n"
+        'expect " > "\n'
+        'send "\\033\\[A"\n'
+        'expect "quit"\n'
+        'send "\\r"\n'
+        "expect eof\n"
+    )
+    process = await asyncio.create_subprocess_exec(
+        expect,
+        "-c",
+        expect_script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+
+    assert process.returncode == 0, stderr.decode()
+    assert b"CALLS=0" in stdout
+    assert b"^[[A" not in stdout
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX terminal behavior is under test")
+@pytest.mark.asyncio
+async def test_run_demo_loop_reads_terminal_without_readline():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    python_path = str(repo_root / "src")
+    if existing_path := env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, existing_path])
+    env["PYTHONPATH"] = python_path
+    expect = shutil.which("expect")
+    if expect is None:
+        pytest.skip("expect is required for the POSIX terminal regression")
+    child_code = (
+        "import asyncio, sys\n"
+        "from agents import Agent, run_demo_loop\n"
+        "assert 'readline' not in sys.modules\n"
+        "asyncio.run(run_demo_loop(Agent(name='test'), stream=False))\n"
+        "print('RETURNED', flush=True)\n"
+    )
+    expect_script = (
+        "log_user 1\n"
+        "set timeout 5\n"
+        f"spawn {{{sys.executable}}} -c {{{child_code}}}\n"
+        "expect {\n"
+        '    " > " {}\n'
+        "    timeout { exit 2 }\n"
+        "    eof { exit 3 }\n"
+        "}\n"
+        'send "quit\\r"\n'
+        "expect {\n"
+        '    "RETURNED" {}\n'
+        "    timeout { exit 4 }\n"
+        "    eof { exit 5 }\n"
+        "}\n"
+        "expect eof\n"
+    )
+    process = await asyncio.create_subprocess_exec(
+        expect,
+        "-c",
+        expect_script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+
+    assert process.returncode == 0, (stdout + stderr).decode()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX readline history is under test")
+@pytest.mark.asyncio
+async def test_run_demo_loop_updates_parent_readline_history():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    python_path = str(repo_root / "src")
+    if existing_path := env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, existing_path])
+    env["PYTHONPATH"] = python_path
+    expect = shutil.which("expect")
+    if expect is None:
+        pytest.skip("expect is required for the POSIX readline regression")
+    child_code = (
+        "import asyncio, readline\n"
+        "from agents import Agent, run_demo_loop\n"
+        "readline.clear_history()\n"
+        "asyncio.run(run_demo_loop(Agent(name='test'), stream=False))\n"
+        "history = [readline.get_history_item(index) for index in "
+        "range(1, readline.get_current_history_length() + 1)]\n"
+        "print('HISTORY=' + repr(history), flush=True)\n"
+    )
+    expect_script = (
+        "log_user 1\n"
+        "set timeout 5\n"
+        f"spawn {{{sys.executable}}} -c {{{child_code}}}\n"
+        'expect " > "\n'
+        'send "\\r"\n'
+        'expect " > "\n'
+        'send "   \\r"\n'
+        'expect " > "\n'
+        'send "   \\r"\n'
+        'expect " > "\n'
+        'send "quit\\r"\n'
+        "expect eof\n"
+    )
+    process = await asyncio.create_subprocess_exec(
+        expect,
+        "-c",
+        expect_script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+
+    assert process.returncode == 0, stderr.decode()
+    assert b"HISTORY=['   ', 'quit']" in stdout
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX terminal SIGINT is under test")
+@pytest.mark.asyncio
+async def test_run_demo_loop_ctrl_c_reaps_terminal_input_helper():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    python_path = str(repo_root / "src")
+    if existing_path := env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, existing_path])
+    env["PYTHONPATH"] = python_path
+    expect = shutil.which("expect")
+    if expect is None:
+        pytest.skip("expect is required for the POSIX terminal regression")
+    child_code = (
+        "import asyncio\n"
+        "from agents import Agent, run_demo_loop\n"
+        "asyncio.run(run_demo_loop(Agent(name='test'), stream=False))\n"
+    )
+    expect_script = (
+        "log_user 1\n"
+        "set timeout 5\n"
+        f"spawn {{{sys.executable}}} -c {{{child_code}}}\n"
+        'expect " > "\n'
+        'send "\\003"\n'
+        "expect eof\n"
+    )
+    process = await asyncio.create_subprocess_exec(
+        expect,
+        "-c",
+        expect_script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    _, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+
+    assert process.returncode == 0, stderr.decode()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX terminal cleanup is under test")
+@pytest.mark.asyncio
+async def test_run_demo_loop_cancellation_restores_terminal_mode():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    python_path = str(repo_root / "src")
+    if existing_path := env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, existing_path])
+    env["PYTHONPATH"] = python_path
+    expect = shutil.which("expect")
+    if expect is None:
+        pytest.skip("expect is required for the POSIX terminal regression")
+    child_code = (
+        "import asyncio, readline, sys, termios\n"
+        "from agents import Agent, run_demo_loop\n"
+        "async def main():\n"
+        "    before = termios.tcgetattr(sys.stdin.fileno())\n"
+        "    task = asyncio.create_task(run_demo_loop(Agent(name='test'), stream=False))\n"
+        "    while termios.tcgetattr(sys.stdin.fileno()) == before:\n"
+        "        await asyncio.sleep(0)\n"
+        "    task.cancel()\n"
+        "    try:\n"
+        "        await task\n"
+        "    except asyncio.CancelledError:\n"
+        "        pass\n"
+        "    assert termios.tcgetattr(sys.stdin.fileno()) == before\n"
+        "    print('TERMINAL_RESTORED', flush=True)\n"
+        "asyncio.run(main())\n"
+    )
+    expect_script = (
+        "log_user 1\n"
+        "set timeout 5\n"
+        f"spawn {{{sys.executable}}} -c {{{child_code}}}\n"
+        'expect "TERMINAL_RESTORED"\n'
+        "expect eof\n"
+    )
+    process = await asyncio.create_subprocess_exec(
+        expect,
+        "-c",
+        expect_script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    _, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+
+    assert process.returncode == 0, stderr.decode()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX cancellation is under test")
+@pytest.mark.asyncio
+async def test_run_demo_loop_ctrl_c_interrupts_continuously_readable_stdin():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    python_path = str(repo_root / "src")
+    if existing_path := env.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, existing_path])
+    env["PYTHONPATH"] = python_path
+
+    with open("/dev/zero", "rb") as stdin:
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            (
+                "import asyncio\n"
+                "from agents import Agent, run_demo_loop\n"
+                "asyncio.run(run_demo_loop(Agent(name='test'), stream=False))\n"
+            ),
+            stdin=stdin,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        assert process.stdout is not None
+        assert process.stderr is not None
+
+        try:
+            prompt = await asyncio.wait_for(process.stdout.readexactly(3), timeout=5)
+            assert prompt == b" > "
+
+            process.send_signal(signal.SIGINT)
+            await asyncio.wait_for(process.wait(), timeout=5)
+        finally:
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
+
+    assert process.returncode == 0
+
+
+@pytest.mark.parametrize("blocking_subprocess", [False, True])
+@pytest.mark.asyncio
+async def test_stdin_helper_is_reaped_on_cancellation(monkeypatch, capsys, blocking_subprocess):
+    read_fd, write_fd = os.pipe()
+    process_created = asyncio.Event()
+    created_process: Any = None
+    real_spawn_process = repl_module._StdinReader._spawn_process
+
+    async def spawn_process(self, prompt, encoding, errors):
+        nonlocal created_process
+        if blocking_subprocess:
+            created_process = await self._spawn_blocking_process(encoding, errors)
+        else:
+            created_process = await real_spawn_process(self, prompt, encoding, errors)
+        process_created.set()
+        return created_process
+
+    monkeypatch.setattr(repl_module._StdinReader, "_spawn_process", spawn_process)
+
+    with os.fdopen(read_fd, encoding="utf-8") as stdin:
+        monkeypatch.setattr(sys, "stdin", stdin)
+        agent = Agent(name="test", model=ScriptedModel())
+        read_task = asyncio.create_task(run_demo_loop(agent, stream=False))
+        try:
+            await asyncio.wait_for(process_created.wait(), timeout=5)
+            read_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(read_task, timeout=5)
+        finally:
+            os.close(write_fd)
+
+    assert created_process is not None
+    assert created_process.returncode is not None
+
+
+@pytest.mark.asyncio
+async def test_handled_sigint_does_not_mask_later_prompt_cancellation(monkeypatch):
+    model_started = asyncio.Event()
+    release_model = asyncio.Event()
+    prompt_pending = asyncio.Event()
+    signal_seen = False
+
+    class PromptReader(repl_module._StdinReader):
+        def __init__(self) -> None:
+            super().__init__(sys.stdin)
+            self.calls = 0
+
+        async def _readline(self, _prompt: str) -> str:
+            self.calls += 1
+            if self.calls == 1:
+                return "hello"
+            prompt_pending.set()
+            await asyncio.Future()
+            raise AssertionError("The pending prompt should be cancelled.")
+
+        async def aclose(self) -> None:
+            self._restore_sigint_handler()
+
+    class FakeRunner:
+        @staticmethod
+        async def run(agent, input_items, context=None, max_turns=None):
+            model_started.set()
+            await release_model.wait()
+            return type(
+                "Result",
+                (),
+                {
+                    "final_output": None,
+                    "last_agent": agent,
+                    "to_input_list": lambda self: input_items,
+                },
+            )()
+
+    def handle_sigint(_signum, _frame) -> None:
+        nonlocal signal_seen
+        signal_seen = True
+
+    previous_handler = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGINT, handle_sigint)
+    reader = PromptReader()
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+    monkeypatch.setattr(repl_module, "Runner", FakeRunner)
+
+    try:
+        task = asyncio.create_task(
+            run_demo_loop(Agent(name="test", model=ScriptedModel()), stream=False)
+        )
+        await asyncio.wait_for(model_started.wait(), timeout=5)
+        current_handler = signal.getsignal(signal.SIGINT)
+        assert callable(current_handler)
+        current_handler(signal.SIGINT, None)
+        release_model.set()
+        await asyncio.wait_for(prompt_pending.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        reader._restore_sigint_handler()
+        signal.signal(signal.SIGINT, previous_handler)
+
+    assert signal_seen
+
+
+@pytest.mark.asyncio
+async def test_programmatic_cancellation_wins_over_overlapping_sigint(monkeypatch):
+    prompt_pending = asyncio.Event()
+    signal_seen = False
+
+    class PromptReader(repl_module._StdinReader):
+        async def _readline(self, _prompt: str) -> str:
+            prompt_pending.set()
+            await asyncio.Future()
+            raise AssertionError("The pending prompt should be cancelled.")
+
+        async def aclose(self) -> None:
+            self._restore_sigint_handler()
+
+    def handle_sigint(_signum, _frame) -> None:
+        nonlocal signal_seen
+        signal_seen = True
+
+    previous_handler = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGINT, handle_sigint)
+    reader = PromptReader(sys.stdin)
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+
+    try:
+        task = asyncio.create_task(
+            run_demo_loop(Agent(name="test", model=ScriptedModel()), stream=False)
+        )
+        await asyncio.wait_for(prompt_pending.wait(), timeout=5)
+        task.cancel("programmatic")
+        current_handler = signal.getsignal(signal.SIGINT)
+        assert callable(current_handler)
+        current_handler(signal.SIGINT, None)
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        reader._restore_sigint_handler()
+        signal.signal(signal.SIGINT, previous_handler)
+
+    assert signal_seen
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_prompt_sigint_cleanup_is_propagated(monkeypatch):
+    prompt_pending = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    class PromptReader(repl_module._StdinReader):
+        async def _readline(self, _prompt: str) -> str:
+            prompt_pending.set()
+            try:
+                await asyncio.Future()
+            finally:
+                cleanup_started.set()
+                await release_cleanup.wait()
+            raise AssertionError("The interrupted prompt should not return.")
+
+        async def aclose(self) -> None:
+            self._restore_sigint_handler()
+
+    reader = PromptReader(sys.stdin)
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+
+    try:
+        task = asyncio.create_task(
+            run_demo_loop(Agent(name="test", model=ScriptedModel()), stream=False)
+        )
+        await asyncio.wait_for(prompt_pending.wait(), timeout=5)
+        current_handler = signal.getsignal(signal.SIGINT)
+        assert callable(current_handler)
+        current_handler(signal.SIGINT, None)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=5)
+        task.cancel("programmatic")
+        release_cleanup.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        release_cleanup.set()
+        reader._restore_sigint_handler()
+
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_input_error_does_not_replace_concurrent_cancellation(monkeypatch):
+    class EOFReader(repl_module._StdinReader):
+        def __init__(self) -> None:
+            super().__init__(sys.stdin)
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def _readline(self, _prompt: str) -> str:
+            self.started.set()
+            await self.release.wait()
+            raise EOFError
+
+        async def aclose(self) -> None:
+            self._restore_sigint_handler()
+
+    reader = EOFReader()
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+    task = asyncio.create_task(
+        run_demo_loop(Agent(name="test", model=ScriptedModel()), stream=False)
+    )
+    await reader.started.wait()
+
+    reader.release.set()
+    task.cancel("caller cancellation")
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_handled_prompt_sigint_leaves_no_task_cancellation(monkeypatch):
+    prompt_pending = asyncio.Event()
+
+    class PromptReader(repl_module._StdinReader):
+        async def _readline(self, _prompt: str) -> str:
+            prompt_pending.set()
+            await asyncio.Future()
+            raise AssertionError("The pending prompt should be interrupted.")
+
+        async def aclose(self) -> None:
+            self._restore_sigint_handler()
+
+    reader = PromptReader(sys.stdin)
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+
+    try:
+        task = asyncio.create_task(
+            run_demo_loop(Agent(name="test", model=ScriptedModel()), stream=False)
+        )
+        await asyncio.wait_for(prompt_pending.wait(), timeout=5)
+        current_handler = signal.getsignal(signal.SIGINT)
+        assert callable(current_handler)
+        current_handler(signal.SIGINT, None)
+        await task
+    finally:
+        reader._restore_sigint_handler()
+
+    assert not task.cancelled()
+    cancelling = getattr(task, "cancelling", None)
+    if cancelling is not None:
+        assert cancelling() == 0
+
+
+_CLEANUP_PROCESS_KILLED = -1
+
+
+class _CleanupProcess:
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.waiting = asyncio.Event()
+        self.release = asyncio.Event()
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = _CLEANUP_PROCESS_KILLED
+
+    async def wait(self) -> int:
+        self.waiting.set()
+        await self.release.wait()
+        assert self.returncode is not None
+        return self.returncode
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_stdin_cleanup_is_propagated(monkeypatch):
+    class QuittingReader(repl_module._StdinReader):
+        async def readline(self, _prompt: str) -> str:
+            return "quit"
+
+    process = _CleanupProcess()
+    reader = QuittingReader(sys.stdin)
+    reader._process = cast(Any, process)
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+
+    task = asyncio.create_task(
+        run_demo_loop(Agent(name="test", model=ScriptedModel()), stream=False)
+    )
+    await asyncio.wait_for(process.waiting.wait(), timeout=5)
+    task.cancel()
+    await asyncio.sleep(0)
+    process.release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.killed
+    assert process.returncode == _CLEANUP_PROCESS_KILLED
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_stdin_cleanup_preserves_body_error(monkeypatch):
+    class FailingReader(repl_module._StdinReader):
+        async def readline(self, _prompt: str) -> str:
+            raise RuntimeError("body failed")
+
+    process = _CleanupProcess()
+    reader = FailingReader(sys.stdin)
+    reader._process = cast(Any, process)
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+
+    task = asyncio.create_task(
+        run_demo_loop(Agent(name="test", model=ScriptedModel()), stream=False)
+    )
+    await asyncio.wait_for(process.waiting.wait(), timeout=5)
+    task.cancel("cleanup cancellation")
+    await asyncio.sleep(0)
+    process.release.set()
+
+    with pytest.raises(RuntimeError, match="body failed"):
+        await task
+
+    assert process.killed
+    assert process.returncode == _CLEANUP_PROCESS_KILLED
+
+
+@pytest.mark.asyncio
+async def test_caller_error_does_not_mask_cancellation_during_stdin_cleanup(monkeypatch):
+    class QuittingReader(repl_module._StdinReader):
+        async def readline(self, _prompt: str) -> str:
+            return "quit"
+
+    process = _CleanupProcess()
+    reader = QuittingReader(sys.stdin)
+    reader._process = cast(Any, process)
+    monkeypatch.setattr(repl_module, "_create_stdin_reader", lambda: reader)
+
+    async def run_with_active_caller_error() -> None:
+        try:
+            raise LookupError("caller error")
+        except LookupError:
+            await run_demo_loop(Agent(name="test", model=ScriptedModel()), stream=False)
+
+    task = asyncio.create_task(run_with_active_caller_error())
+    await asyncio.wait_for(process.waiting.wait(), timeout=5)
+    task.cancel("cleanup cancellation")
+    await asyncio.sleep(0)
+    process.release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.killed
+    assert process.returncode == _CLEANUP_PROCESS_KILLED


### PR DESCRIPTION
This pull request fixes #4670 by moving `run_demo_loop()` prompt reads off the event loop while giving the REPL deterministic ownership of input cancellation and shutdown.

It preserves normal interactive input, EOF, `quit`/`exit`, readline history, custom SIGINT handlers, and buffered multi-line redirected input across prompts. It also reaps the owned helper after Ctrl+C or programmatic cancellation and adds cross-platform deterministic regression coverage.

Callers that need to consume or frame `sys.stdin` before starting the interactive loop should drive `Runner` directly. This implementation takes over #4671 and preserves the original contributor's authorship with a co-author trailer.