### PR TITLE
fix(core): apply **kwargs value annotation to each keyword value

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -416,17 +416,12 @@ def function_schema(
             )
 
         elif param.kind == param.VAR_KEYWORD:
-            # **kwargs handling
-            if get_origin(ann) is dict:
-                # e.g. def foo(**kwargs: dict[str, int])
-                dict_args = get_args(ann)
-                if len(dict_args) == 2:
-                    ann = dict[dict_args[0], dict_args[1]]  # type: ignore
-                else:
-                    ann = dict[str, Any]
-            else:
-                # e.g. def foo(**kwargs: int) -> Dict[str, int]
-                ann = dict[str, ann]  # type: ignore
+            # **kwargs handling: a ``**kwargs: X`` annotation applies to each keyword *value*
+            # (PEP 484), so the collected container is always ``dict[str, X]``. Preserve the full
+            # annotation as the value type -- mirroring the variadic-positional handling above,
+            # where ``*args: X`` becomes ``list[X]`` (see #4655). A bare ``**kwargs`` has ``ann``
+            # set to ``Any`` above, yielding ``dict[str, Any]``.
+            ann = dict[str, ann]  # type: ignore
 
             fields[name] = (
                 ann,

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -464,8 +464,9 @@ def test_var_positional_tuple_annotation():
 
 def test_var_keyword_dict_annotation():
     # Case 3:
-    # When a function has a var-keyword parameter annotated with a dict type,
-    # function_schema() should convert it into a field with type Dict[<key>, <value>].
+    # A ``**kwargs: X`` annotation applies to each keyword *value* (PEP 484), so a
+    # ``**kwargs: dict[str, int]`` parameter collects into ``dict[str, dict[str, int]]`` --
+    # mirroring the variadic-positional handling in test_var_positional_tuple_annotation.
     def func(**kwargs: dict[str, int]):
         return kwargs
 
@@ -473,9 +474,37 @@ def test_var_keyword_dict_annotation():
 
     properties = fs.params_json_schema.get("properties", {})
     # The name of the field is "kwargs", and it's a JSON object i.e. a dict.
-    assert properties.get("kwargs").get("type") == "object"
-    # The values in the dict are integers.
-    assert properties.get("kwargs").get("additionalProperties").get("type") == "integer"
+    kwargs_schema = properties.get("kwargs", {})
+    assert kwargs_schema.get("type") == "object"
+    # Each keyword value is itself a dict[str, int].
+    value_schema = kwargs_schema.get("additionalProperties", {})
+    assert value_schema.get("type") == "object"
+    assert value_schema.get("additionalProperties", {}).get("type") == "integer"
+
+    # A correctly-shaped input round-trips back to the original call.
+    parsed = fs.params_pydantic_model.model_validate({"kwargs": {"a": {"x": 1}, "b": {"y": 2}}})
+    args, kwargs = fs.to_call_args(parsed)
+    assert func(*args, **kwargs) == {"a": {"x": 1}, "b": {"y": 2}}
+
+    # A flat mapping of ints no longer matches the declared value type.
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model.model_validate({"kwargs": {"a": 1, "b": 2}})
+
+
+def test_var_keyword_scalar_annotation():
+    # A ``**kwargs: int`` parameter collects each keyword value as an int: ``dict[str, int]``.
+    def func(**kwargs: int) -> int:
+        return sum(kwargs.values())
+
+    fs = function_schema(func, use_docstring_info=False, strict_json_schema=False)
+
+    kwargs_schema = fs.params_json_schema.get("properties", {}).get("kwargs", {})
+    assert kwargs_schema.get("type") == "object"
+    assert kwargs_schema.get("additionalProperties", {}).get("type") == "integer"
+
+    parsed = fs.params_pydantic_model.model_validate({"kwargs": {"a": 2, "b": 3}})
+    args, kwargs = fs.to_call_args(parsed)
+    assert func(*args, **kwargs) == 5
 
 
 def test_schema_with_mapping_raises_strict_mode_error():


### PR DESCRIPTION
### Summary

`function_schema` builds the wrong type for a variadic-keyword parameter annotated with a generic, so the generated tool schema and the argument validation are one nesting level too shallow.

A `**kwargs: X` annotation applies to each keyword *value* (PEP 484), so the collected container is always `dict[str, X]`. For a scalar `X` the SDK already did this, but when `X` was itself a generic `dict[...]` a special case collapsed the value type:

```python
def tool(**kwargs: dict[str, int]): ...
```

- **Generated schema (before):** `kwargs` is `{additionalProperties: {type: integer}}` — i.e. `dict[str, int]`.
- **Correct schema:** `{additionalProperties: {additionalProperties: {type: integer}}}` — i.e. `dict[str, dict[str, int]]`.

The consequences are concrete: the model is told the wrong argument shape, a correctly-shaped call like `{"kwargs": {"group": {"x": 1}}}` is **rejected** with a `ValidationError`, and a wrong flat mapping `{"kwargs": {"a": 1}}` is **accepted**.

This is the exact bug that #4655 fixed for the symmetric variadic-positional case — there, `*args: tuple[int, ...]` was collapsed to `list[int]` instead of `list[tuple[int, ...]]`. This PR applies the same PEP 484 correction to `**kwargs`: the value annotation is preserved as-is and the container is always `dict[str, X]`. The buggy `dict`-origin special case is removed (a scalar `**kwargs: int` still yields `dict[str, int]`, and a bare `**kwargs` still yields `dict[str, Any]`).

### Test plan

- Updated `test_var_keyword_dict_annotation` to mirror `test_var_positional_tuple_annotation` (as revised by #4655): it now asserts the nested `dict[str, dict[str, int]]` schema, round-trips a correctly-shaped input through `to_call_args`, and asserts a flat `dict[str, int]` input raises `ValidationError`.
- Added `test_var_keyword_scalar_annotation` to lock in that `**kwargs: int` stays `dict[str, int]` and round-trips.
- `uv run pytest tests/test_function_schema.py` passes; `ruff format --check`, `ruff check`, and `mypy` on the changed files pass.

### Issue number

None (found while auditing variadic-annotation handling after #4655).

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `make lint`, `make format` and `make tests` (ran targeted lint/format/typecheck and the function-schema suite locally)
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
