### PR TITLE
feat(modal): support OIDC bucket mounts

### DIFF
--- a/src/agents/extensions/sandbox/modal/mounts.py
+++ b/src/agents/extensions/sandbox/modal/mounts.py
@@ -23,12 +23,14 @@ class ModalCloudBucketMountConfig:
     secret_name: str | None = None
     secret_environment_name: str | None = None
     read_only: bool = True
+    oidc_auth_role_arn: str | None = None
 
 
 class ModalCloudBucketMountStrategy(MountStrategyBase):
     type: Literal["modal_cloud_bucket"] = "modal_cloud_bucket"
     secret_name: str | None = None
     secret_environment_name: str | None = None
+    oidc_auth_role_arn: str | None = None
 
     def validate_mount(self, mount: Mount) -> None:
         _ = self._build_modal_cloud_bucket_mount_config(mount)
@@ -117,6 +119,24 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                 ),
                 context={"mount_type": mount.type},
             )
+        if self.oidc_auth_role_arn is not None and self.oidc_auth_role_arn == "":
+            raise MountConfigError(
+                message="modal cloud bucket oidc_auth_role_arn must be a non-empty string",
+                context={"mount_type": mount.type},
+            )
+        if self.oidc_auth_role_arn is not None and not isinstance(mount, S3Mount):
+            raise MountConfigError(
+                message="modal cloud bucket OIDC authentication is only supported for S3 mounts",
+                context={"mount_type": mount.type},
+            )
+        if self.oidc_auth_role_arn is not None and self.secret_name is not None:
+            raise MountConfigError(
+                message=(
+                    "modal cloud bucket mounts do not support both oidc_auth_role_arn "
+                    "and secret_name"
+                ),
+                context={"mount_type": mount.type},
+            )
 
         if isinstance(mount, S3Mount):
             s3_credentials: dict[str, str] = {}
@@ -134,6 +154,14 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                     ),
                     context={"mount_type": mount.type},
                 )
+            if self.oidc_auth_role_arn is not None and s3_credentials:
+                raise MountConfigError(
+                    message=(
+                        "modal cloud bucket mounts do not support both oidc_auth_role_arn "
+                        "and inline credentials"
+                    ),
+                    context={"mount_type": mount.type},
+                )
             return ModalCloudBucketMountConfig(
                 bucket_name=mount.bucket,
                 bucket_endpoint_url=mount.endpoint_url,
@@ -142,6 +170,7 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                 secret_name=self.secret_name,
                 secret_environment_name=self.secret_environment_name,
                 read_only=mount.read_only,
+                oidc_auth_role_arn=self.oidc_auth_role_arn,
             )
 
         if isinstance(mount, R2Mount):

--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -2028,6 +2028,7 @@ class ModalSandboxSession(BaseSandboxSession):
                 bucket_endpoint_url=config.bucket_endpoint_url,
                 key_prefix=config.key_prefix,
                 secret=secret,
+                oidc_auth_role_arn=config.oidc_auth_role_arn,
                 read_only=config.read_only,
             )
         return volumes

