### PR TITLE
fix(tracing): close the default exporter at shutdown

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -761,3 +761,10 @@ def default_processor() -> BatchTraceProcessor:
             _global_processor = processor
 
     return processor
+
+
+def shutdown_default_exporter() -> None:
+    """Close the lazily-created default exporter, if tracing initialized it."""
+    exporter = _global_exporter
+    if exporter is not None:
+        exporter.close()

--- a/src/agents/tracing/setup.py
+++ b/src/agents/tracing/setup.py
@@ -20,6 +20,9 @@ def _shutdown_global_trace_provider() -> None:
 
         if isinstance(provider, DefaultTraceProvider):
             provider.shutdown(timeout=_DEFAULT_SHUTDOWN_TIMEOUT)
+            from .processors import shutdown_default_exporter
+
+            shutdown_default_exporter()
             return
         provider.shutdown()
 

--- a/src/agents/tracing/setup.py
+++ b/src/agents/tracing/setup.py
@@ -18,14 +18,15 @@ def _shutdown_global_trace_provider() -> None:
     if provider is not None:
         from .provider import DefaultTraceProvider
 
-        if isinstance(provider, DefaultTraceProvider):
-            provider.shutdown(timeout=_DEFAULT_SHUTDOWN_TIMEOUT)
-        else:
-            provider.shutdown()
+        try:
+            if isinstance(provider, DefaultTraceProvider):
+                provider.shutdown(timeout=_DEFAULT_SHUTDOWN_TIMEOUT)
+            else:
+                provider.shutdown()
+        finally:
+            from .processors import shutdown_default_exporter
 
-        from .processors import shutdown_default_exporter
-
-        shutdown_default_exporter()
+            shutdown_default_exporter()
 
 
 def set_trace_provider(provider: TraceProvider) -> None:

--- a/src/agents/tracing/setup.py
+++ b/src/agents/tracing/setup.py
@@ -20,11 +20,12 @@ def _shutdown_global_trace_provider() -> None:
 
         if isinstance(provider, DefaultTraceProvider):
             provider.shutdown(timeout=_DEFAULT_SHUTDOWN_TIMEOUT)
-            from .processors import shutdown_default_exporter
+        else:
+            provider.shutdown()
 
-            shutdown_default_exporter()
-            return
-        provider.shutdown()
+        from .processors import shutdown_default_exporter
+
+        shutdown_default_exporter()
 
 
 def set_trace_provider(provider: TraceProvider) -> None:

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -451,6 +451,33 @@ def test_global_default_provider_shutdown_closes_default_exporter(monkeypatch):
     exporter.close.assert_called_once_with()
 
 
+def test_custom_provider_shutdown_closes_default_exporter(monkeypatch):
+    provider = MagicMock()
+    exporter = MagicMock()
+
+    monkeypatch.setattr(tracing_setup, "GLOBAL_TRACE_PROVIDER", provider)
+    monkeypatch.setattr("agents.tracing.processors._global_exporter", exporter)
+
+    tracing_setup._shutdown_global_trace_provider()
+
+    provider.shutdown.assert_called_once_with()
+    exporter.close.assert_called_once_with()
+
+
+def test_default_exporter_closes_when_provider_shutdown_fails(monkeypatch):
+    provider = MagicMock()
+    provider.shutdown.side_effect = RuntimeError("provider shutdown failed")
+    exporter = MagicMock()
+
+    monkeypatch.setattr(tracing_setup, "GLOBAL_TRACE_PROVIDER", provider)
+    monkeypatch.setattr("agents.tracing.processors._global_exporter", exporter)
+
+    with pytest.raises(RuntimeError, match="provider shutdown failed"):
+        tracing_setup._shutdown_global_trace_provider()
+
+    exporter.close.assert_called_once_with()
+
+
 def mock_processor():
     processor = MagicMock()
     processor.on_trace_start = MagicMock()

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -12,7 +12,7 @@ import httpx2
 import pytest
 
 import agents._debug as _debug
-from agents.tracing import flush_traces, get_trace_provider
+from agents.tracing import flush_traces, get_trace_provider, setup as tracing_setup
 from agents.tracing.processor_interface import TracingExporter, TracingProcessor
 from agents.tracing.processors import BackendSpanExporter, BatchTraceProcessor, ConsoleSpanExporter
 from agents.tracing.provider import DefaultTraceProvider, TraceProvider
@@ -435,6 +435,20 @@ def test_get_trace_provider_force_flush_flushes_default_processor(mocked_exporte
     )
     assert total_exported == 2
     processor.shutdown()
+
+
+def test_global_default_provider_shutdown_closes_default_exporter(monkeypatch):
+    provider = DefaultTraceProvider()
+    exporter = MagicMock()
+
+    monkeypatch.setattr(tracing_setup, "GLOBAL_TRACE_PROVIDER", provider)
+    monkeypatch.setattr("agents.tracing.processors._global_exporter", exporter)
+    monkeypatch.setattr(provider, "shutdown", MagicMock())
+
+    tracing_setup._shutdown_global_trace_provider()
+
+    provider.shutdown.assert_called_once_with(timeout=5.0)
+    exporter.close.assert_called_once_with()
 
 
 def mock_processor():

--- a/tests/tracing/test_setup.py
+++ b/tests/tracing/test_setup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import atexit
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -59,6 +60,19 @@ def test_shutdown_global_trace_provider_passes_timeout_to_default_provider(
     tracing_setup._shutdown_global_trace_provider()
 
     assert provider.shutdown_timeout == tracing_setup._DEFAULT_SHUTDOWN_TIMEOUT
+
+
+def test_custom_provider_shutdown_closes_default_exporter(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _DummyProvider()
+    exporter = MagicMock()
+
+    monkeypatch.setattr(tracing_setup, "GLOBAL_TRACE_PROVIDER", provider)
+    monkeypatch.setattr("agents.tracing.processors._global_exporter", exporter)
+
+    tracing_setup._shutdown_global_trace_provider()
+
+    assert provider.shutdown_calls == 1
+    exporter.close.assert_called_once_with()
 
 
 def test_set_trace_provider_registers_shutdown_once(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #4681

`BackendSpanExporter` owns a pooled HTTP client, but the default tracing shutdown chain only stopped the processor and never closed that client. This can leave the tracing connection pool open until interpreter teardown and leak a client when the default provider is replaced.

This change adds an explicit setup-boundary cleanup for the lazily-created default exporter after the default provider has flushed and shut down. Injected exporters remain untouched because `BatchTraceProcessor` does not own arbitrary exporter instances.

Tests:
- `uv run --frozen pytest tests/test_trace_processor.py tests/test_tracing.py tests/test_tracing_errors.py tests/tracing -q` (159 passed)
- `uv run --frozen ruff format --check src/agents/tracing/processors.py src/agents/tracing/setup.py tests/test_trace_processor.py`
- `uv run --frozen ruff check src/agents/tracing/processors.py src/agents/tracing/setup.py tests/test_trace_processor.py`
- `uv run --frozen mypy src/agents/tracing/processors.py src/agents/tracing/setup.py`
- `git diff --check`

The focused suite reports one pre-existing Python 3.16 deprecation warning from `asyncio.get_event_loop_policy`.
