### PR TITLE
docs: fix broken API reference links in zh/ja/ko translations

### DIFF
--- a/docs/ja/agents.md
+++ b/docs/ja/agents.md
@@ -300,7 +300,7 @@ result = await Runner.run(agent, "Explain quines", hooks=LoggingHooks())
 print(result.final_output)
 ```
 
-コールバックの全機能については、[Lifecycle API リファレンス](ref/lifecycle.md)を参照してください。
+コールバックの全機能については、[Lifecycle API リファレンス](../ref/lifecycle.md)を参照してください。
 
 ## ガードレール {#guardrails}
 

--- a/docs/ja/mcp.md
+++ b/docs/ja/mcp.md
@@ -367,7 +367,7 @@ async with MCPServerStdio(
 
 ## 5. MCP サーバーマネージャー {#5-mcp-server-manager}
 
-複数の MCP サーバーがある場合は、`MCPServerManager` を使用して事前に接続し、正常に接続されたサーバーのみをエージェントに公開します。コンストラクターのオプションと再接続の動作については、[MCPServerManager API リファレンス](ref/mcp/manager.md)を参照してください。
+複数の MCP サーバーがある場合は、`MCPServerManager` を使用して事前に接続し、正常に接続されたサーバーのみをエージェントに公開します。コンストラクターのオプションと再接続の動作については、[MCPServerManager API リファレンス](../ref/mcp/manager.md)を参照してください。
 
 ```python
 from agents import Agent, Runner

--- a/docs/ja/sessions.md
+++ b/docs/ja/sessions.md
@@ -454,6 +454,6 @@ if __name__ == "__main__":
 
 - [`Session`][agents.memory.Session] - プロトコルインターフェース
 - [`SQLiteSession`][agents.memory.SQLiteSession] - SQLite 実装
-- [`OpenAIConversationsSession`](ref/memory/openai_conversations_session.md) - OpenAI Conversations API 実装
+- [`OpenAIConversationsSession`](../ref/memory/openai_conversations_session.md) - OpenAI Conversations API 実装
 - [`SQLAlchemySession`][agents.extensions.memory.sqlalchemy_session.SQLAlchemySession] - SQLAlchemy ベースの実装
 - [`EncryptedSession`][agents.extensions.memory.encrypt_session.EncryptedSession] - TTL 付き暗号化セッションラッパー

--- a/docs/ja/testing.md
+++ b/docs/ja/testing.md
@@ -570,6 +570,6 @@ Responses API または Chat Completions のリクエストシリアライズ、
 
 ## API リファレンス {#api-reference}
 
-- [`agents.testing`](ref/testing.md)
-- [`agents.realtime.testing`](ref/realtime/testing.md)
-- [`agents.voice.testing`](ref/voice/testing.md)
+- [`agents.testing`](../ref/testing.md)
+- [`agents.realtime.testing`](../ref/realtime/testing.md)
+- [`agents.voice.testing`](../ref/voice/testing.md)

