### PR TITLE
fix(sandbox): keep split UTF-8 characters intact across PTY output windows

### DIFF
--- a/src/agents/sandbox/session/pty_output.py
+++ b/src/agents/sandbox/session/pty_output.py
@@ -14,14 +14,18 @@ def _incomplete_utf8_suffix_length(data: bytes | bytearray) -> int:
         byte = data[-back]
         if byte < 0x80:
             return 0
-        if byte >= 0xC0:
-            if byte >= 0xF0:
-                needed = 4
-            elif byte >= 0xE0:
-                needed = 3
-            else:
-                needed = 2
-            return back if back < needed else 0
+        # Only real lead bytes can still be completed. 0xC0, 0xC1 and 0xF5 to 0xFF never
+        # start a valid sequence, so carrying them would withhold a byte that no later
+        # output can finish and would suppress the replacement character forever.
+        if 0xC2 <= byte <= 0xDF:
+            needed = 2
+        elif 0xE0 <= byte <= 0xEF:
+            needed = 3
+        elif 0xF0 <= byte <= 0xF4:
+            needed = 4
+        else:
+            return 0
+        return back if back < needed else 0
     return 0
 
 

--- a/src/agents/sandbox/session/pty_output.py
+++ b/src/agents/sandbox/session/pty_output.py
@@ -10,10 +10,15 @@ from .pty_types import truncate_text_by_tokens
 
 def _incomplete_utf8_suffix_length(data: bytes | bytearray) -> int:
     """Return how many trailing bytes start a UTF-8 sequence that is not finished yet."""
-    for back in range(1, min(3, len(data)) + 1):
+    # A sequence is at most four bytes, so the lead byte is within four of the end.
+    for back in range(1, min(4, len(data)) + 1):
         byte = data[-back]
         if byte < 0x80:
+            # ASCII cannot be part of a multi-byte sequence, so nothing is pending.
             return 0
+        if byte < 0xC0:
+            # Continuation byte. Keep walking back to find the lead byte it belongs to.
+            continue
         # Only real lead bytes can still be completed. 0xC0, 0xC1 and 0xF5 to 0xFF never
         # start a valid sequence, so carrying them would withhold a byte that no later
         # output can finish and would suppress the replacement character forever.
@@ -26,6 +31,7 @@ def _incomplete_utf8_suffix_length(data: bytes | bytearray) -> int:
         else:
             return 0
         return back if back < needed else 0
+    # Four trailing bytes with no lead byte cannot be completed either.
     return 0
 
 

--- a/src/agents/sandbox/session/pty_output.py
+++ b/src/agents/sandbox/session/pty_output.py
@@ -8,6 +8,23 @@ from collections.abc import Callable
 from .pty_types import truncate_text_by_tokens
 
 
