### PR TITLE
feat(tracing): expose provider tool call IDs on function spans

### DIFF
--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -208,6 +208,7 @@ class ComputerAction:
         return await with_tool_function_span(
             config=config,
             tool_name=trace_tool_name,
+            tool_call_id=action.tool_call.call_id,
             fn=_run_action,
         )
 
@@ -658,6 +659,7 @@ class ShellAction:
         return await with_tool_function_span(
             config=config,
             tool_name=shell_tool.name,
+            tool_call_id=shell_call.call_id,
             fn=_run_call,
         )
 
@@ -829,6 +831,7 @@ class CustomToolAction:
         return await with_tool_function_span(
             config=config,
             tool_name=custom_tool.name,
+            tool_call_id=call_id,
             fn=_run_call,
         )
 
@@ -1067,6 +1070,7 @@ class ApplyPatchAction:
         return await with_tool_function_span(
             config=config,
             tool_name=apply_patch_tool.name,
+            tool_call_id=call_id,
             fn=_run_call,
         )
 

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1121,6 +1121,7 @@ async def with_tool_function_span(
     *,
     config: RunConfig,
     tool_name: str,
+    tool_call_id: str,
     fn: Callable[[Span[Any] | None], MaybeAwaitable[TToolSpanResult]],
 ) -> TToolSpanResult:
     """Execute a tool callback in a function span when tracing is active."""
@@ -1131,7 +1132,7 @@ async def with_tool_function_span(
         direct_result: object = result
         return cast(TToolSpanResult, direct_result)
 
-    with function_span(tool_name) as span:
+    with function_span(tool_name, tool_call_id=tool_call_id) as span:
         result = fn(span)
         if inspect.isawaitable(result):
             return await result
@@ -1802,7 +1803,7 @@ class _FunctionToolBatchExecutor:
             or get_function_tool_trace_name(func_tool)
             or func_tool.name
         )
-        with function_span(trace_tool_name) as span_fn:
+        with function_span(trace_tool_name, tool_call_id=tool_call.call_id) as span_fn:
             tool_context_namespace = get_tool_call_namespace(raw_tool_call)
             if tool_context_namespace is None:
                 tool_context_namespace = get_tool_call_namespace(tool_call)

--- a/src/agents/tracing/create.py
+++ b/src/agents/tracing/create.py
@@ -159,6 +159,7 @@ def function_span(
     span_id: str | None = None,
     parent: Trace | Span[Any] | None = None,
     disabled: bool = False,
+    tool_call_id: str | None = None,
 ) -> Span[FunctionSpanData]:
     """Create a new function span. The span will not be started automatically, you should either do
     `with function_span() ...` or call `span.start()` + `span.finish()` manually.
@@ -173,12 +174,18 @@ def function_span(
         parent: The parent span or trace. If not provided, we will automatically use the current
             trace/span as the parent.
         disabled: If True, we will return a Span but the Span will not be recorded.
+        tool_call_id: The provider-supplied ID for this tool invocation, if available.
 
     Returns:
         The newly created function span.
     """
     return get_trace_provider().create_span(
-        span_data=FunctionSpanData(name=name, input=input, output=output),
+        span_data=FunctionSpanData(
+            name=name,
+            input=input,
+            output=output,
+            tool_call_id=tool_call_id,
+        ),
         span_id=span_id,
         parent=parent,
         disabled=disabled,

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -278,6 +278,13 @@ class BackendSpanExporter(TracingExporter):
                 did_mutate = True
             sanitized_span_data[field_name] = sanitized_field
 
+        # Keep SDK-only fields without published ingest support off the OpenAI wire payload.
+        if span_data.get("type") == "function" and "tool_call_id" in span_data:
+            if not did_mutate:
+                sanitized_span_data = dict(span_data)
+                did_mutate = True
+            sanitized_span_data.pop("tool_call_id", None)
+
         if span_data.get("type") not in self._OPENAI_TRACING_USAGE_SPAN_TYPES:
             if "usage" in span_data:
                 if not did_mutate:

--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -135,10 +135,10 @@ class TurnSpanData(SpanData):
 class FunctionSpanData(SpanData):
     """
     Represents a Function Span in the trace.
-    Includes input, output and MCP data (if applicable).
+    Includes input, output, MCP data, and a provider tool call ID (if applicable).
     """
 
-    __slots__ = ("name", "input", "output", "mcp_data")
+    __slots__ = ("name", "input", "output", "mcp_data", "tool_call_id")
 
     def __init__(
         self,
@@ -146,11 +146,13 @@ class FunctionSpanData(SpanData):
         input: str | None,
         output: Any | None,
         mcp_data: dict[str, Any] | None = None,
+        tool_call_id: str | None = None,
     ):
         self.name = name
         self.input = input
         self.output = output
         self.mcp_data = mcp_data
+        self.tool_call_id = tool_call_id
 
     @property
     def type(self) -> str:
@@ -163,6 +165,7 @@ class FunctionSpanData(SpanData):
             "input": self.input,
             "output": str(self.output) if self.output is not None else None,
             "mcp_data": self.mcp_data,
+            "tool_call_id": self.tool_call_id,
         }
 
 