--- a/docs/ja/tools.md
+++ b/docs/ja/tools.md
@@ -905,7 +905,7 @@ agent = Agent(
 
 リファレンス：
 
--   [Codex ツール API リファレンス](ref/extensions/experimental/codex/codex_tool.md)
--   [ThreadOptions リファレンス](ref/extensions/experimental/codex/thread_options.md)
--   [TurnOptions リファレンス](ref/extensions/experimental/codex/turn_options.md)
+-   [Codex ツール API リファレンス](../ref/extensions/experimental/codex/codex_tool.md)
+-   [ThreadOptions リファレンス](../ref/extensions/experimental/codex/thread_options.md)
+-   [TurnOptions リファレンス](../ref/extensions/experimental/codex/turn_options.md)
 -   完全に実行可能なサンプルについては、`examples/tools/codex.py` と `examples/tools/codex_same_thread.py` を参照してください。

--- a/docs/ko/agents.md
+++ b/docs/ko/agents.md
@@ -300,7 +300,7 @@ result = await Runner.run(agent, "Explain quines", hooks=LoggingHooks())
 print(result.final_output)
 ```
 
-전체 콜백 인터페이스는 [수명 주기 API 레퍼런스](ref/lifecycle.md)를 참조하세요.
+전체 콜백 인터페이스는 [수명 주기 API 레퍼런스](../ref/lifecycle.md)를 참조하세요.
 
 ## 가드레일 {#guardrails}
 

--- a/docs/ko/mcp.md
+++ b/docs/ko/mcp.md
@@ -368,7 +368,7 @@ async with MCPServerStdio(
 
 ## 5. MCP 서버 관리자 {#5-mcp-server-manager}
 
-MCP 서버가 여러 개라면 `MCPServerManager`을 사용하여 미리 연결하고, 연결에 성공한 서버만 에이전트에 노출하세요. 생성자 옵션과 재연결 동작은 [MCPServerManager API 레퍼런스](ref/mcp/manager.md)를 참고하세요.
+MCP 서버가 여러 개라면 `MCPServerManager`을 사용하여 미리 연결하고, 연결에 성공한 서버만 에이전트에 노출하세요. 생성자 옵션과 재연결 동작은 [MCPServerManager API 레퍼런스](../ref/mcp/manager.md)를 참고하세요.
 
 ```python
 from agents import Agent, Runner

--- a/docs/ko/sessions.md
+++ b/docs/ko/sessions.md
@@ -455,6 +455,6 @@ if __name__ == "__main__":
 
 -   [`Session`][agents.memory.Session] - 프로토콜 인터페이스
 -   [`SQLiteSession`][agents.memory.SQLiteSession] - SQLite 구현
--   [`OpenAIConversationsSession`](ref/memory/openai_conversations_session.md) - OpenAI Conversations API 구현
+-   [`OpenAIConversationsSession`](../ref/memory/openai_conversations_session.md) - OpenAI Conversations API 구현
 -   [`SQLAlchemySession`][agents.extensions.memory.sqlalchemy_session.SQLAlchemySession] - SQLAlchemy 기반 구현
 -   [`EncryptedSession`][agents.extensions.memory.encrypt_session.EncryptedSession] - TTL이 포함된 암호화 세션 래퍼

--- a/docs/ko/testing.md
+++ b/docs/ko/testing.md
@@ -570,6 +570,6 @@ WebSocket 연결을 열지 않고 `RealtimeSession` 동작 또는 `RealtimeAgent
 
 ## API 레퍼런스 {#api-reference}
 
-- [`agents.testing`](ref/testing.md)
-- [`agents.realtime.testing`](ref/realtime/testing.md)
-- [`agents.voice.testing`](ref/voice/testing.md)
+- [`agents.testing`](../ref/testing.md)
+- [`agents.realtime.testing`](../ref/realtime/testing.md)
+- [`agents.voice.testing`](../ref/voice/testing.md)

--- a/docs/ko/tools.md
+++ b/docs/ko/tools.md
@@ -905,7 +905,7 @@ agent = Agent(
 
 참조:
 
-- [Codex 도구 API 레퍼런스](ref/extensions/experimental/codex/codex_tool.md)
-- [ThreadOptions 레퍼런스](ref/extensions/experimental/codex/thread_options.md)
-- [TurnOptions 레퍼런스](ref/extensions/experimental/codex/turn_options.md)
+- [Codex 도구 API 레퍼런스](../ref/extensions/experimental/codex/codex_tool.md)
+- [ThreadOptions 레퍼런스](../ref/extensions/experimental/codex/thread_options.md)
+- [TurnOptions 레퍼런스](../ref/extensions/experimental/codex/turn_options.md)
 - 완전한 실행 가능 샘플은 `examples/tools/codex.py` 및 `examples/tools/codex_same_thread.py`을 참조하세요.

--- a/docs/zh/agents.md
+++ b/docs/zh/agents.md
@@ -300,7 +300,7 @@ result = await Runner.run(agent, "Explain quines", hooks=LoggingHooks())
 print(result.final_output)
 ```
 
-有关完整的回调接口，请参阅[生命周期 API 参考](ref/lifecycle.md)。
+有关完整的回调接口，请参阅[生命周期 API 参考](../ref/lifecycle.md)。
 
 ## 安全防护措施 {#guardrails}
 

--- a/docs/zh/mcp.md
+++ b/docs/zh/mcp.md
@@ -367,7 +367,7 @@ async with MCPServerStdio(
 
 ## 5. MCP 服务器管理器 {#5-mcp-server-manager}
 
-如果有多个 MCP 服务器，请使用 `MCPServerManager` 预先连接它们，并向智能体公开其中成功连接的服务器子集。有关构造函数选项和重新连接行为，请参阅 [MCPServerManager API 参考](ref/mcp/manager.md)。
+如果有多个 MCP 服务器，请使用 `MCPServerManager` 预先连接它们，并向智能体公开其中成功连接的服务器子集。有关构造函数选项和重新连接行为，请参阅 [MCPServerManager API 参考](../ref/mcp/manager.md)。
 
 ```python
 from agents import Agent, Runner

--- a/docs/zh/sessions.md
+++ b/docs/zh/sessions.md
@@ -455,6 +455,6 @@ if __name__ == "__main__":
 
 -   [`Session`][agents.memory.Session] - 协议接口
 -   [`SQLiteSession`][agents.memory.SQLiteSession] - SQLite 实现
--   [`OpenAIConversationsSession`](ref/memory/openai_conversations_session.md) - OpenAI Conversations API 实现
+-   [`OpenAIConversationsSession`](../ref/memory/openai_conversations_session.md) - OpenAI Conversations API 实现
 -   [`SQLAlchemySession`][agents.extensions.memory.sqlalchemy_session.SQLAlchemySession] - 由 SQLAlchemy 驱动的实现
 -   [`EncryptedSession`][agents.extensions.memory.encrypt_session.EncryptedSession] - 具有 TTL 的加密会话封装器

--- a/docs/zh/testing.md
+++ b/docs/zh/testing.md
@@ -570,6 +570,6 @@ stt = ScriptedSTTModel(sessions=[session])
 
 ## API 参考 {#api-reference}
 
-- [`agents.testing`](ref/testing.md)
-- [`agents.realtime.testing`](ref/realtime/testing.md)
-- [`agents.voice.testing`](ref/voice/testing.md)
+- [`agents.testing`](../ref/testing.md)
+- [`agents.realtime.testing`](../ref/realtime/testing.md)
+- [`agents.voice.testing`](../ref/voice/testing.md)

--- a/docs/zh/tools.md
+++ b/docs/zh/tools.md
@@ -905,7 +905,7 @@ agent = Agent(
 
 参考资料：
 
--   [Codex 工具 API 参考](ref/extensions/experimental/codex/codex_tool.md)
--   [ThreadOptions 参考](ref/extensions/experimental/codex/thread_options.md)
--   [TurnOptions 参考](ref/extensions/experimental/codex/turn_options.md)
+-   [Codex 工具 API 参考](../ref/extensions/experimental/codex/codex_tool.md)
+-   [ThreadOptions 参考](../ref/extensions/experimental/codex/thread_options.md)
+-   [TurnOptions 参考](../ref/extensions/experimental/codex/turn_options.md)
 -   有关完整的可运行代码示例，请参阅 `examples/tools/codex.py` 和 `examples/tools/codex_same_thread.py`。


### PR DESCRIPTION
### Summary

Fix 27 broken relative links in the translated docs (`docs/zh`, `docs/ja`, `docs/ko`).

The API reference pages live under `docs/ref/` (English only). From a page under `docs/{zh,ja,ko}/`, the current `ref/...` links resolve to a non-existent `docs/{zh,ja,ko}/ref/` path, which 404s on the published site (for example, `docs/zh/testing.md` → `ref/testing.md` resolves to `/zh/ref/testing.md`).

This PR adds the missing `../` prefix so the links resolve to the shared English reference pages (`../ref/...`).

### Test plan

- Verified all 9 link targets exist under `docs/ref/` (e.g. `ref/testing.md`, `ref/mcp/manager.md`, `ref/extensions/experimental/codex/*.md`)
- Confirmed no remaining `](ref/` links under `docs/zh`, `docs/ja`, `docs/ko`
- English docs are unchanged
- Docs-only change (no code changes)

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh` (skipped: docs-only change)
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
