### PR TITLE
Validate ToolOutputTrimmer integer settings

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -115,6 +115,10 @@ class ToolOutputTrimmer:
     trimmable_tools: str | Iterable[str] | None = field(default=None)
 
     def __post_init__(self) -> None:
+        for field_name in ("recent_turns", "max_output_chars", "preview_chars"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError(f"{field_name} must be an integer, got {value!r}")
         if self.recent_turns < 1:
             raise ValueError(f"recent_turns must be >= 1, got {self.recent_turns}")
         if self.max_output_chars < 1:

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -108,6 +108,12 @@ class TestValidation:
         trimmer = ToolOutputTrimmer(preview_chars=0)
         assert trimmer.preview_chars == 0
 
+    @pytest.mark.parametrize("field_name", ["recent_turns", "max_output_chars", "preview_chars"])
+    @pytest.mark.parametrize("value", [1.5, True])
+    def test_integer_settings_reject_non_integers(self, field_name: str, value: object) -> None:
+        with pytest.raises(ValueError, match=rf"{field_name} must be an integer"):
+            ToolOutputTrimmer(**{field_name: value})  # type: ignore[arg-type]
+
     def test_trimmable_tools_bytes_raises(self) -> None:
         with pytest.raises(ValueError, match="trimmable_tools must be a string or iterable"):
             ToolOutputTrimmer(trimmable_tools=b"search")  # type: ignore[arg-type]


### PR DESCRIPTION
### Summary

Reject non-integer `ToolOutputTrimmer` limits during construction instead of allowing them to fail later during trimming. Adds regression coverage for all three integer settings with float and boolean inputs.

### Test plan

- `uv run pytest -q tests/extensions/test_tool_output_trimmer.py` — 66 passed
- `uv run ruff format --check` — 921 files already formatted
- `uv run ruff check` — passed
- `uv run python .github/scripts/check_optional_truthiness.py src/agents` — passed
- `uv run mypy src` — passed (307 source files)
- `uv run pyright --project pyrightconfig.json --threads "${PYRIGHT_THREADS:-4}"` — passed
- `make tests-serial` — 77 passed, 4 skipped, 55 deselected
- `make tests-parallel` — 9239 passed, 28 skipped; one unrelated failure in `tests/sandbox/test_run_cwd.py::test_python_skill_uses_absolute_root_from_nested_workdir`, reproduced unchanged on `upstream/main`

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
