### PR TITLE
fix(core): support tool parameters named like BaseModel members

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -10,13 +10,26 @@ from typing import Annotated, Any, Literal, get_args, get_origin, get_type_hints
 
 # griffelib exposes the `griffe` package at runtime but currently does not ship typing markers.
 from griffe import Docstring, DocstringSectionKind  # type: ignore[import-untyped]
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, ConfigDict, Field, create_model
 from pydantic.fields import FieldInfo
 
 from .exceptions import UserError
 from .run_context import RunContextWrapper
 from .strict_schema import ensure_strict_json_schema
 from .tool_context import ToolContext
+
+
+class _ToolArgsBaseModel(BaseModel):
+    """Base for dynamically generated tool-argument models.
+
+    ``protected_namespaces=()`` disables Pydantic's ``model_`` guard so a tool may declare
+    parameters whose names collide with ``BaseModel`` members (for example ``model_dump`` or
+    ``model_validate``) without raising at tool-definition time. The runtime call layer reads
+    argument values from instance ``__dict__`` rather than by attribute access, so a field that
+    shadows a model member is still resolved correctly.
+    """
+
+    model_config = ConfigDict(protected_namespaces=())
 
 
 @dataclass
@@ -470,7 +483,18 @@ def function_schema(
                 )
 
     # 3. Dynamically build a Pydantic model
-    dynamic_model = create_model(f"{func_name}_args", __base__=BaseModel, **fields)
+    #
+    # ``model_config`` cannot be a field name: ``create_model`` interprets a ``model_config``
+    # keyword as the model's configuration, not a field, which otherwise fails with an opaque
+    # ``TypeError`` deep inside Pydantic. Reject it with an actionable error. Other names that
+    # collide with ``BaseModel`` members (``model_dump``, ``model_validate``, ...) are handled by
+    # ``_ToolArgsBaseModel`` disabling the protected-namespace guard.
+    if "model_config" in fields:
+        raise UserError(
+            "Tool parameter 'model_config' is not supported because Pydantic reserves that name "
+            "for model configuration. Rename the parameter (for example to 'config')."
+        )
+    dynamic_model = create_model(f"{func_name}_args", __base__=_ToolArgsBaseModel, **fields)
 
     # 4. Build JSON schema from that model
     json_schema = dynamic_model.model_json_schema()

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -131,6 +131,37 @@ def test_to_call_args_does_not_shadow_pydantic_model_fields_set():
     assert result == "hello:42"
 
 
+@pytest.mark.parametrize(
+    "param_name",
+    ["model_dump", "model_dump_json", "model_validate", "model_validate_json", "model_json_schema"],
+)
+def test_parameter_named_like_a_basemodel_method_is_supported(param_name: str) -> None:
+    """A tool parameter that shadows a ``BaseModel`` method must not crash at definition time."""
+    namespace: dict[str, Any] = {}
+    exec(
+        f"def tool({param_name}: int, query: str) -> str:\n"
+        f"    return f'{{{param_name}}}:{{query}}'",
+        namespace,
+    )
+    tool = namespace["tool"]
+
+    func_schema = function_schema(tool, use_docstring_info=False, strict_json_schema=False)
+    parsed = func_schema.params_pydantic_model.model_validate({param_name: 7, "query": "q"})
+
+    args, kwargs_dict = func_schema.to_call_args(parsed)
+    assert tool(*args, **kwargs_dict) == "7:q"
+
+
+def test_parameter_named_model_config_raises_actionable_error() -> None:
+    """``model_config`` is reserved by ``create_model``; surface a clear error, not a TypeError."""
+
+    def tool(model_config: str) -> str:
+        return model_config
+
+    with pytest.raises(UserError, match="model_config"):
+        function_schema(tool, use_docstring_info=False, strict_json_schema=False)
+
+
 def varargs_function(x: int, *numbers: float, flag: bool = False, **kwargs: Any):
     return x, numbers, flag, kwargs
 


### PR DESCRIPTION
### Summary

A function tool whose parameter name shadows a Pydantic `BaseModel` member crashes at tool-definition time, deep inside `function_schema`'s `create_model` call, with an error that gives no hint about the real cause:

```python
from agents import function_tool

@function_tool
def export_row(model_dump: bool) -> str:   # ValueError: Field 'model_dump' conflicts with member ...
    ...

@function_tool
def configure(model_config: str) -> str:    # TypeError: 'FieldInfo' object is not iterable
    ...
```

`model_dump`, `model_validate`, `model_dump_json`, `model_json_schema` and the other `model_*` methods raise a `ValueError` from Pydantic's protected-namespace guard; `model_config` raises a `TypeError` because `create_model` treats a `model_config` keyword as configuration.

This completes #4627, which taught the runtime call layer to read argument values from instance `__dict__` (rather than by attribute access) precisely so parameters can shadow `BaseModel` members like `model_extra` / `model_fields_set` — but those names still had to be *definable* first, and the `model_*` methods crash before that support is ever reached.

**Change:** build the generated args model on a small base whose `model_config` sets `protected_namespaces=()`, so method-shadowing parameter names no longer trip Pydantic's guard. Because the call layer already resolves values via `__dict__`, a field that shadows a model member is still passed to the tool correctly. `model_config` itself cannot be a Pydantic field name, so it is rejected with an actionable `UserError` ("Rename the parameter…") instead of an opaque `TypeError`.

### Test plan

- `test_parameter_named_like_a_basemodel_method_is_supported` (parametrized over `model_dump`, `model_dump_json`, `model_validate`, `model_validate_json`, `model_json_schema`): the tool is defined, validates input, and round-trips through `to_call_args` to the original function.
- `test_parameter_named_model_config_raises_actionable_error`: `model_config` raises a `UserError` mentioning the parameter, not a `TypeError`.
- 5 of the 6 new cases fail on `main` without the source change.
- The existing #4627 `model_extra` / `model_fields_set` tests still pass unchanged.
- `uv run pytest tests/test_function_schema.py tests/test_function_tool_decorator.py tests/test_tool_converter.py tests/test_released_api_contract.py` → 231 passed. `ruff format --check`, `ruff check`, and `mypy` on the changed file pass.

### Issue number

Follows up #4627 (closed #3547 / #3549 covered the same crash; the runtime shadowing was fixed there, the definition-time crash remained).

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `make lint`, `make format` and `make tests` (ran targeted lint/format/typecheck and the tool suites locally)
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