--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -157,7 +157,11 @@ _CANONICAL_MOUNT_TYPES: tuple[tuple[type[Mount], str], ...] = (
 # from durable state as a unit.
 _OPAQUE_STRATEGY_AUTHORITY_FIELDS: dict[str, tuple[str, ...]] = {
     "docker_volume": ("driver_options",),
-    "modal_cloud_bucket": ("secret_name", "secret_environment_name"),
+    "modal_cloud_bucket": (
+        "secret_name",
+        "secret_environment_name",
+        "oidc_auth_role_arn",
+    ),
 }
 
 # SDK-owned extension entry types are not necessarily imported when raw RunState is restored.
@@ -263,7 +267,9 @@ _SERIALIZED_FIELDS_BY_STRATEGY_TYPE: dict[str, frozenset[str]] = {
     "cloudflare_bucket_mount": frozenset({"type"}),
     "daytona_cloud_bucket": frozenset({"type", "pattern"}),
     "e2b_cloud_bucket": frozenset({"type", "pattern"}),
-    "modal_cloud_bucket": frozenset({"type", "secret_name", "secret_environment_name"}),
+    "modal_cloud_bucket": frozenset(
+        {"type", "secret_name", "secret_environment_name", "oidc_auth_role_arn"}
+    ),
     "runloop_cloud_bucket": frozenset({"type", "pattern"}),
     "vercel_cloud_bucket": frozenset({"type"}),
 }

--- a/tests/extensions/sandbox/test_modal.py
+++ b/tests/extensions/sandbox/test_modal.py
@@ -382,12 +382,14 @@ def _load_modal_module(
             bucket_endpoint_url: str | None = None,
             key_prefix: str | None = None,
             secret: _FakeSecret | None = None,
+            oidc_auth_role_arn: str | None = None,
             read_only: bool = True,
         ) -> None:
             self.bucket_name = bucket_name
             self.bucket_endpoint_url = bucket_endpoint_url
             self.key_prefix = key_prefix
             self.secret = secret
+            self.oidc_auth_role_arn = oidc_auth_role_arn
             self.read_only = read_only
 
     class _FakeConfig:
@@ -878,6 +880,34 @@ async def test_modal_sandbox_create_passes_named_modal_secret_environment_for_cl
     assert mount.secret.value is None
 
 
+@pytest.mark.asyncio
+async def test_modal_sandbox_create_passes_oidc_role_for_cloud_bucket_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, create_calls, _registry_tags = _load_modal_module(monkeypatch)
+
+    client = modal_module.ModalSandboxClient()
+    await client.create(
+        manifest=Manifest(
+            entries={
+                "remote": S3Mount(
+                    bucket="bucket",
+                    mount_strategy=modal_module.ModalCloudBucketMountStrategy(
+                        oidc_auth_role_arn="arn:aws:iam::123456789012:role/modal-s3-reader"
+                    ),
+                )
+            }
+        ),
+        options=modal_module.ModalSandboxClientOptions(app_name="sandbox-tests"),
+    )
+
+    volumes = create_calls[0]["volumes"]
+    assert isinstance(volumes, dict)
+    mount = volumes["/workspace/remote"]
+    assert mount.secret is None
+    assert mount.oidc_auth_role_arn == "arn:aws:iam::123456789012:role/modal-s3-reader"
+
+
 def test_modal_cloud_bucket_mount_strategy_round_trips_through_manifest_parse(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -926,6 +956,35 @@ def test_modal_cloud_bucket_mount_strategy_round_trips_secret_name_through_manif
     assert isinstance(mount, S3Mount)
     assert isinstance(mount.mount_strategy, modal_module.ModalCloudBucketMountStrategy)
     assert mount.mount_strategy.secret_name == "named-modal-secret"
+
+
+def test_modal_cloud_bucket_mount_strategy_round_trips_oidc_role_through_manifest_parse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+
+    manifest = Manifest.model_validate(
+        {
+            "entries": {
+                "remote": {
+                    "type": "s3_mount",
+                    "bucket": "bucket",
+                    "mount_strategy": {
+                        "type": "modal_cloud_bucket",
+                        "oidc_auth_role_arn": ("arn:aws:iam::123456789012:role/modal-s3-reader"),
+                    },
+                }
+            }
+        }
+    )
+
+    mount = manifest.entries["remote"]
+
+    assert isinstance(mount, S3Mount)
+    assert isinstance(mount.mount_strategy, modal_module.ModalCloudBucketMountStrategy)
+    assert (
+        mount.mount_strategy.oidc_auth_role_arn == "arn:aws:iam::123456789012:role/modal-s3-reader"
+    )
 
 
 def test_modal_cloud_bucket_mount_strategy_round_trips_secret_env_name(
@@ -1138,6 +1197,49 @@ def test_modal_cloud_bucket_mount_strategy_rejects_mixed_inline_credentials_and_
                 access_key_id="access-key",
                 secret_access_key="secret-key",
                 mount_strategy=strategy,
+            )
+        )
+
+
+def test_modal_cloud_bucket_mount_strategy_rejects_unsupported_oidc_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    role_arn = "arn:aws:iam::123456789012:role/modal-s3-reader"
+
+    empty_strategy = modal_module.ModalCloudBucketMountStrategy(oidc_auth_role_arn="")
+    with pytest.raises(MountConfigError, match="must be a non-empty string"):
+        empty_strategy._build_modal_cloud_bucket_mount_config(  # noqa: SLF001
+            S3Mount(bucket="bucket", mount_strategy=empty_strategy)
+        )
+
+    secret_strategy = modal_module.ModalCloudBucketMountStrategy(
+        secret_name="named-modal-secret", oidc_auth_role_arn=role_arn
+    )
+    with pytest.raises(MountConfigError, match="oidc_auth_role_arn and secret_name"):
+        secret_strategy._build_modal_cloud_bucket_mount_config(  # noqa: SLF001
+            S3Mount(bucket="bucket", mount_strategy=secret_strategy)
+        )
+
+    credential_strategy = modal_module.ModalCloudBucketMountStrategy(oidc_auth_role_arn=role_arn)
+    with pytest.raises(MountConfigError, match="oidc_auth_role_arn and inline credentials"):
+        credential_strategy._build_modal_cloud_bucket_mount_config(  # noqa: SLF001
+            S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key="secret-key",
+                mount_strategy=credential_strategy,
+            )
+        )
+
+    with pytest.raises(MountConfigError, match="only supported for S3 mounts"):
+        credential_strategy._build_modal_cloud_bucket_mount_config(  # noqa: SLF001
+            R2Mount(
+                bucket="bucket",
+                account_id="abc123accountid",
+                access_key_id="access-key",
+                secret_access_key="secret-key",
+                mount_strategy=credential_strategy,
             )
         )
 
