### PR TITLE
fix(core): reject fixed-length tuple annotations for variadic tool arguments

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -441,6 +441,14 @@ def function_schema(
                 args_of_tuple = get_args(ann)
                 if len(args_of_tuple) == 2 and args_of_tuple[1] is Ellipsis:
                     ann = list[ann]  # type: ignore
+                # tuple[()] parameterizes an empty tuple and reports no args, while a bare
+                # typing.Tuple is unparameterized and carries no element type to reject.
+                elif hasattr(ann, "__args__"):
+                    raise UserError(
+                        f"Variadic parameter `*{name}` in function {func.__name__} is annotated"
+                        f" with the fixed-length tuple `{ann}`. A variadic annotation describes"
+                        " each positional argument, so use tuple[T, ...] or list[T] instead."
+                    )
                 else:
                     ann = list[Any]
             else:

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -462,6 +462,53 @@ def test_var_positional_tuple_annotation():
         fs.params_pydantic_model.model_validate({"args": [1, 2, 3]})
 
 
+def _var_positional_fixed_pair(*args: tuple[int, str]) -> int:
+    return len(args)
+
+
+def _var_positional_fixed_single(*args: tuple[int]) -> int:
+    return len(args)
+
+
+def _var_positional_empty_tuple(*args: tuple[()]) -> int:
+    return len(args)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [_var_positional_fixed_pair, _var_positional_fixed_single, _var_positional_empty_tuple],
+)
+def test_var_positional_fixed_length_tuple_annotation_is_rejected(func: Any):
+    # A fixed-length tuple cannot describe every positional argument, so reject it at
+    # construction instead of silently widening each argument to Any. tuple[()] reports no
+    # args yet is still parameterized, so it belongs in this group.
+    with pytest.raises(UserError, match=r"use tuple\[T, \.\.\.\] or list\[T\] instead"):
+        function_schema(func, use_docstring_info=False)
+
+
+def _var_positional_homogeneous_tuple(*args: tuple[int, ...]) -> int:
+    return len(args)
+
+
+def _var_positional_list(*args: list[int]) -> int:
+    return len(args)
+
+
+def _var_positional_scalar(*args: int) -> int:
+    return len(args)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [_var_positional_homogeneous_tuple, _var_positional_list, _var_positional_scalar],
+)
+def test_var_positional_supported_annotations_still_build(func: Any):
+    # The alternatives named by the rejection message must keep working.
+    fs = function_schema(func, use_docstring_info=False)
+
+    assert fs.params_json_schema["properties"]["args"]["type"] == "array"
+
+
 def test_var_keyword_dict_annotation():
     # Case 3:
     # A ``**kwargs: X`` annotation applies to each keyword *value* (PEP 484), so a


### PR DESCRIPTION
### Summary

A variadic parameter annotated with a fixed-length tuple silently loses every element constraint. `function_schema()` maps that annotation to `list[Any]`:

```python
args_of_tuple = get_args(ann)
if len(args_of_tuple) == 2 and args_of_tuple[1] is Ellipsis:
    ann = list[ann]  # type: ignore
else:
    ann = list[Any]  # tuple[int, str] lands here
```

So `def f(*args: tuple[int, str])` produces `{"args": {"items": {}, "title": "Args", "type": "array"}}`. The empty `items` schema constrains nothing, so the model may send any JSON for each positional argument, validation accepts it, and the reconstructed call violates the annotation the author wrote. The neighbouring supported forms all keep their element types: `*args: int`, `*args: list[int]`, and `*args: tuple[int, ...]` (the last one since #4655).

This change rejects the fixed-length form during tool construction and names the two supported alternatives in the error, which is the direction requested on #4696:

> The narrower SDK behavior should be to reject fixed-length tuple annotations during tool construction and identify `tuple[T, ...]` or `list[T]` as the supported alternative. A focused follow-up PR implementing that fail-fast behavior would be welcome.

`tuple[()]` is included in the rejection: it parameterizes an empty tuple but reports no args, so the check tests whether the annotation is parameterized rather than whether `get_args()` is non-empty. That distinction also keeps the behavior stable across the supported interpreters, because `get_args(Tuple[()])` is `((),)` on 3.10 and `()` on 3.12 while `__args__` is present on both. Unparameterized `tuple` and bare `typing.Tuple` are unchanged, since they carry no element type to preserve or reject. This is a behavior change for callers who previously built such a tool: the annotation used to be accepted and silently widened, and now raises `UserError` at construction rather than producing a schema that cannot describe the call.

### Test plan

`test_var_positional_fixed_length_tuple_annotation_is_rejected` is parametrized over `tuple[int, str]`, `tuple[int]`, and `tuple[()]`, and asserts the message names both supported alternatives. Bare `typing.Tuple` also reports no args but must keep building, so it is covered by the condition rather than by a test: ruff bans that annotation in this repository, and writing the test required contortions that were worse than the coverage they bought. `test_var_positional_supported_annotations_still_build` is parametrized over `tuple[T, ...]`, `list[T]`, and a plain scalar so the alternatives named in the error keep working.

Verified the rejection test fails without the source change by stashing `src/agents/function_schema.py` and rerunning: `DID NOT RAISE <class 'agents.exceptions.UserError'>`, with the supported-annotations test still passing.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full suite. The complete suite is 9362 passed, 32 skipped, so nothing in the repository depended on the previously accepted annotation.

### Issue number

None. Requested by a maintainer on #4696.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
