### PR TITLE
fix(sessions): cap Conversations item pagination at the API limit

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -11,6 +11,8 @@ from ..items import TResponseInputItem
 from .session import SessionABC
 from .session_settings import SessionSettings, coerce_session_settings, resolve_session_limit
 
+_MAX_ITEMS_PAGE_SIZE = 100
+
 
 async def start_openai_conversations_session(openai_client: AsyncOpenAI | None = None) -> str:
     _maybe_openai_client = openai_client
@@ -100,7 +102,7 @@ class OpenAIConversationsSession(SessionABC):
         else:
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
-                limit=session_limit,
+                limit=min(session_limit, _MAX_ITEMS_PAGE_SIZE),
                 order="desc",
             ):
                 # calling model_dump() to make this serializable

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -233,6 +233,32 @@ class TestOpenAIConversationsSessionBasicOperations:
         mock_openai_client.conversations.items.list.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_get_items_caps_provider_page_size_for_large_limits(self, mock_openai_client):
+        class ConversationItem:
+            def __init__(self, item_id: int) -> None:
+                self.item_id = item_id
+
+            def model_dump(self, *, exclude_unset: bool) -> dict[str, int]:
+                assert exclude_unset is True
+                return {"item_id": self.item_id}
+
+        async def descending_items():
+            for item_id in range(100, -1, -1):
+                yield ConversationItem(item_id)
+
+        mock_openai_client.conversations.items.list = MagicMock(return_value=descending_items())
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        items = await session.get_items(limit=101)
+
+        assert [item["item_id"] for item in items] == list(range(101))
+        mock_openai_client.conversations.items.list.assert_called_once_with(
+            conversation_id="test_id", limit=100, order="desc"
+        )
+
+    @pytest.mark.asyncio
     async def test_add_items_simple(self, mock_openai_client):
         """Test adding items to the conversation."""
         session = OpenAIConversationsSession(


### PR DESCRIPTION
### Summary

Cap the Conversations items provider page size at 100 while preserving the caller's larger `get_items(limit=N)` cutoff. This lets session callers retrieve more than 100 recent items without sending an invalid page-size value to the API, while retaining chronological output ordering.

### Test plan

- `uv run pytest -q tests/memory/test_openai_conversations_session.py` — 39 passed
- `uv run ruff format --check` — 921 files already formatted
- `uv run ruff check` — passed
- `uv run python .github/scripts/check_optional_truthiness.py src/agents` — passed
- `uv run mypy src` — passed (307 source files)
- `uv run pyright --project pyrightconfig.json --threads "${PYRIGHT_THREADS:-4}"` — passed
- `make tests-serial` — 77 passed, 4 skipped, 55 deselected
- `make tests-parallel` — 9234 passed, 28 skipped; one unrelated failure in `tests/sandbox/test_run_cwd.py::test_python_skill_uses_absolute_root_from_nested_workdir`, reproduced unchanged on `upstream/main`

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
