### PR TITLE
fix(voice): keep emitted PCM16 audio arrays writable

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -107,7 +107,8 @@ class StreamedAudioResult:
         np_array = np.frombuffer(combined_buffer, dtype=np.int16)
 
         if output_dtype == np.int16:
-            return np_array
+            # frombuffer aliases the immutable bytes, so copy to keep the emitted array writable.
+            return np_array.copy()
         elif output_dtype == np.float32:
             return (np_array.astype(np.float32) / 32767.0).reshape(-1, 1)
         else:

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -4,7 +4,7 @@ import asyncio
 import gc
 import logging
 import weakref
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 from unittest.mock import patch
@@ -30,7 +30,7 @@ try:
         VoiceStreamEventAudio,
         VoiceStreamEventLifecycle,
     )
-    from agents.voice.testing import ScriptedTTSModel
+    from agents.voice.testing import ScriptedTTSModel, TTSResult, pcm16_samples
 
     from .helpers import extract_events
     from .pipeline_test_models import (
@@ -858,6 +858,52 @@ async def test_voicepipeline_run_single_turn() -> None:
         "session_ended",
     ]
     await fake_tts.verify_audio("out_1", audio_chunks[0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dtype", [np.int16, np.float32])
+async def test_voicepipeline_transform_data_can_edit_audio_in_place(
+    dtype: npt.DTypeLike,
+) -> None:
+    # transform_data receives every emitted array, so in-place edits must work for each dtype.
+
+    async def run_pipeline(
+        transform: Callable[
+            [npt.NDArray[np.int16 | np.float32]], npt.NDArray[np.int16 | np.float32]
+        ]
+        | None,
+    ) -> list[npt.NDArray[np.int16 | np.float32]]:
+        config = VoicePipelineConfig(
+            tts_settings=TTSModelSettings(
+                buffer_size=1,
+                dtype=dtype,
+                transform_data=transform,
+            )
+        )
+        pipeline = VoicePipeline(
+            workflow=QueuedVoiceWorkflow([["out_1"]]),
+            stt_model=QueuedSTTModel(["first"]),
+            tts_model=ScriptedTTSModel([TTSResult([pcm16_samples([1, 2, 3])])]),
+            config=config,
+        )
+        result = await pipeline.run(AudioInput(buffer=np.zeros(2, dtype=np.int16)))
+        chunks: list[npt.NDArray[np.int16 | np.float32]] = []
+        async for event in result.stream():
+            if isinstance(event, VoiceStreamEventAudio) and event.data is not None:
+                chunks.append(event.data)
+        return chunks
+
+    def double_in_place(
+        data: npt.NDArray[np.int16 | np.float32],
+    ) -> npt.NDArray[np.int16 | np.float32]:
+        data *= 2
+        return data
+
+    baseline = await run_pipeline(None)
+    doubled = await run_pipeline(double_in_place)
+
+    assert baseline, "the pipeline emitted no audio, so the comparison below would be vacuous"
+    assert [chunk.tolist() for chunk in doubled] == [(chunk * 2).tolist() for chunk in baseline]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`StreamedAudioResult._transform_audio_buffer` builds every emitted chunk with `np.frombuffer`, which aliases the immutable `bytes` it was handed, and returns that view unchanged on the `int16` branch:

```python
np_array = np.frombuffer(combined_buffer, dtype=np.int16)

if output_dtype == np.int16:
    return np_array                                          # read-only view
elif output_dtype == np.float32:
    return (np_array.astype(np.float32) / 32767.0).reshape(-1, 1)   # new, writable
```

The `float32` branch computes a new array and is writable. `TTSModelSettings.dtype` defaults to `np.int16`, so the read-only array is what callers get unless they opt out.

Anything that edits the array in place then fails. A `transform_data` callback applying gain with `data *= 2` raises `ValueError: output array is read-only`, and so does a consumer writing into `VoiceStreamEventAudio.data`. The identical callback succeeds when `dtype` is `np.float32`, so whether in-place work is allowed depends on a setting that says nothing about mutability, and neither the field docs nor the voice docs mention the difference.

Copying on the `int16` branch is the narrowest fix. `b"".join(...)` currently returns the single buffered chunk unchanged, so today that branch allocates nothing; the copy adds one allocation there and leaves `float32` untouched, since `astype` already allocates. Joining into a `bytearray` to get a writable view was rejected because it forces an allocation on both dtypes and makes `float32` strictly more expensive for no benefit. No public signature changes.

### Test plan

`tests/voice/test_pipeline.py::test_voicepipeline_transform_data_can_edit_audio_in_place`, parametrized over both supported dtypes. It drives the public `VoicePipeline` and compares the emitted samples against a baseline run of the same pipeline without the transform, so the expected values come from an independent run rather than from the implementation's own arithmetic. It asserts the baseline is non-empty first, so the comparison cannot pass vacuously.

Verified it fails without the source change by restoring `src/agents/voice/result.py` to `main` and rerunning: the `int16` case fails with `ValueError: output array is read-only` and the `float32` case passes. That split is the inconsistency the change removes.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full suite. `uv run mypy --platform win32 src` is clean, and `uv run pytest tests/voice -q` is 210 passed.

### Issue number

None. Found while auditing the PCM framing path in the voice pipeline.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