+def _incomplete_utf8_suffix_length(data: bytes | bytearray) -> int:
+    """Return how many trailing bytes start a UTF-8 sequence that is not finished yet."""
+    for back in range(1, min(3, len(data)) + 1):
+        byte = data[-back]
+        if byte < 0x80:
+            return 0
+        if byte >= 0xC0:
+            if byte >= 0xF0:
+                needed = 4
+            elif byte >= 0xE0:
+                needed = 3
+            else:
+                needed = 2
+            return back if back < needed else 0
+    return 0
+
+
 async def collect_pty_output(
     *,
     output_chunks: deque[bytes],
@@ -44,6 +61,18 @@ async def collect_pty_output(
         except asyncio.TimeoutError:
             break
         output_notify.clear()
+
+    if not is_done():
+        # A multi-byte character can straddle two collection windows. Decoding a partial
+        # sequence with errors="replace" destroys those bytes, so hold the unfinished tail
+        # back for the next window. Once the producer is done nothing can complete it, so
+        # the replacement behaviour below is the right answer then.
+        carry = _incomplete_utf8_suffix_length(output)
+        if carry:
+            tail = bytes(output[-carry:])
+            del output[-carry:]
+            async with output_lock:
+                output_chunks.appendleft(tail)
 
     text = output.decode("utf-8", errors="replace")
     truncated, original_token_count = truncate_text_by_tokens(text, max_output_tokens)

--- a/tests/sandbox/test_pty_output.py
+++ b/tests/sandbox/test_pty_output.py
@@ -113,4 +113,3 @@ async def test_collect_pty_output_replaces_partial_utf8_once_the_producer_is_don
 
     assert output.decode("utf-8") == "ok\ufffd"
     assert not output_chunks
-

--- a/tests/sandbox/test_pty_output.py
+++ b/tests/sandbox/test_pty_output.py
@@ -57,3 +57,60 @@ async def test_collect_pty_output_drains_chunks_added_when_done() -> None:
 
     assert output == b"before done after done"
     assert original_token_count is None
+
+
+@pytest.mark.asyncio
+async def test_collect_pty_output_holds_split_utf8_character_for_the_next_window() -> None:
+    """A character split across two collection windows must survive, not become U+FFFD."""
+    text = "h\u00e9llo w\u00f6rld \u2705"
+    raw = text.encode("utf-8")
+    split = 2  # after "h" and the first byte of the two-byte "e" with acute
+
+    output_chunks: deque[bytes] = deque()
+    output_lock = asyncio.Lock()
+    output_notify = asyncio.Event()
+    producer_done = False
+
+    async def window() -> bytes:
+        output_notify.set()
+        collected, _ = await collect_pty_output(
+            output_chunks=output_chunks,
+            output_lock=output_lock,
+            output_notify=output_notify,
+            is_done=lambda: producer_done,
+            yield_time_ms=1,
+            max_output_tokens=None,
+        )
+        return collected
+
+    output_chunks.append(raw[:split])
+    first = await window()
+    # The partial sequence is withheld rather than decoded, so the window ends on "h".
+    assert first == b"h"
+
+    output_chunks.append(raw[split:])
+    producer_done = True
+    second = await window()
+
+    assert (first + second).decode("utf-8") == text
+
+
+@pytest.mark.asyncio
+async def test_collect_pty_output_replaces_partial_utf8_once_the_producer_is_done() -> None:
+    """Nothing can complete a truncated sequence after the producer closes, so replace it."""
+    output_chunks: deque[bytes] = deque([b"ok\xc3"])
+    output_notify = asyncio.Event()
+    output_notify.set()
+
+    output, _ = await collect_pty_output(
+        output_chunks=output_chunks,
+        output_lock=asyncio.Lock(),
+        output_notify=output_notify,
+        is_done=lambda: True,
+        yield_time_ms=1,
+        max_output_tokens=None,
+    )
+
+    assert output.decode("utf-8") == "ok\ufffd"
+    assert not output_chunks
+

--- a/tests/sandbox/test_pty_output.py
+++ b/tests/sandbox/test_pty_output.py
@@ -113,3 +113,27 @@ async def test_collect_pty_output_replaces_partial_utf8_once_the_producer_is_don
 
     assert output.decode("utf-8") == "ok\ufffd"
     assert not output_chunks
+
+
+@pytest.mark.parametrize("lead", [b"\xc0", b"\xc1", b"\xf5", b"\xff"])
+@pytest.mark.asyncio
+async def test_collect_pty_output_replaces_bytes_that_cannot_start_a_character(
+    lead: bytes,
+) -> None:
+    """Only real lead bytes may be carried; others can never be completed by later output."""
+    output_chunks: deque[bytes] = deque([b"prompt" + lead])
+    output_notify = asyncio.Event()
+    output_notify.set()
+
+    output, _ = await collect_pty_output(
+        output_chunks=output_chunks,
+        output_lock=asyncio.Lock(),
+        output_notify=output_notify,
+        is_done=lambda: False,
+        yield_time_ms=1,
+        max_output_tokens=None,
+    )
+
+    # Replaced in this window rather than withheld from an interactive prompt forever.
+    assert output.decode("utf-8") == "prompt\ufffd"
+    assert not output_chunks

--- a/tests/sandbox/test_pty_output.py
+++ b/tests/sandbox/test_pty_output.py
@@ -5,7 +5,10 @@ from collections import deque
 
 import pytest
 
-from agents.sandbox.session.pty_output import collect_pty_output
+from agents.sandbox.session.pty_output import (
+    _incomplete_utf8_suffix_length,
+    collect_pty_output,
+)
 
 
 @pytest.mark.asyncio
@@ -137,3 +140,66 @@ async def test_collect_pty_output_replaces_bytes_that_cannot_start_a_character(
     # Replaced in this window rather than withheld from an interactive prompt forever.
     assert output.decode("utf-8") == "prompt\ufffd"
     assert not output_chunks
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (b"abc", 0),
+        (b"a\xc3", 1),
+        (b"a\xc3\xa9", 0),
+        (b"a\xe2", 1),
+        (b"a\xe2\x82", 2),
+        (b"a\xe2\x82\xac", 0),
+        (b"a\xf0", 1),
+        (b"a\xf0\x9f", 2),
+        (b"a\xf0\x9f\x98", 3),
+        (b"a\xf0\x9f\x98\x80", 0),
+        (b"a\xc0", 0),
+        (b"a\xc1", 0),
+        (b"a\xf5", 0),
+        (b"a\xff", 0),
+        (b"a\x80", 0),
+        (b"\x80\x80\x80\x80", 0),
+    ],
+)
+def test_incomplete_utf8_suffix_length(data: bytes, expected: int) -> None:
+    """Every split position of every sequence length, plus bytes that can never complete."""
+    assert _incomplete_utf8_suffix_length(data) == expected
+
+
+@pytest.mark.parametrize("split", [1, 2])
+@pytest.mark.asyncio
+async def test_collect_pty_output_holds_three_byte_character_split_at_any_point(
+    split: int,
+) -> None:
+    """A three-byte character must survive a window boundary after one or two bytes."""
+    text = "a\u20acb"
+    raw = text.encode("utf-8")
+    boundary = 1 + split  # after "a" plus part of the euro sign
+
+    output_chunks: deque[bytes] = deque([raw[:boundary]])
+    output_lock = asyncio.Lock()
+    output_notify = asyncio.Event()
+    producer_done = False
+
+    async def window() -> bytes:
+        output_notify.set()
+        collected, _ = await collect_pty_output(
+            output_chunks=output_chunks,
+            output_lock=output_lock,
+            output_notify=output_notify,
+            is_done=lambda: producer_done,
+            yield_time_ms=1,
+            max_output_tokens=None,
+        )
+        return collected
+
+    first = await window()
+    assert first == b"a"
+
+    output_chunks.append(raw[boundary:])
+    producer_done = True
+    second = await window()
+
+    assert (first + second).decode("utf-8") == text


### PR DESCRIPTION
### Summary

`collect_pty_output` decodes each collection window with `errors="replace"`:

```python
text = output.decode("utf-8", errors="replace")
```

PTY output is not collected once. It is collected in repeated windows over one persistent chunk deque: `pty_exec_start` takes a window, then each `pty_write_stdin` takes another from the same `entry.output_chunks`. So a multi-byte character whose bytes land either side of a window boundary is decoded as two separate partial sequences, and both halves become U+FFFD. The bytes are destroyed at that first decode, so no later window can put the character back together.

Reproduced against `main` with one persistent deque, the producer still running for the first window:

```
window 1 out = b'h\xef\xbf\xbd'
window 2 out = b'\xef\xbf\xbdllo w\xc3\xb6rld \xe2\x9c\x85'
joined       : h??llo wörld ✅     <- two replacement characters
```

After the change the same sequence round trips, with the first window ending on `b"h"` and holding the partial byte back:

```
window 1 out = b'h'
window 2 out = b'\xc3\xa9llo w\xc3\xb6rld \xe2\x9c\x85'
joined       : héllo wörld ✅
```

The fix holds an unfinished trailing sequence back on the deque for the next window. It needs no new state, because the deque already outlives a single window and is owned by the PTY entry. When `is_done()` reports the producer has closed, nothing can complete the sequence, so the existing replacement behaviour is kept for that case.

This is not backend-specific. `collect_pty_output` is the shared helper behind the `unix_local`, `docker`, `blaxel`, `daytona` and `modal` PTY paths, so any of them silently mangles a character that straddles a window today. It is the same class as #4707, which fixed a UTF-8 boundary in the Cloudflare SSE reader; this is the boundary that the shared PTY collector has.

Note on overlap: #4572 also edits this function, adding a final drain immediately above the decode line. The two changes are independent and compose, but they will touch adjacent lines, so this may need a trivial rebase depending on merge order.

### Test plan

Two tests in `tests/sandbox/test_pty_output.py`:

- `test_collect_pty_output_holds_split_utf8_character_for_the_next_window` splits a two-byte character across two windows on one deque, asserts the first window ends on `b"h"` rather than emitting a replacement character, and asserts the two windows concatenate back to the original text.
- `test_collect_pty_output_replaces_partial_utf8_once_the_producer_is_done` pins the deliberate exception: after `is_done()` is true a truncated sequence still becomes U+FFFD and is not left stranded on the deque.

Verified the first fails without the source change by reverting `src/`: it fails on the `b"h"` assertion, which is the corruption itself. The second passes either way, since it pins existing behaviour.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full suite.

### Issue number

None. Found while sibling-checking #4707.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

I went looking for this straight after #4707 landed, on the theory that a UTF-8 boundary bug in one reader usually has a sibling wherever else the SDK decodes bytes it did not accumulate itself. The judgement call I would most like checked is keeping `errors="replace"` once the producer is done, since holding bytes back forever would be worse than losing them. I'm a freshman in college and the PTY collector is a path I only learned recently, so please push back if the carry-back belongs in the backends rather than the shared helper.