--- a/tests/mcp/test_mcp_tracing.py
+++ b/tests/mcp/test_mcp_tracing.py
@@ -69,6 +69,7 @@ async def test_mcp_tracing():
                                     "input": "",
                                     "output": "{'type': 'text', 'text': 'result_test_tool_1_{}'}",  # noqa: E501
                                     "mcp_data": {"server": "fake_mcp_server"},
+                                    "tool_call_id": "mcp_call_1",
                                 },
                             },
                             {
@@ -131,6 +132,7 @@ async def test_mcp_tracing():
                                     "name": "non_mcp_tool",
                                     "input": "",
                                     "output": "tool_result",
+                                    "tool_call_id": "function_call_1",
                                 },
                             },
                             {
@@ -140,6 +142,7 @@ async def test_mcp_tracing():
                                     "input": "",
                                     "output": "{'type': 'text', 'text': 'result_test_tool_2_{}'}",  # noqa: E501
                                     "mcp_data": {"server": "fake_mcp_server"},
+                                    "tool_call_id": "mcp_call_2",
                                 },
                             },
                             {
@@ -204,6 +207,7 @@ async def test_mcp_tracing():
                                     "input": "",
                                     "output": "{'type': 'text', 'text': 'result_test_tool_3_{}'}",  # noqa: E501
                                     "mcp_data": {"server": "fake_mcp_server"},
+                                    "tool_call_id": "2",
                                 },
                             },
                             {
@@ -265,6 +269,7 @@ async def test_mcp_tracing_redacts_output_when_sensitive_data_disabled():
                                 "data": {
                                     "name": "test_tool_1",
                                     "mcp_data": {"server": "fake_mcp_server"},
+                                    "tool_call_id": "2",
                                 },
                             },
                             {

--- a/tests/test_apply_patch_tool.py
+++ b/tests/test_apply_patch_tool.py
@@ -175,6 +175,7 @@ async def test_apply_patch_tool_emits_function_span() -> None:
     assert isinstance(result, ToolCallOutputItem)
     function_span = _get_function_span(tool.name)
     span_data = cast(dict[str, Any], function_span["span_data"])
+    assert span_data.get("tool_call_id") == "call_apply_trace"
     assert "tasks.md" in cast(str, span_data.get("input", ""))
     assert "Updated tasks.md" in cast(str, span_data.get("output", ""))
 
@@ -215,6 +216,7 @@ async def test_apply_patch_tool_redacts_span_error_when_sensitive_data_disabled(
     }
     assert secret_error not in json.dumps(function_span)
     span_data = cast(dict[str, Any], function_span["span_data"])
+    assert span_data.get("tool_call_id") == "call_apply_trace_redacted"
     assert span_data.get("input") is None
     assert span_data.get("output") is None
 

--- a/tests/test_computer_action.py
+++ b/tests/test_computer_action.py
@@ -622,6 +622,7 @@ async def test_execute_emits_function_span() -> None:
     assert ComputerAction.TRACE_TOOL_NAME == "computer"
     function_span = _get_function_span(ComputerAction.TRACE_TOOL_NAME)
     span_data = cast(dict[str, Any], function_span["span_data"])
+    assert span_data.get("tool_call_id") == "tool_trace"
     assert span_data.get("input") is not None
     assert cast(str, span_data.get("output", "")).startswith("data:image/png;base64,")
 
@@ -741,6 +742,7 @@ async def test_execute_redacts_span_error_when_sensitive_data_disabled() -> None
     }
     assert secret_error not in json.dumps(function_span)
     span_data = cast(dict[str, Any], function_span["span_data"])
