### PR TITLE
fix(core): resolve JSON Pointer array indexes in $ref paths

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -425,7 +425,12 @@ def _json_pointer_child(container: object, token: str, *, ref: str) -> object:
     if is_dict(container):
         return container[token]
     if is_list(container):
-        if not token.isdigit() or (len(token) > 1 and token.startswith("0")):
+        # RFC 6901 array indexes use JSON decimal digits (ASCII 0-9 only).
+        if (
+            not token
+            or not all("0" <= char <= "9" for char in token)
+            or (len(token) > 1 and token.startswith("0"))
+        ):
             raise ValueError(f"Invalid JSON Pointer array index {token!r} while resolving {ref}")
         index = int(token)
         if index >= len(container):

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -410,18 +410,30 @@ def resolve_ref(*, root: dict[str, object], ref: str) -> object:
         raise ValueError(f"Unexpected $ref format {ref!r}; Does not start with #/")
 
     path = ref[2:].split("/")
-    resolved = root
+    resolved: object = root
     for raw_key in path:
         key = raw_key.replace("~1", "/").replace("~0", "~")
-        value = resolved[key]
-        assert is_dict(value), (
-            f"encountered non-dictionary entry while resolving {ref} - {resolved}"
-        )
-        resolved = value
-        if _declares_schema_resource(resolved):
+        resolved = _json_pointer_child(resolved, key, ref=ref)
+        if is_dict(resolved) and _declares_schema_resource(resolved):
             raise UserError(_NESTED_RESOURCE_REF_ERROR)
 
     return resolved
+
+
+def _json_pointer_child(container: object, token: str, *, ref: str) -> object:
+    """Return the JSON Pointer child named by ``token`` (RFC 6901)."""
+    if is_dict(container):
+        return container[token]
+    if is_list(container):
+        if not token.isdigit() or (len(token) > 1 and token.startswith("0")):
+            raise ValueError(f"Invalid JSON Pointer array index {token!r} while resolving {ref}")
+        index = int(token)
+        if index >= len(container):
+            raise ValueError(
+                f"JSON Pointer array index {token} is out of range while resolving {ref}"
+            )
+        return container[index]
+    raise TypeError(f"encountered non-container entry while resolving {ref} - {container}")
 
 
 def _declares_schema_resource(schema: dict[str, object]) -> bool:

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -709,6 +709,29 @@ def test_resolve_ref_rejects_non_integer_json_pointer_array_index():
         resolve_ref(root=root, ref="#/allOf/x")
 
 
+@pytest.mark.parametrize(
+    "index_token",
+    [
+        "\u0660",  # Arabic-Indic digit zero
+        "\u0661",  # Arabic-Indic digit one
+        "\uff10",  # Full-width digit zero
+        "\uff11",  # Full-width digit one
+        "0\u0661",  # Mixed ASCII and Arabic-Indic digits
+        "1\uff10",  # Mixed ASCII and full-width digits
+    ],
+)
+def test_resolve_ref_rejects_non_ascii_json_pointer_array_index_tokens(index_token):
+    root = {
+        "allOf": [
+            {"type": "object", "properties": {"a": {"type": "string"}}},
+            {"type": "object", "properties": {"b": {"type": "integer"}}},
+        ]
+    }
+
+    with pytest.raises(ValueError, match="Invalid JSON Pointer array index"):
+        resolve_ref(root=root, ref=f"#/allOf/{index_token}")
+
+
 def test_ensure_strict_json_schema_inlines_ref_to_allof_member():
     schema = {
         "type": "object",

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -1,10 +1,17 @@
 import copy
 from collections import OrderedDict
+from typing import Any
 
 import pytest
 
 from agents.exceptions import UserError
 from agents.strict_schema import ensure_strict_json_schema, resolve_ref
+from agents.tool import FunctionTool
+from agents.tool_context import ToolContext
+
+
+async def _echo_tool_input(_ctx: ToolContext[Any], input_json: str) -> str:
+    return input_json
 
 
 def _nested_object_schema(depth: int) -> dict[str, object]:
@@ -732,12 +739,12 @@ def test_resolve_ref_rejects_non_ascii_json_pointer_array_index_tokens(index_tok
         resolve_ref(root=root, ref=f"#/allOf/{index_token}")
 
 
-def test_ensure_strict_json_schema_inlines_ref_to_allof_member():
+def test_function_tool_inlines_ref_through_allof_array_member():
     schema = {
         "type": "object",
         "properties": {
             "value": {
-                "$ref": "#/allOf/0",
+                "$ref": "#/allOf/0/properties/value",
                 "description": "from the first allOf member",
             }
         },
@@ -745,26 +752,108 @@ def test_ensure_strict_json_schema_inlines_ref_to_allof_member():
         "allOf": [
             {
                 "type": "object",
-                "properties": {"a": {"type": "string"}},
-                "required": ["a"],
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
                 "additionalProperties": False,
             },
             {
                 "type": "object",
-                "properties": {"b": {"type": "integer"}},
-                "required": ["b"],
+                "properties": {"value": {"type": "string", "minLength": 1}},
+                "required": ["value"],
                 "additionalProperties": False,
             },
         ],
     }
 
-    result = ensure_strict_json_schema(schema)
+    tool = FunctionTool(
+        name="array_ref",
+        description="Resolve a reference through an array member.",
+        params_json_schema=schema,
+        on_invoke_tool=_echo_tool_input,
+    )
 
-    value_schema = result["properties"]["value"]
-    assert value_schema["type"] == "object"
+    value_schema = tool.params_json_schema["properties"]["value"]
     assert value_schema["description"] == "from the first allOf member"
     assert "$ref" not in value_schema
-    assert value_schema["properties"]["a"]["type"] == "string"
+    assert value_schema["type"] == "string"
+    assert tool.params_json_schema["allOf"] == [
+        {
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        {
+            "type": "object",
+            "properties": {"value": {"type": "string", "minLength": 1}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+    ]
+
+
+@pytest.mark.parametrize("index_token", ["00", "01"], ids=["zero", "nonzero"])
+def test_function_tool_rejects_leading_zero_json_pointer_array_indexes(index_token):
+    schema = {
+        "type": "object",
+        "properties": {
+            "value": {
+                "$ref": f"#/allOf/{index_token}/properties/value",
+                "description": "value",
+            }
+        },
+        "allOf": [
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": False,
+            },
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string", "minLength": 1}},
+                "required": ["value"],
+                "additionalProperties": False,
+            },
+        ],
+    }
+
+    with pytest.raises(ValueError, match="Invalid JSON Pointer array index"):
+        FunctionTool(
+            name="invalid_array_ref",
+            description="Invalid array reference.",
+            params_json_schema=schema,
+            on_invoke_tool=_echo_tool_input,
+        )
+
+
+def test_function_tool_rejects_out_of_range_json_pointer_array_index():
+    schema = {
+        "type": "object",
+        "properties": {"value": {"$ref": "#/allOf/2/properties/value", "description": "value"}},
+        "allOf": [
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": False,
+            },
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string", "minLength": 1}},
+                "required": ["value"],
+                "additionalProperties": False,
+            },
+        ],
+    }
+
+    with pytest.raises(ValueError, match="out of range"):
+        FunctionTool(
+            name="invalid_array_ref",
+            description="Invalid array reference.",
+            params_json_schema=schema,
+            on_invoke_tool=_echo_tool_input,
+        )
 
 
 @pytest.mark.parametrize("additional_properties", [True, {}], ids=["true", "schema"])

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import pytest
 
 from agents.exceptions import UserError
-from agents.strict_schema import ensure_strict_json_schema
+from agents.strict_schema import ensure_strict_json_schema, resolve_ref
 
 
 def _nested_object_schema(depth: int) -> dict[str, object]:
@@ -688,6 +688,60 @@ def test_allOf_single_ref_entry_decodes_json_pointer_tokens(definition_name, ref
     assert result["properties"] == {"value": {"type": "string"}}
     assert result["required"] == ["value"]
     assert result["additionalProperties"] is False
+
+
+def test_resolve_ref_follows_json_pointer_array_indexes():
+    root = {
+        "allOf": [
+            {"type": "object", "properties": {"a": {"type": "string"}}},
+            {"type": "object", "properties": {"b": {"type": "integer"}}},
+        ]
+    }
+
+    assert resolve_ref(root=root, ref="#/allOf/0") == root["allOf"][0]
+    assert resolve_ref(root=root, ref="#/allOf/1") == root["allOf"][1]
+
+
+def test_resolve_ref_rejects_non_integer_json_pointer_array_index():
+    root = {"allOf": [{"type": "object"}]}
+
+    with pytest.raises(ValueError, match="Invalid JSON Pointer array index"):
+        resolve_ref(root=root, ref="#/allOf/x")
+
+
+def test_ensure_strict_json_schema_inlines_ref_to_allof_member():
+    schema = {
+        "type": "object",
+        "properties": {
+            "value": {
+                "$ref": "#/allOf/0",
+                "description": "from the first allOf member",
+            }
+        },
+        "required": ["value"],
+        "allOf": [
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "required": ["a"],
+                "additionalProperties": False,
+            },
+            {
+                "type": "object",
+                "properties": {"b": {"type": "integer"}},
+                "required": ["b"],
+                "additionalProperties": False,
+            },
+        ],
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    value_schema = result["properties"]["value"]
+    assert value_schema["type"] == "object"
+    assert value_schema["description"] == "from the first allOf member"
+    assert "$ref" not in value_schema
+    assert value_schema["properties"]["a"]["type"] == "string"
 
 
 @pytest.mark.parametrize("additional_properties", [True, {}], ids=["true", "schema"])


### PR DESCRIPTION
### Summary

\`resolve_ref()\` treated every JSON Pointer hop as a dict lookup. A valid pointer such as \`#/allOf/0\` therefore crashed with \`AssertionError: encountered non-dictionary entry\` because \`allOf\` is an array.

JSON Pointer (RFC 6901) uses decimal array indexes. OpenAPI and MCP schemas commonly \`$ref\` into \`allOf\` / \`anyOf\` / \`prefixItems\` members. Default \`FunctionTool\` construction (\`strict_json_schema=True\`) and MCP \`convert_schemas_to_strict=True\` run this path, so those tools fail at setup.

### Reproduction

```python
from agents.tool import FunctionTool

schema = {
    \"type\": \"object\",
    \"properties\": {
        \"value\": {\"\$ref\": \"#/allOf/0\", \"description\": \"first member\"},
    },
    \"allOf\": [
        {\"type\": \"object\", \"properties\": {\"a\": {\"type\": \"string\"}}, \"required\": [\"a\"], \"additionalProperties\": False},
        {\"type\": \"object\", \"properties\": {\"b\": {\"type\": \"integer\"}}, \"required\": [\"b\"], \"additionalProperties\": False},
    ],
}

FunctionTool(name=\"t\", description=\"d\", params_json_schema=schema, on_invoke_tool=lambda ctx, s: s)
# Before: AssertionError
# After: schema is inlined as a strict object
```

### Solution

Walk dict keys and RFC 6901 array indexes. Reject non-integer tokens, leading zeros, and out-of-range indexes with \`ValueError\`. Nested \`$id\` resource checks still apply only to dict nodes.

### Test plan

- [x] Direct \`resolve_ref(\"#/allOf/0\")\` and \`#/allOf/1\`
- [x] Invalid array token raises \`ValueError\`
- [x] \`ensure_strict_json_schema\` inlines a sibling \`$ref\` into an \`allOf\` member
- [x] \`uv run pytest tests/test_strict_schema.py\` (75 passed)
- [x] \`ruff\` / \`pyright\` on the changed files

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run format, lint, typecheck, and targeted tests
- [ ] If using Codex, I've run \`/review\` before submitting this PR