### PR TITLE
fix(sessions): release unused SQLAlchemy table-init locks

### DIFF
--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -66,7 +66,9 @@ _T = TypeVar("_T")
 class SQLAlchemySession(SessionABC):
     """SQLAlchemy implementation of [`Session`][agents.memory.session.Session]."""
 
-    _table_init_locks: ClassVar[dict[tuple[str, str, str], threading.Lock]] = {}
+    _table_init_locks: ClassVar[
+        weakref.WeakValueDictionary[tuple[str, str, str], threading.Lock]
+    ] = weakref.WeakValueDictionary()
     _table_init_locks_guard: ClassVar[threading.Lock] = threading.Lock()
     # Keyed on id(engine.sync_engine) so two distinct engines that happen to compare equal
     # never share a cache entry.  A weakref.finalize callback removes the entry when the sync

--- a/tests/extensions/memory/test_sqlalchemy_session.py
+++ b/tests/extensions/memory/test_sqlalchemy_session.py
@@ -4,6 +4,7 @@ import asyncio
 import gc
 import json
 import threading
+import weakref
 from collections.abc import Iterable, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
@@ -901,6 +902,74 @@ async def test_create_tables_false_does_not_allocate_shared_init_lock(tmp_path):
         assert len(SQLAlchemySession._table_init_locks) == before
     finally:
         await session.engine.dispose()
+
+
+async def test_table_init_registry_releases_collected_sessions(tmp_path):
+    """The registry must not own locks after the last session owner disappears."""
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'lock_registry.db'}")
+    locks = []
+    keys = []
+    try:
+        for index in range(25):
+            sessions_table = f"sessions_{index}"
+            messages_table = f"messages_{index}"
+            session = SQLAlchemySession(
+                f"session_{index}",
+                engine=engine,
+                create_tables=True,
+                sessions_table=sessions_table,
+                messages_table=messages_table,
+            )
+            assert session._init_lock is not None
+            locks.append(weakref.ref(session._init_lock))
+            keys.append(
+                (engine.url.render_as_string(hide_password=True), sessions_table, messages_table)
+            )
+            del session
+
+        gc.collect()
+
+        # The caller's engine can remain alive without retaining discarded sessions' locks.
+        assert all(lock() is None for lock in locks)
+        assert all(key not in SQLAlchemySession._table_init_locks for key in keys)
+    finally:
+        await engine.dispose()
+
+
+async def test_table_init_lock_remains_shared_while_a_session_survives(tmp_path):
+    """Dropping one owner must not let a newcomer bypass a surviving owner's lock."""
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'surviving_init_lock.db'}"
+    survivor = SQLAlchemySession.from_url("survivor", url=db_url, create_tables=True)
+    peer = SQLAlchemySession.from_url("peer", url=db_url, create_tables=True)
+    peer_engine = peer.engine
+    newcomer = None
+    try:
+        assert survivor._init_lock is not None
+        assert peer._init_lock is survivor._init_lock
+        await peer.engine.dispose()
+        del peer
+        gc.collect()
+
+        assert survivor._init_lock.acquire(blocking=False)
+        try:
+            newcomer = SQLAlchemySession.from_url("newcomer", url=db_url, create_tables=True)
+            assert newcomer._init_lock is not None
+            assert newcomer._init_lock is survivor._init_lock
+            assert not newcomer._init_lock.acquire(blocking=False)
+        finally:
+            survivor._init_lock.release()
+
+        await asyncio.gather(
+            survivor.add_items([{"role": "user", "content": "surviving writer"}]),
+            newcomer.add_items([{"role": "user", "content": "new writer"}]),
+        )
+        assert await survivor.get_items() == [{"role": "user", "content": "surviving writer"}]
+        assert await newcomer.get_items() == [{"role": "user", "content": "new writer"}]
+    finally:
+        await survivor.engine.dispose()
+        await peer_engine.dispose()
+        if newcomer is not None:
+            await newcomer.engine.dispose()
 
 
 async def test_get_items_same_timestamp_consistent_order():


### PR DESCRIPTION
### Summary

This pull request fixes unused SQLAlchemy table-initialization locks remaining in the process-wide registry.

`SQLAlchemySession(create_tables=True)` currently keeps one initialization lock for every distinct database/table configuration, even after all sessions using that configuration have been released.

The registry now holds weak values, while each live session keeps its existing strong lock reference. Sessions sharing a key still use the same lock; the registry guard, initialization ordering and cancellation handling are unchanged.

In a probe creating and discarding sessions for 100,000 distinct configurations, the old registry retained 100,000 entries after collection. The updated registry retained none. The measured allocation delta came from `tracemalloc`; it is not RSS or the byte size of the lock objects.

### Test plan

- Added regression coverage for collection of unused locks and sharing with surviving owners during concurrent first writes.
- Confirmed the collection regression fails against the unchanged base and existing cross-loop and cancelled-waiter tests still pass.
- Ran the complete format, lint, Mypy, Pyright and test verification on Python3.12, plus focused tests on Python3.10.

### Checks

- [x] Added regression tests.
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh`.
- [x] Confirmed all verification steps pass.
