### PR TITLE
fix(chat-completions): merge a streamed turn's message into its pending tool-call message

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -738,18 +738,15 @@ class Converter:
 
             # 3) response output message => assistant
             elif resp_msg := cls.maybe_response_output_message(item):
-                # A reasoning item can be followed by an assistant message and then tool calls
-                # in the same turn, so preserve pending reasoning state across this flush.
-                flush_assistant_message(clear_pending_reasoning=False)
-                new_asst = ChatCompletionAssistantMessageParam(role="assistant")
                 contents = resp_msg["content"]
 
                 text_segments = []
+                refusal: str | None = None
                 for c in contents:
                     if c["type"] == "output_text":
                         text_segments.append(c["text"])
                     elif c["type"] == "refusal":
-                        new_asst["refusal"] = c["refusal"]
+                        refusal = c["refusal"]
                     elif c["type"] == "output_audio":
                         # Can't handle this, b/c chat completions expects an ID which we dont have
                         raise UserError(
@@ -758,14 +755,57 @@ class Converter:
                     else:
                         raise UserError(f"Unknown content type in ResponseOutputMessage: {c}")
 
-                if text_segments:
-                    combined = "\n".join(text_segments)
-                    new_asst["content"] = combined
+                # A streamed turn can order its function calls before its text message,
+                # and the pending assistant message then already carries the tool calls
+                # of this same turn: a function_call_output always flushes, so tool calls
+                # from a previous turn cannot still be pending here. Merge the message
+                # into that pending assistant message. Flushing instead would emit an
+                # assistant message with tool_calls directly followed by another
+                # assistant message, a sequence the Chat Completions API rejects.
+                pending_content = (
+                    current_assistant_msg.get("content")
+                    if current_assistant_msg is not None
+                    else None
+                )
+                if (
+                    current_assistant_msg is not None
+                    and current_assistant_msg.get("tool_calls")
+                    and "refusal" not in current_assistant_msg
+                    # None is the untouched state; a list means thinking blocks were
+                    # already reconstructed into content parts and text can be appended.
+                    and (pending_content is None or isinstance(pending_content, list))
+                ):
+                    merged_asst = current_assistant_msg
+                    if text_segments:
+                        combined = "\n".join(text_segments)
+                        if isinstance(pending_content, list):
+                            merged_asst["content"] = [
+                                *pending_content,
+                                ChatCompletionContentPartTextParam(text=combined, type="text"),
+                            ]
+                        else:
+                            merged_asst["content"] = combined
+                    if refusal is not None:
+                        merged_asst["refusal"] = refusal
+                    apply_pending_thinking_blocks(merged_asst)
+                    apply_pending_reasoning_content(merged_asst)
+                else:
+                    # A reasoning item can be followed by an assistant message and then
+                    # tool calls in the same turn, so preserve pending reasoning state
+                    # across this flush.
+                    flush_assistant_message(clear_pending_reasoning=False)
+                    new_asst = ChatCompletionAssistantMessageParam(role="assistant")
+                    if refusal is not None:
+                        new_asst["refusal"] = refusal
 
-                apply_pending_thinking_blocks(new_asst)
-                new_asst["tool_calls"] = []
-                apply_pending_reasoning_content(new_asst)
-                current_assistant_msg = new_asst
+                    if text_segments:
+                        combined = "\n".join(text_segments)
+                        new_asst["content"] = combined
+
+                    apply_pending_thinking_blocks(new_asst)
+                    new_asst["tool_calls"] = []
+                    apply_pending_reasoning_content(new_asst)
+                    current_assistant_msg = new_asst
 
             # 4) function/file-search calls => attach to assistant
             elif file_search := cls.maybe_file_search_call(item):

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -379,6 +379,119 @@ def test_items_to_messages_with_output_message_and_function_call():
     assert tool_call["function"]["arguments"] == "{}"
 
 
+def _turn_items_function_call_first() -> list[TResponseInputItem]:
+    """One completed tool turn in the order the streaming handler emits it.
+
+    A provider that streams tool-call deltas before the same turn's text yields
+    response outputs ordered [function_call, message]; the runner then appends
+    the function_call_output.
+    """
+    func_item: ResponseFunctionToolCallParam = {
+        "id": "99",
+        "call_id": "abc",
+        "name": "math",
+        "arguments": "{}",
+        "type": "function_call",
+    }
+    resp_msg = ResponseOutputMessage(
+        id="42",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(text="Let me calculate.", type="output_text", annotations=[])],
+    )
+    return [
+        cast(TResponseInputItem, func_item),
+        cast(TResponseInputItem, resp_msg.model_dump()),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call_output", "call_id": "abc", "output": "4"},
+        ),
+    ]
+
+
+def test_items_to_messages_merges_function_call_before_output_message():
+    """A streamed turn ordered [function_call, message] must convert to one
+    assistant message; an assistant message with tool_calls followed by another
+    assistant message is rejected by the Chat Completions API."""
+    messages = Converter.items_to_messages(_turn_items_function_call_first())
+
+    assert len(messages) == 2
+    assistant = messages[0]
+    assert assistant["role"] == "assistant"
+    assert assistant["content"] == "Let me calculate."
+    tool_calls = assistant.get("tool_calls")
+    assert isinstance(tool_calls, list)
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "math"
+    assert messages[1]["role"] == "tool"
+    assert messages[1]["tool_call_id"] == "abc"
+
+
+def test_items_to_messages_streamed_and_nonstreamed_turn_order_converge():
+    """[function_call, message] and [message, function_call] describe the same
+    turn and must produce identical Chat Completions messages."""
+    streamed = _turn_items_function_call_first()
+    non_streamed = [streamed[1], streamed[0], streamed[2]]
+
+    assert Converter.items_to_messages(streamed) == Converter.items_to_messages(non_streamed)
+
+
+def test_items_to_messages_does_not_merge_a_later_turn_into_a_tool_turn():
+    """A plain assistant turn after a completed tool turn stays a separate
+    message; only the same turn's text merges into the tool_calls message."""
+    items = _turn_items_function_call_first()
+    later_turn = cast(
+        TResponseInputItem,
+        ResponseOutputMessage(
+            id="43",
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[ResponseOutputText(text="Done.", type="output_text", annotations=[])],
+        ).model_dump(),
+    )
+    messages = Converter.items_to_messages([*items, later_turn])
+
+    assert len(messages) == 3
+    assert messages[0]["role"] == "assistant"
+    assert messages[0].get("tool_calls")
+    assert messages[1]["role"] == "tool"
+    assert messages[2]["role"] == "assistant"
+    assert messages[2]["content"] == "Done."
+    assert not messages[2].get("tool_calls")
+
+
+def test_items_to_messages_merges_refusal_into_pending_tool_call_message():
+    """A refusal-bearing message after its turn's function call merges into the
+    same assistant message instead of opening an invalid second one."""
+    func_item: ResponseFunctionToolCallParam = {
+        "id": "99",
+        "call_id": "abc",
+        "name": "math",
+        "arguments": "{}",
+        "type": "function_call",
+    }
+    resp_msg = ResponseOutputMessage(
+        id="42",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputRefusal(refusal="won't do that", type="refusal")],
+    )
+    messages = Converter.items_to_messages(
+        [
+            cast(TResponseInputItem, func_item),
+            cast(TResponseInputItem, resp_msg.model_dump()),
+        ]
+    )
+
+    assert len(messages) == 1
+    assistant = messages[0]
+    assert assistant["refusal"] == "won't do that"
+    assert assistant.get("tool_calls")
+
+
 def test_items_to_messages_accepts_statusless_output_message():
     """Output messages remain recognizable after replay normalization removes null status."""
     statusless_message = cast(


### PR DESCRIPTION
### Summary

A provider that streams tool-call deltas before the same turn's text yields response outputs ordered `[function_call, message]`. Replaying that history through `Converter.items_to_messages` flushed the pending tool_calls message when the message item arrived and opened a second assistant message for the text. Chat Completions rejects an assistant message with `tool_calls` that is not directly followed by its tool messages, so the next turn failed with 400 and the session was unrecoverable. The identical turn converted correctly when not streamed.

This PR merges the message into the pending assistant message instead. The merge only triggers on the same-turn streamed ordering: a `function_call_output` always flushes, so tool calls from a previous turn cannot still be pending when a message item arrives. Streamed and non-streamed histories now convert identically, and histories already persisted in sessions are healed on replay. When legacy thinking blocks were already reconstructed into content parts, the text is appended as a content part rather than discarded.

Fixes #4727.

### Test plan

- Four regression tests in `tests/models/test_openai_chatcompletions_converter.py`: the merged turn, streamed/non-streamed convergence, no merging across turn boundaries, and refusal merging. All four fail on `main`.
- Full verification stack (`.agents/skills/code-change-verification/scripts/run.sh`): format, lint, typecheck pass; tests 9217 passed, 28 skipped, with one failure — `tests/sandbox/test_run_cwd.py::test_python_skill_uses_absolute_root_from_nested_workdir`, which fails identically on a clean `main` checkout in this environment (local sandbox setup, unrelated to this change).

### Issue number

Closes #4727

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