+    assert span_data.get("tool_call_id") == "tool_trace_error"
     assert span_data.get("input") is None
     assert span_data.get("output") is None
 

--- a/tests/test_custom_tool.py
+++ b/tests/test_custom_tool.py
@@ -3,13 +3,22 @@ from typing import Any, cast
 import pytest
 from openai.types.responses import ResponseCustomToolCall
 
-from agents import Agent, CustomTool, RunConfig, RunContextWrapper
+from agents import (
+    Agent,
+    CustomTool,
+    RunConfig,
+    RunContextWrapper,
+    set_tracing_disabled,
+    trace,
+)
 from agents.items import ToolApprovalItem, ToolCallOutputItem
 from agents.lifecycle import RunHooks
 from agents.run_internal.run_steps import ToolRunCustom
 from agents.run_internal.tool_actions import CustomToolAction
 from agents.tool import CustomToolOnApprovalFunctionResult
 from agents.tool_context import ToolContext
+
+from .testing_processor import SPAN_PROCESSOR_TESTING
 
 
 @pytest.mark.asyncio
@@ -33,13 +42,15 @@ async def test_custom_tool_action_returns_custom_tool_call_output() -> None:
         input="hello",
     )
 
-    result = await CustomToolAction.execute(
-        agent=agent,
-        call=ToolRunCustom(tool_call=tool_call, custom_tool=tool),
-        hooks=RunHooks[Any](),
-        context_wrapper=RunContextWrapper(context=None),
-        config=RunConfig(),
-    )
+    set_tracing_disabled(False)
+    with trace("custom-tool-call-id-test"):
+        result = await CustomToolAction.execute(
+            agent=agent,
+            call=ToolRunCustom(tool_call=tool_call, custom_tool=tool),
+            hooks=RunHooks[Any](),
+            context_wrapper=RunContextWrapper(context=None),
+            config=RunConfig(),
+        )
 
     assert isinstance(result, ToolCallOutputItem)
     raw_item = cast(dict[str, Any], result.raw_item)
@@ -48,6 +59,16 @@ async def test_custom_tool_action_returns_custom_tool_call_output() -> None:
         "call_id": "call_custom",
         "output": "HELLO",
     }
+    function_spans = [
+        span.export()
+        for span in SPAN_PROCESSOR_TESTING.get_ordered_spans(including_empty=True)
+        if span.span_data.type == "function"
+    ]
+    assert len(function_spans) == 1
+    exported_span = function_spans[0]
+    assert exported_span is not None
+    span_data = cast(dict[str, Any], exported_span["span_data"])
+    assert span_data["tool_call_id"] == "call_custom"
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -1623,6 +1623,48 @@ async def test_execute_function_tool_calls_allows_non_agent_function_tool() -> N
 
 
 @pytest.mark.asyncio