@@ -1383,8 +1485,20 @@ async def test_modal_resume_reconnects_generically_parsed_credentialless_mount(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("authority_config", "authority_value"),
+    [
+        ({"secret_name": "current-secret"}, "current-secret"),
+        (
+            {"oidc_auth_role_arn": "arn:aws:iam::123456789012:role/modal-s3-reader"},
+            "arn:aws:iam::123456789012:role/modal-s3-reader",
+        ),
+    ],
+)
 async def test_modal_resume_creates_fresh_sandbox_for_rebound_mount_authority(
     monkeypatch: pytest.MonkeyPatch,
+    authority_config: dict[str, str],
+    authority_value: str,
 ) -> None:
     modal_module, create_calls, _registry_tags = _load_modal_module(monkeypatch)
     trusted_manifest = Manifest(
@@ -1392,9 +1506,7 @@ async def test_modal_resume_creates_fresh_sandbox_for_rebound_mount_authority(
         entries={
             "remote": S3Mount(
                 bucket="bucket",
-                mount_strategy=modal_module.ModalCloudBucketMountStrategy(
-                    secret_name="current-secret"
-                ),
+                mount_strategy=modal_module.ModalCloudBucketMountStrategy(**authority_config),
             )
         },
     )
@@ -1406,7 +1518,7 @@ async def test_modal_resume_creates_fresh_sandbox_for_rebound_mount_authority(
     )
     client = modal_module.ModalSandboxClient()
     serialized = client.serialize_session_state(state)
-    assert "current-secret" not in repr(serialized)
+    assert authority_value not in repr(serialized)
     restored = client.deserialize_session_state(serialized)
     assert restored.mount_authority_redacted is True
     rebound = restored.rebind_persisted_mount_authority(
@@ -1426,7 +1538,12 @@ async def test_modal_resume_creates_fresh_sandbox_for_rebound_mount_authority(
     volumes = cast(dict[str, object], create_calls[0]["volumes"])
     assert volumes.keys() == {"/workspace/remote"}
     mount = cast(Any, volumes["/workspace/remote"])
-    assert mount.secret.name == "current-secret"
+    if "secret_name" in authority_config:
+        assert mount.secret.name == authority_value
+        assert mount.oidc_auth_role_arn is None
+    else:
+        assert mount.secret is None
+        assert mount.oidc_auth_role_arn == authority_value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

- add `oidc_auth_role_arn` to Modal S3 cloud bucket mount strategies
- forward the role ARN to `modal.CloudBucketMount` while rejecting conflicting or unsupported authentication configurations
- treat the role ARN as live mount authority so persisted sessions redact it and require trusted rebind

This pull request resolves #4705.

### Test plan

- [x] `pytest tests/extensions/sandbox/test_modal.py -q` (`114 passed`)
- [x] `pytest tests/sandbox/test_mount_security.py -k "modal or opaque_external_authority" -q` (`2 passed`)
- [x] focused branch coverage confirmed every added executable line and added conditional branch was exercised
- [ ] complete verification wrapper: formatting and lint passed, but the fresh WSL environment lacked optional extras required by repository-wide tests and type checking; `uv sync --all-extras --all-packages --group dev` was not able to complete reliably because dependency downloads timed out

### Issue number

#4705

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
