### PR TITLE
Reject kwargs keys that collide with named tool parameters

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -13,7 +13,7 @@ from griffe import Docstring, DocstringSectionKind  # type: ignore[import-untype
 from pydantic import BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
 
-from .exceptions import UserError
+from .exceptions import ModelBehaviorError, UserError
 from .run_context import RunContextWrapper
 from .strict_schema import ensure_strict_json_schema
 from .tool_context import ToolContext
@@ -51,6 +51,13 @@ class FuncSchema:
         positional_args: list[Any] = []
         keyword_args: dict[str, Any] = {}
         seen_var_positional = False
+        named_parameter_names = {
+            name
+            for idx, (name, param) in enumerate(self.signature.parameters.items())
+            if not (self.takes_context and idx == 0)
+            and param.kind
+            in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+        }
         # Read instance storage first so Pydantic properties such as ``model_extra``
         # and ``model_fields_set`` do not shadow tool parameters of the same name.
         # ``model_dump()`` is unsuitable here because it converts nested models to dicts.
@@ -69,7 +76,15 @@ class FuncSchema:
                 seen_var_positional = True
             elif param.kind == param.VAR_KEYWORD:
                 # e.g. **kwargs handling
-                keyword_args.update(value or {})
+                var_keyword_args = value or {}
+                collisions = var_keyword_args.keys() & named_parameter_names
+                if collisions:
+                    names = ", ".join(sorted(collisions))
+                    raise ModelBehaviorError(
+                        f"Invalid tool arguments: **{name} contains keys that conflict with "
+                        f"named arguments: {names}"
+                    )
+                keyword_args.update(var_keyword_args)
             elif param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
                 # Before *args, add to positional args. After *args, add to keyword args.
                 if not seen_var_positional:

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -8,7 +8,7 @@ from pydantic.json_schema import PydanticJsonSchemaWarning
 from typing_extensions import TypedDict
 
 from agents import RunContextWrapper, function_tool
-from agents.exceptions import UserError
+from agents.exceptions import ModelBehaviorError, UserError
 from agents.function_schema import function_schema, generate_func_documentation
 
 
@@ -171,6 +171,28 @@ def test_varargs_function():
     result2 = varargs_function(*args2, **kwargs_dict2)
     # result2 should be (7, (9.9,), False, {'some_key': 'some_value'})
     assert result2 == (7, (9.9,), False, {"some_key": "some_value"})
+
+
+def test_to_call_args_rejects_kwargs_colliding_with_keyword_only_argument():
+    def func(*, option: int, **kwargs: Any) -> None:
+        pass
+
+    func_schema = function_schema(func, strict_json_schema=False)
+    parsed = func_schema.params_pydantic_model(option=5, kwargs={"option": 9})
+
+    with pytest.raises(ModelBehaviorError, match="option"):
+        func_schema.to_call_args(parsed)
+
+
+def test_to_call_args_rejects_kwargs_colliding_with_positional_argument():
+    def func(value: int, *args: int, **kwargs: Any) -> None:
+        pass
+
+    func_schema = function_schema(func, strict_json_schema=False)
+    parsed = func_schema.params_pydantic_model(value=1, args=[2], kwargs={"value": 9})
+
+    with pytest.raises(ModelBehaviorError, match="value"):
+        func_schema.to_call_args(parsed)
 
 
 class Foo(TypedDict):


### PR DESCRIPTION
## Summary

`FuncSchema.to_call_args` could silently overwrite a validated named argument, or produce an invalid Python call, when a `**kwargs` key collided with a named function parameter.

This change rejects those collisions with `ModelBehaviorError` before invocation. Non-conflicting `**kwargs` continue to be passed through unchanged.

## Testing

- `uv run --frozen pytest tests/test_function_schema.py -q` (41 passed)
- `uv run --frozen ruff check src/agents/function_schema.py tests/test_function_schema.py`
- `git diff --check`

Mypy was attempted but did not complete on the local Windows environment.
