### PR TITLE
fix(core): reject fixed-length tuple annotations for **kwargs variadic arguments

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -467,6 +467,22 @@ def function_schema(
             # annotation as the value type -- mirroring the variadic-positional handling above,
             # where ``*args: X`` becomes ``list[X]`` (see #4655). A bare ``**kwargs`` has ``ann``
             # set to ``Any`` above, yielding ``dict[str, Any]``.
+            # A fixed-length tuple cannot describe each keyword value, so reject it at
+            # construction instead of silently narrowing every value to that exact shape --
+            # mirroring the variadic-positional guard (see #4735). A bare ``tuple`` is
+            # unparameterized and carries no element type to reject; tuple[()] and other
+            # fixed-length tuples are parameterized, so they raise instead of producing a
+            # schema that cannot describe the call.
+            if get_origin(ann) is tuple:
+                args_of_tuple = get_args(ann)
+                if not (len(args_of_tuple) == 2 and args_of_tuple[1] is Ellipsis) and hasattr(
+                    ann, "__args__"
+                ):
+                    raise UserError(
+                        f"Variadic parameter **{name} in function {func.__name__} is annotated"
+                        f" with the fixed-length tuple {ann}. A variadic annotation describes"
+                        " each keyword value, so use tuple[T, ...] or list[T] instead."
+                    )
             ann = dict[str, ann]  # type: ignore
 
             fields[name] = (

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -554,6 +554,38 @@ def test_var_keyword_scalar_annotation():
     assert func(*args, **kwargs) == 5
 
 
+def test_var_keyword_fixed_length_tuple_annotation_is_rejected():
+    # A fixed-length or empty tuple cannot describe each keyword value, so reject it at
+    # construction instead of silently narrowing every value to that shape -- mirroring the
+    # variadic-positional guard (see #4735).
+    def pair(**kwargs: tuple[int, str]) -> int:
+        return 0
+
+    def empty_tuple(**kwargs: tuple[()]) -> int:
+        return 0
+
+    for func in (pair, empty_tuple):
+        with pytest.raises(UserError) as excinfo:
+            function_schema(func, use_docstring_info=False)
+        assert "use tuple[T, ...] or list[T] instead" in str(excinfo.value)
+
+
+def test_var_keyword_supported_annotations_still_build():
+    # The alternatives named by the rejection message must keep working.
+    def homogeneous_tuple(**kwargs: tuple[int, ...]) -> int:
+        return 0
+
+    def value_list(**kwargs: list[int]) -> int:
+        return 0
+
+    def scalar(**kwargs: int) -> int:
+        return 0
+
+    for func in (homogeneous_tuple, value_list, scalar):
+        fs = function_schema(func, use_docstring_info=False, strict_json_schema=False)
+        assert fs.params_json_schema["properties"]["kwargs"]["type"] == "object"
+
+
 def test_schema_with_mapping_raises_strict_mode_error():
     """A mapping type is not allowed in strict mode. Same for dicts. Ensure we raise a UserError."""
 


### PR DESCRIPTION
### Summary

A `**kwargs` parameter annotated with a fixed-length tuple silently loses every element constraint. `function_schema()` maps that annotation to `dict[str, ann]` unchanged, so `def f(**kwargs: tuple[int, str])` produces an `additionalProperties` schema whose value type is the bare tuple `tuple[int, str]`. `tuple[()]` is worse: `get_args(Tuple[()])` reports no args, so the value schema collapses to `{type: array, minItems: 0, maxItems: 0}` and forces every keyword value to be the empty array.

`#4735` fixed the symmetric `*args` path by rejecting fixed-length tuple annotations during tool construction and naming the supported alternatives. This PR applies the same fail-fast guard to `**kwargs`, which is the mirror direction of the follow-up requested on #4696:

> The narrower SDK behavior should be to reject fixed-length tuple annotations during tool construction and identify `tuple[T, ...]` or `list[T]` as the supported alternative. A focused follow-up PR implementing that fail-fast behavior would be welcome.

`tuple[()]` is included in the rejection for the same reason as in #4735: it parameterizes an empty tuple but reports no args, so the check tests whether the annotation is parameterized rather than whether `get_args()` is non-empty. Unparameterized `tuple` is unchanged, since it carries no element type to preserve or reject. This is a behavior change for callers who previously built such a tool: the annotation used to be accepted and silently widened, and now raises `UserError` at construction rather than producing a schema that cannot describe the call.

The supported forms keep building unchanged: `**kwargs: tuple[int, ...]`, `list[T]`, a scalar, and `dict[str, X]`.

### Test plan

`test_var_keyword_fixed_length_tuple_annotation_is_rejected` is parametrized over `tuple[int, str]` and `tuple[()]`, and asserts the message names both supported alternatives. `test_var_keyword_supported_annotations_still_build` is parametrized over `tuple[int, ...]`, `list[T]`, and a plain scalar so the alternatives named in the error keep working.

Verified the rejection test fails without the source change by stashing `src/agents/function_schema.py` and rerunning: the guard is skipped, so the fixed annotation passes through to a late strict-schema `UserError` instead of failing at construction.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the targeted suite. `pytest tests/test_function_schema.py tests/test_strict_schema.py tests/test_function_tool.py` is 186 passed.

### Issue number

None. Mirrors the follow-up requested by a maintainer on #4696 and implemented for `*args` in #4735.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR