### PR TITLE
fix(sessions): match non-ASCII content in AdvancedSQLiteSession search

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -36,6 +36,17 @@ def _allow_all_sqlite_actions(
     return sqlite3.SQLITE_OK
 
 
+def _stored_message_data_needle(search_term: str) -> str:
+    """Return ``search_term`` in the encoding used by the stored ``message_data`` column.
+
+    Session rows are written as ``json.dumps(item)``, which escapes every non-ASCII character
+    as ``\\uXXXX`` and escapes ``"``, ``\\``, and control characters. Matching a raw search term
+    against that column therefore never finds non-ASCII content. Re-encoding the term the same
+    way keeps ASCII searches byte-identical while making non-ASCII searches match.
+    """
+    return json.dumps(search_term)[1:-1]
+
+
 def _content_preview(content: Any, max_length: int | None = None) -> str:
     """Return a string preview of a stored user-message ``content``.
 
@@ -1598,7 +1609,11 @@ class AdvancedSQLiteSession(SQLiteSession):
                         AND am.message_data LIKE ?
                         ORDER BY ms.branch_turn_number
                     """,
-                        (self.session_id, resolved_branch_id, f"%{search_term}%"),
+                        (
+                            self.session_id,
+                            resolved_branch_id,
+                            f"%{_stored_message_data_needle(search_term)}%",
+                        ),
                     )
 
                     matches = []

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -36,15 +36,26 @@ def _allow_all_sqlite_actions(
     return sqlite3.SQLITE_OK
 
 
+_LIKE_ESCAPE_CHAR = "\\"
+
+
 def _stored_message_data_needle(search_term: str) -> str:
-    """Return ``search_term`` in the encoding used by the stored ``message_data`` column.
+    """Return ``search_term`` as a literal LIKE pattern for the ``message_data`` column.
 
     Session rows are written as ``json.dumps(item)``, which escapes every non-ASCII character
     as ``\\uXXXX`` and escapes ``"``, ``\\``, and control characters. Matching a raw search term
-    against that column therefore never finds non-ASCII content. Re-encoding the term the same
-    way keeps ASCII searches byte-identical while making non-ASCII searches match.
+    against that column therefore never finds non-ASCII content, so the term is re-encoded the
+    same way first.
+
+    ``%`` and ``_`` are then escaped, along with the escape character itself, so that a term
+    containing them matches literally instead of acting as a LIKE wildcard. Callers must pair
+    this with ``LIKE ? ESCAPE '\\'``.
     """
-    return json.dumps(search_term)[1:-1]
+    encoded = json.dumps(search_term)[1:-1]
+    # The escape character has to be escaped first, or it would double-escape the others.
+    for char in (_LIKE_ESCAPE_CHAR, "%", "_"):
+        encoded = encoded.replace(char, _LIKE_ESCAPE_CHAR + char)
+    return encoded
 
 
 def _content_preview(content: Any, max_length: int | None = None) -> str:
@@ -1606,7 +1617,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                         JOIN {self.messages_table} am ON ms.message_id = am.id
                         WHERE ms.session_id = ? AND ms.branch_id = ?
                         AND ms.message_type = 'user'
-                        AND am.message_data LIKE ?
+                        AND am.message_data LIKE ? ESCAPE '\\'
                         ORDER BY ms.branch_turn_number
                     """,
                         (

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1802,6 +1802,41 @@ async def test_get_conversation_turns_with_list_content():
     session.close()
 
 
+async def test_find_turns_by_content_matches_non_ascii_content():
+    """Non-ASCII and JSON-escaped user content must be searchable."""
+    session_id = "find_turns_non_ascii_test"
+    session = AdvancedSQLiteSession(session_id=session_id, create_tables=True)
+
+    await session.add_items(
+        [
+            {"role": "user", "content": "東京の天気はどうですか"},
+            {"role": "assistant", "content": "晴れです"},
+        ]
+    )
+    await session.add_items(
+        [
+            {"role": "user", "content": "What is the weather in Tokyo?"},
+            {"role": "assistant", "content": "Sunny."},
+        ]
+    )
+    await session.add_items(
+        [
+            {"role": "user", "content": 'Le café est "très" bon'},
+            {"role": "assistant", "content": "Oui."},
+        ]
+    )
+
+    assert [turn["turn"] for turn in await session.find_turns_by_content("東京")] == [1]
+    assert [turn["turn"] for turn in await session.find_turns_by_content("weather")] == [2]
+    assert [turn["turn"] for turn in await session.find_turns_by_content('café est "très"')] == [3]
+    assert await session.find_turns_by_content("大阪") == []
+
+    branch_id = await session.create_branch_from_content("東京", "tokyo_branch")
+    assert branch_id == "tokyo_branch"
+
+    session.close()
+
+
 async def test_find_turns_by_content_with_list_content():
     """find_turns_by_content returns a string preview for list (multimodal) content."""
     session_id = "find_turns_list_content_test"

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1837,6 +1837,36 @@ async def test_find_turns_by_content_matches_non_ascii_content():
     session.close()
 
 
+async def test_find_turns_by_content_treats_like_metacharacters_literally():
+    """% and _ in a search term must match literally, not act as LIKE wildcards."""
+    session_id = "find_turns_like_metachars_test"
+    session = AdvancedSQLiteSession(session_id=session_id, create_tables=True)
+
+    await session.add_items(
+        [{"role": "user", "content": "進捗は 50% です"}, {"role": "assistant", "content": "了解"}]
+    )
+    await session.add_items(
+        [{"role": "user", "content": "進捗は 5000 です"}, {"role": "assistant", "content": "了解"}]
+    )
+    await session.add_items(
+        [{"role": "user", "content": "変数 a_b を確認"}, {"role": "assistant", "content": "了解"}]
+    )
+    await session.add_items(
+        [{"role": "user", "content": "変数 axb を確認"}, {"role": "assistant", "content": "了解"}]
+    )
+
+    # "50%" must not behave as "50 followed by anything".
+    assert [t["turn"] for t in await session.find_turns_by_content("50%")] == [1]
+    # "a_b" must not behave as "a, any character, b".
+    assert [t["turn"] for t in await session.find_turns_by_content("a_b")] == [3]
+    # A bare "%" is a literal percent sign, so it matches only the turn that has one,
+    # rather than acting as a wildcard and matching every turn.
+    assert [t["turn"] for t in await session.find_turns_by_content("%")] == [1]
+    assert [t["turn"] for t in await session.find_turns_by_content("_")] == [3]
+
+    session.close()
+
+
 async def test_find_turns_by_content_with_list_content():
     """find_turns_by_content returns a string preview for list (multimodal) content."""
     session_id = "find_turns_list_content_test"


### PR DESCRIPTION
### The bug

`AdvancedSQLiteSession.find_turns_by_content()` never matches non-ASCII content.

Session rows are stored with `json.dumps(item)`, which escapes every non-ASCII character as `\uXXXX`. The search then does `... AND am.message_data LIKE ?` with the raw term, so the term and the stored bytes can never line up. A user who stores a Japanese conversation and searches it for a Japanese word gets an empty list, with no error.

`create_branch_from_content()` searches the same column, so it fails the same way — you can't branch from a non-ASCII turn.

### Repro on main

```
>       assert [turn["turn"] for turn in await session.find_turns_by_content("東京")] == [1]
E       assert [] == [1]
E         Right contains one more item: 1
tests/extensions/memory/test_advanced_sqlite_session.py:1829: AssertionError
1 failed in 0.90s
```

### The fix

Re-encode the search term with `json.dumps` before building the `LIKE` pattern, so it is in the same encoding as the column. ASCII searches are byte-identical to before. This also fixes terms containing `"` or `\`, which were escaped in storage but not in the query.

With the fix, that test passes and the full file is green:

```
1 passed in 0.45s
129 passed in 8.55s
```

`ruff check`, `ruff format --check` and `mypy` are clean on both files.
