### PR TITLE
docs: clarify database driver installation for SQLAlchemy sessions

### DIFF
--- a/docs/sessions/sqlalchemy_session.md
+++ b/docs/sessions/sqlalchemy_session.md
@@ -4,10 +4,18 @@
 
 ## Installation
 
-SQLAlchemy sessions require the `sqlalchemy` optional-dependency extra from the `openai-agents` package:
+SQLAlchemy sessions require the `sqlalchemy` optional-dependency extra and an async database driver that matches your database URL.
+
+For the SQLite examples below (`sqlite+aiosqlite://`), install `aiosqlite` alongside the extra:
 
 ```bash
-pip install openai-agents[sqlalchemy]
+pip install 'openai-agents[sqlalchemy]' aiosqlite
+```
+
+The extra already includes `asyncpg` for PostgreSQL URLs that start with `postgresql+asyncpg://`. For MySQL URLs that start with `mysql+aiomysql://`, install `aiomysql` alongside the extra. The driver's `rsa` extra supplies dependencies for MySQL's SHA-256 authentication methods:
+
+```bash
+pip install 'openai-agents[sqlalchemy]' 'aiomysql[rsa]'
 ```
 
 ## Quick start


### PR DESCRIPTION
### Summary

This pull request updates the SQLAlchemy session installation instructions to include the async driver required by each database URL.

The SQLite quick start uses `sqlite+aiosqlite://`, but the `sqlalchemy` extra does not install `aiosqlite`. The instructions now include it explicitly, explain that PostgreSQL's `asyncpg` is already included, and show the MySQL driver installation with its authentication dependencies. Package extras and runtime behavior are unchanged.

### Test plan

- Checked the dependency declarations against v0.22.0 and reproduced the missing SQLite driver in an isolated install.
- Verified SQLite table creation and session operations after installing `aiosqlite`.
- Ran `make build-docs`.

### Related context

#4740

### Checks

- [x] Verified the installation commands against an isolated environment.
- [x] Confirmed the documentation build passes.