+async def test_parallel_function_tool_spans_preserve_provider_call_ids() -> None:
+    slow_started = asyncio.Event()
+    fast_finished = asyncio.Event()
+    completion_order: list[str] = []
+
+    async def _slow_tool() -> str:
+        slow_started.set()
+        await fast_finished.wait()
+        completion_order.append("slow")
+        return "slow-result"
+
+    async def _fast_tool() -> str:
+        await slow_started.wait()
+        completion_order.append("fast")
+        fast_finished.set()
+        return "fast-result"
+
+    slow_tool = function_tool(_slow_tool, name_override="slow_tool")
+    fast_tool = function_tool(_fast_tool, name_override="fast_tool")
+    agent = Agent(name="test", tools=[slow_tool, fast_tool])
+    response = ModelResponse(
+        output=[
+            get_function_tool_call("slow_tool", "{}", call_id="call-slow"),
+            get_function_tool_call("fast_tool", "{}", call_id="call-fast"),
+        ],
+        usage=Usage(),
+        response_id=None,
+    )
+
+    with trace("parallel-tool-call-id-test"):
+        await get_execute_result(agent, response)
+
+    span_data_by_name = {
+        cast(dict[str, Any], span["span_data"])["name"]: cast(dict[str, Any], span["span_data"])
+        for span in _function_spans()
+    }
+    assert completion_order == ["fast", "slow"]
+    assert span_data_by_name["slow_tool"]["tool_call_id"] == "call-slow"
+    assert span_data_by_name["fast_tool"]["tool_call_id"] == "call-fast"
+
+
+@pytest.mark.asyncio
 async def test_execute_function_tool_calls_collapse_trace_name_for_top_level_deferred_tools():
     async def _shipping_eta(tracking_number: str) -> str:
         return f"eta:{tracking_number}"

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -306,6 +306,7 @@ async def test_shell_tool_emits_function_span() -> None:
     assert isinstance(result, ToolCallOutputItem)
     function_span = _get_function_span(shell_tool.name)
     span_data = cast(dict[str, Any], function_span["span_data"])
+    assert span_data.get("tool_call_id") == "call_shell_trace"
     assert "echo hi" in cast(str, span_data.get("input", ""))
     assert span_data.get("output") == "shell span output"
 
@@ -347,6 +348,7 @@ async def test_shell_tool_redacts_span_error_when_sensitive_data_disabled() -> N
     }
     assert secret_error not in json.dumps(function_span)
     span_data = cast(dict[str, Any], function_span["span_data"])
+    assert span_data.get("tool_call_id") == "call_shell_trace_redacted"
     assert span_data.get("input") is None
     assert span_data.get("output") is None
 

--- a/tests/test_source_compat_constructors.py
+++ b/tests/test_source_compat_constructors.py
@@ -29,6 +29,7 @@ from agents import (
     tool_output_guardrail,
 )
 from agents.tool_context import ToolContext
+from agents.tracing import FunctionSpanData, function_span
 
 
 def test_run_config_positional_arguments_remain_backward_compatible() -> None:
@@ -345,6 +346,21 @@ def test_tool_context_supports_agent_keyword_argument() -> None:
     assert context.tool_call_id == "call_id"
     assert context.tool_arguments == '{"x":1}'
     assert context.agent is agent
