### PR TITLE
fix(util): keep memoryview opaque in dump-compatible conversion

### DIFF
--- a/src/agents/util/_json.py
+++ b/src/agents/util/_json.py
@@ -73,7 +73,7 @@ def _to_dump_compatible_internal(obj: Any) -> Any:
     if isinstance(obj, list | tuple):
         return [_to_dump_compatible_internal(x) for x in obj]
 
-    if isinstance(obj, Iterable) and not isinstance(obj, str | bytes | bytearray):
+    if isinstance(obj, Iterable) and not isinstance(obj, str | bytes | bytearray | memoryview):
         return [_to_dump_compatible_internal(x) for x in obj]
 
     return obj

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -41,3 +41,10 @@ def test_to_dump_compatible_preserves_non_dict_mapping_values():
     assert out == {"config": {"timeout": 30, "retries": 3}}
     # A top-level mapping is preserved as an object, not flattened to its keys.
     assert _to_dump_compatible(MappingProxyType({"a": 1, "b": 2})) == {"a": 1, "b": 2}
+
+
+def test_to_dump_compatible_does_not_expand_memoryview():
+    view = memoryview(b"hello")
+
+    assert _to_dump_compatible(view) is view
+    assert _to_dump_compatible({"data": view})["data"] is view


### PR DESCRIPTION
### Summary

\`_to_dump_compatible()\` already leaves \`bytes\` and \`bytearray\` opaque, but it still walked \`memoryview\` as a generic iterable. Nested binary payloads (for example input audio in \`ItemHelpers.input_to_new_input_list\` and Chat Completions request conversion) were therefore rewritten to lists of integers such as \`[104, 101, 108, 108, 111]\`. \`json.dumps\` then succeeded, so the API could receive corrupted data instead of failing closed.

Tracing already treats \`memoryview\` as bytes-like. This change matches that rule.

### Reproduction

```python
from agents.util._json import _to_dump_compatible

print(_to_dump_compatible(memoryview(b\"hello\")))
# Before: [104, 101, 108, 108, 111]
# After: memoryview(b'hello')
```

### Solution

Exclude \`memoryview\` from the iterable conversion, next to \`str | bytes | bytearray\`.

### Test plan

- [x] Regression that a top-level and nested \`memoryview\` is left unchanged
- [x] \`uv run pytest tests/utils/test_json.py\` (3 passed)
- [x] \`ruff\` / \`pyright\` on the changed files

### Issue number

N/A. Related but different: #3700 preserved non-dict Mapping values in the same helper.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run format, lint, typecheck, and targeted tests
- [ ] If using Codex, I've run \`/review\` before submitting this PR