+
+
+def test_function_span_positional_prefix_remains_backward_compatible() -> None:
+    span_data = FunctionSpanData("tool", "input", "output", {"server": "mcp"})
+
+    assert span_data.name == "tool"
+    assert span_data.input == "input"
+    assert span_data.output == "output"
+    assert span_data.mcp_data == {"server": "mcp"}
+    assert span_data.tool_call_id is None
+
+    disabled_span = function_span("tool", "input", "output", None, None, True)
+
+    assert disabled_span.export() is None
+    assert disabled_span.span_data.tool_call_id is None
 
 
 def test_run_result_v070_positional_constructor_still_works() -> None:

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -949,6 +949,68 @@ def test_backend_span_exporter_keeps_non_generation_usage_for_custom_endpoint(mo
     exporter.close()
 
 
+@patch("httpx2.Client")
+def test_backend_span_exporter_drops_tool_call_id_for_openai_endpoint(mock_client):
+    class DummyItem:
+        tracing_api_key = None
+
+        def __init__(self):
+            self.exported_payload = {
+                "object": "trace.span",
+                "span_data": {
+                    "type": "function",
+                    "name": "lookup",
+                    "tool_call_id": "call_123",
+                },
+            }
+
+        def export(self):
+            return self.exported_payload
+
+    item = DummyItem()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_client.return_value.post.return_value = mock_response
+
+    exporter = BackendSpanExporter(api_key="test_key")
+    exporter.export([cast(Any, item)])
+
+    sent_payload = mock_client.return_value.post.call_args.kwargs["json"]["data"][0]
+    assert "tool_call_id" not in sent_payload["span_data"]
+    assert item.exported_payload["span_data"]["tool_call_id"] == "call_123"
+    exporter.close()
+
+
+@patch("httpx2.Client")
+def test_backend_span_exporter_keeps_tool_call_id_for_custom_endpoint(mock_client):
+    class DummyItem:
+        tracing_api_key = None
+
+        def export(self):
+            return {
+                "object": "trace.span",
+                "span_data": {
+                    "type": "function",
+                    "name": "lookup",
+                    "tool_call_id": "call_123",
+                },
+            }
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_client.return_value.post.return_value = mock_response
+
+    exporter = BackendSpanExporter(
+        api_key="test_key",
+        endpoint="https://example.com/v1/traces/ingest",
+    )
+    exporter.export([cast(Any, DummyItem())])
+
+    sent_payload = mock_client.return_value.post.call_args.kwargs["json"]["data"][0]
+    assert sent_payload["span_data"]["tool_call_id"] == "call_123"
+    exporter.close()
+
+
 def test_sanitize_for_openai_tracing_api_keeps_allowed_generation_usage():
     exporter = BackendSpanExporter(api_key="test_key")
     payload = {

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -229,7 +229,7 @@ def spans_with_setters():
         with agent_span(name="agent_1") as span_a:
             span_a.span_data.name = "agent_2"
 
-            with function_span(name="function_1") as span_b:
+            with function_span(name="function_1", tool_call_id="call_function_1") as span_b:
                 span_b.span_data.input = "i"
                 span_b.span_data.output = "o"
 
@@ -255,7 +255,12 @@ def test_spans_with_setters() -> None:
                         "children": [
                             {
                                 "type": "function",
-                                "data": {"name": "function_1", "input": "i", "output": "o"},
+                                "data": {
+                                    "name": "function_1",
+                                    "input": "i",
+                                    "output": "o",
+                                    "tool_call_id": "call_function_1",
+                                },
                             },
                             {
                                 "type": "generation",

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -122,6 +122,7 @@ async def test_multi_turn_no_handoffs():
                                     "name": "foo",
                                     "input": '{"a": "b"}',
                                     "output": "tool_result",
+                                    "tool_call_id": "2",
                                 },
                             },
                             {
@@ -199,6 +200,7 @@ async def test_tool_call_error(monkeypatch: pytest.MonkeyPatch):
                                         "Please try again with valid JSON. Error: Expecting "
                                         "value: line 1 column 1 (char 0)"
                                     ),
+                                    "tool_call_id": "2",
                                 },
                             },
                             {"type": "generation"},
@@ -267,6 +269,7 @@ async def test_multiple_handoff_doesnt_error():
                                     "name": "some_function",
                                     "input": '{"a": "b"}',
                                     "output": "result",
+                                    "tool_call_id": "2",
                                 },
                             },
                             {"type": "generation"},
@@ -405,6 +408,7 @@ async def test_handoffs_lead_to_correct_agent_spans():
                                     "name": "some_function",
                                     "input": '{"a": "b"}',
                                     "output": "result",
+                                    "tool_call_id": "tool_1",
                                 },
                             },
                             {"type": "generation"},
@@ -439,6 +443,7 @@ async def test_handoffs_lead_to_correct_agent_spans():
                                     "name": "some_function",
                                     "input": '{"a": "b"}',
                                     "output": "result",
+                                    "tool_call_id": "tool_2",
                                 },
                             },
                             {"type": "generation"},
@@ -506,12 +511,22 @@ async def test_max_turns_exceeded():
                             {"type": "generation"},
                             {
                                 "type": "function",
-                                "data": {"name": "foo", "input": "", "output": "result"},
+                                "data": {
+                                    "name": "foo",
+                                    "input": "",
+                                    "output": "result",
+                                    "tool_call_id": "tool_1",
+                                },
                             },
                             {"type": "generation"},
                             {
                                 "type": "function",
-                                "data": {"name": "foo", "input": "", "output": "result"},
+                                "data": {
+                                    "name": "foo",
+                                    "input": "",
+                                    "output": "result",
+                                    "tool_call_id": "tool_2",
+                                },
                             },
                         ],
                     }

--- a/tests/test_tracing_errors_streamed.py
+++ b/tests/test_tracing_errors_streamed.py
@@ -176,6 +176,7 @@ async def test_multi_turn_no_handoffs():
                                     "name": "foo",
                                     "input": '{"a": "b"}',
                                     "output": "tool_result",
+                                    "tool_call_id": "2",
                                 },
                             },
                             {
@@ -255,6 +256,7 @@ async def test_tool_call_error(monkeypatch: pytest.MonkeyPatch):
                                         "Please try again with valid JSON. Error: Expecting "
                                         "value: line 1 column 1 (char 0)"
                                     ),
+                                    "tool_call_id": "2",
                                 },
                             },
                             {"type": "generation"},
@@ -326,6 +328,7 @@ async def test_multiple_handoff_doesnt_error():
                                     "name": "some_function",
                                     "input": '{"a": "b"}',
                                     "output": "result",
+                                    "tool_call_id": "2",
                                 },
                             },
                             {"type": "generation"},
@@ -465,6 +468,7 @@ async def test_handoffs_lead_to_correct_agent_spans():
                                     "name": "some_function",
                                     "input": '{"a": "b"}',
                                     "output": "result",
+                                    "tool_call_id": "tool_1",
                                 },
                             },
                             {"type": "generation"},
@@ -494,6 +498,7 @@ async def test_handoffs_lead_to_correct_agent_spans():
                                     "name": "some_function",
                                     "input": '{"a": "b"}',
                                     "output": "result",
+                                    "tool_call_id": "tool_2",
                                 },
                             },
                             {"type": "generation"},
@@ -563,12 +568,22 @@ async def test_max_turns_exceeded():
                             {"type": "generation"},
                             {
                                 "type": "function",
-                                "data": {"name": "foo", "input": "", "output": "result"},
+                                "data": {
+                                    "name": "foo",
+                                    "input": "",
+                                    "output": "result",
+                                    "tool_call_id": "tool_1",
+                                },
                             },
                             {"type": "generation"},
                             {
                                 "type": "function",
-                                "data": {"name": "foo", "input": "", "output": "result"},
+                                "data": {
+                                    "name": "foo",
+                                    "input": "",
+                                    "output": "result",
+                                    "tool_call_id": "tool_2",
+                                },
                             },
                         ],
                     }


### PR DESCRIPTION
### Summary

- Add an optional `tool_call_id` to `FunctionSpanData` and `function_span()` so tracing processors can correlate tool spans with provider calls.
- Forward canonical call IDs for function, computer, shell, custom, and apply-patch tools, including concurrent calls that complete out of order.
- Preserve the released v0.22.0 positional API and keep the current default OpenAI traces ingest wire shape by removing the SDK-only field only in the endpoint-specific sanitizer. Custom processors and custom endpoints retain the field.

This addresses the `gen_ai.tool.call.id` gap documented in open-telemetry/opentelemetry-python-genai#90 without adding OpenTelemetry dependencies or correlation state.

### Test plan

- `UV_CACHE_DIR=/tmp/openai-agents-uv-cache uv run --frozen pytest -q tests/test_trace_processor.py tests/test_tracing.py tests/test_source_compat_constructors.py tests/test_run_step_execution.py tests/test_computer_action.py tests/test_shell_tool.py tests/test_custom_tool.py tests/test_apply_patch_tool.py` (`274 passed`)
- `UV_CACHE_DIR=/tmp/openai-agents-uv-cache /usr/bin/env -u OPENAI_API_KEY OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1 UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` (format, lint, typecheck, and tests passed)
- Two independent final reviews of the same fingerprint returned clean with no findings.
- `codex review --base origin/main` completed clean and reran the affected tests (`98 + 176 passed`).

### Issue number

Related: open-telemetry/opentelemetry-python-genai#90

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
