### PR TITLE
fix(sandbox): clean up PTY startup cancellation

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -842,9 +842,12 @@ class BlaxelSandboxSession(BaseSandboxSession):
             if not registered:
                 await _settle_pty_cleanup(self._terminate_pty_entry(entry))
             raise ExecTimeoutError(command=command, timeout_s=exec_timeout, cause=e) from e
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as cancellation:
             if not registered:
-                await _settle_pty_cleanup(self._terminate_pty_entry(entry))
+                await _settle_pty_cleanup(
+                    self._terminate_pty_entry(entry),
+                    initial_cancellation=cancellation,
+                )
             raise
         except Exception as e:
             if not registered:

--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -51,6 +51,7 @@ from ....sandbox.session.pty_types import (
     PTY_PROCESSES_MAX,
     PTY_PROCESSES_WARNING,
     PtyExecUpdate,
+    _settle_pty_cleanup,
     allocate_pty_process_id,
     clamp_pty_yield_time_ms,
     process_id_to_prune_from_meta,
@@ -839,11 +840,15 @@ class BlaxelSandboxSession(BaseSandboxSession):
                 registered = True
         except asyncio.TimeoutError as e:
             if not registered:
-                await self._terminate_pty_entry(entry)
+                await _settle_pty_cleanup(self._terminate_pty_entry(entry))
             raise ExecTimeoutError(command=command, timeout_s=exec_timeout, cause=e) from e
+        except asyncio.CancelledError:
+            if not registered:
+                await _settle_pty_cleanup(self._terminate_pty_entry(entry))
+            raise
         except Exception as e:
             if not registered:
-                await self._terminate_pty_entry(entry)
+                await _settle_pty_cleanup(self._terminate_pty_entry(entry))
             raise _blaxel_exec_transport_error(command=command, cause=e) from e
 
         if pruned is not None:

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -634,7 +634,8 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                 try:
                     process.kill()
                 except ProcessLookupError:
-                    pass
+                    if not isinstance(group_error, ProcessLookupError):
+                        termination_error = group_error
                 except OSError as process_error:
                     termination_error = process_error
                     termination_cause = group_error

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -393,6 +393,13 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                 self._pty_processes[process_id] = entry
                 process_count = len(self._pty_processes)
                 registered = True
+        except asyncio.CancelledError as cancellation:
+            if not registered:
+                await _settle_pty_cleanup(
+                    self._terminate_pty_entry(entry),
+                    initial_cancellation=cancellation,
+                )
+            raise
         except BaseException:
             if not registered:
                 await _settle_pty_cleanup(self._terminate_pty_entry(entry))

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -487,9 +487,17 @@ class UnixLocalSandboxSession(BaseSandboxSession):
             }
             self._pty_processes.clear()
             self._reserved_pty_process_ids.clear()
+            self._unregistered_pty_processes.update(entries_by_id)
 
+        first_error: Exception | None = None
         for entry in entries_by_id.values():
-            await self._terminate_pty_entry(entry)
+            try:
+                await self._terminate_pty_entry(entry)
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
     async def _resolved_exec_context(self) -> tuple[dict[str, str], str]:
         if self._host_environment_allowlist is None:
@@ -613,23 +621,23 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         process = entry.process
         primary_fd = entry.primary_fd
         entry.primary_fd = None
+        self._unregistered_pty_processes[id(entry)] = entry
 
-        termination_failed = process.returncode is None and process.pid is None
+        termination_error: OSError | None = None
+        termination_cause: OSError | None = None
+        if process.returncode is None and process.pid is None:
+            termination_error = OSError("Cannot terminate PTY process without a PID")
         if process.returncode is None and process.pid is not None:
             try:
                 os.killpg(process.pid, signal.SIGKILL)
-            except OSError:
+            except OSError as group_error:
                 try:
                     process.kill()
                 except ProcessLookupError:
                     pass
-                except OSError:
-                    termination_failed = True
-
-        if termination_failed:
-            self._unregistered_pty_processes[id(entry)] = entry
-        else:
-            self._unregistered_pty_processes.pop(id(entry), None)
+                except OSError as process_error:
+                    termination_error = process_error
+                    termination_cause = group_error
 
         for task in entry.pump_tasks:
             task.cancel()
@@ -643,13 +651,16 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                 self._schedule_fd_close(primary_fd)
             entry.output_closed.set()
             entry.output_notify.set()
-            return
+        else:
+            if primary_fd is not None:
+                _close_fd_quietly(primary_fd)
+            await asyncio.gather(*entry.pump_tasks, return_exceptions=True)
+            if entry.wait_task is not None:
+                await asyncio.gather(entry.wait_task, return_exceptions=True)
 
-        if primary_fd is not None:
-            _close_fd_quietly(primary_fd)
-        await asyncio.gather(*entry.pump_tasks, return_exceptions=True)
-        if entry.wait_task is not None:
-            await asyncio.gather(entry.wait_task, return_exceptions=True)
+        if termination_error is not None:
+            raise termination_error from termination_cause
+        self._unregistered_pty_processes.pop(id(entry), None)
 
     def _schedule_fd_close(self, fd: int) -> None:
         task = asyncio.create_task(asyncio.to_thread(_close_fd_quietly, fd))

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -605,7 +605,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         entry.primary_fd = None
 
         if process.returncode is None and process.pid is not None:
-            with suppress(ProcessLookupError):
+            with suppress(OSError):
                 os.killpg(process.pid, signal.SIGKILL)
 
         for task in entry.pump_tasks:

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -144,6 +144,7 @@ class _UnixPtyProcessEntry:
     process: asyncio.subprocess.Process
     tty: bool
     primary_fd: int | None = None
+    group_termination_pending: bool = False
     last_used: float = field(default_factory=time.monotonic)
     output_chunks: deque[bytes] = field(default_factory=deque)
     output_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -625,9 +626,11 @@ class UnixLocalSandboxSession(BaseSandboxSession):
 
         termination_error: OSError | None = None
         termination_cause: OSError | None = None
-        if process.returncode is None and process.pid is None:
+        should_terminate_group = process.returncode is None or entry.group_termination_pending
+        if should_terminate_group and process.pid is None:
             termination_error = OSError("Cannot terminate PTY process without a PID")
-        if process.returncode is None and process.pid is not None:
+        if should_terminate_group and process.pid is not None:
+            entry.group_termination_pending = False
             try:
                 os.killpg(process.pid, signal.SIGKILL)
             except OSError as group_error:
@@ -635,10 +638,17 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                     process.kill()
                 except ProcessLookupError:
                     if not isinstance(group_error, ProcessLookupError):
+                        entry.group_termination_pending = True
                         termination_error = group_error
                 except OSError as process_error:
+                    if not isinstance(group_error, ProcessLookupError):
+                        entry.group_termination_pending = True
                     termination_error = process_error
                     termination_cause = group_error
+                else:
+                    entry.group_termination_pending = False
+            else:
+                entry.group_termination_pending = False
 
         for task in entry.pump_tasks:
             task.cancel()

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -53,7 +53,6 @@ from ..session.pty_types import (
     PTY_PROCESSES_MAX,
     PTY_PROCESSES_WARNING,
     PtyExecUpdate,
-    _settle_pty_cleanup,
     allocate_pty_process_id,
     clamp_pty_yield_time_ms,
     process_id_to_prune_from_meta,
@@ -144,7 +143,6 @@ class _UnixPtyProcessEntry:
     process: asyncio.subprocess.Process
     tty: bool
     primary_fd: int | None = None
-    group_termination_pending: bool = False
     last_used: float = field(default_factory=time.monotonic)
     output_chunks: deque[bytes] = field(default_factory=deque)
     output_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -164,7 +162,6 @@ class UnixLocalSandboxSession(BaseSandboxSession):
     _running: bool
     _pty_lock: asyncio.Lock
     _pty_processes: dict[int, _UnixPtyProcessEntry]
-    _unregistered_pty_processes: dict[int, _UnixPtyProcessEntry]
     _reserved_pty_process_ids: set[int]
     _fd_close_tasks: set[asyncio.Task[None]]
     _host_environment_allowlist: frozenset[str] | None
@@ -174,7 +171,6 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         self._running = False
         self._pty_lock = asyncio.Lock()
         self._pty_processes = {}
-        self._unregistered_pty_processes = {}
         self._reserved_pty_process_ids = set()
         self._fd_close_tasks = set()
         self._host_environment_allowlist = None
@@ -384,31 +380,15 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                 asyncio.create_task(self._pump_process_stream(entry, process.stderr)),
             ]
 
-        self._unregistered_pty_processes[id(entry)] = entry
-        registered = False
-        try:
-            entry.wait_task = asyncio.create_task(self._watch_process_exit(entry))
+        entry.wait_task = asyncio.create_task(self._watch_process_exit(entry))
 
-            pruned_entry: _UnixPtyProcessEntry | None = None
-            async with self._pty_lock:
-                process_id = allocate_pty_process_id(self._reserved_pty_process_ids)
-                self._reserved_pty_process_ids.add(process_id)
-                pruned_entry = self._prune_pty_processes_if_needed()
-                self._pty_processes[process_id] = entry
-                self._unregistered_pty_processes.pop(id(entry), None)
-                process_count = len(self._pty_processes)
-                registered = True
-        except asyncio.CancelledError as cancellation:
-            if not registered:
-                await _settle_pty_cleanup(
-                    self._terminate_pty_entry(entry),
-                    initial_cancellation=cancellation,
-                )
-            raise
-        except BaseException:
-            if not registered:
-                await _settle_pty_cleanup(self._terminate_pty_entry(entry))
-            raise
+        pruned_entry: _UnixPtyProcessEntry | None = None
+        async with self._pty_lock:
+            process_id = allocate_pty_process_id(self._reserved_pty_process_ids)
+            self._reserved_pty_process_ids.add(process_id)
+            pruned_entry = self._prune_pty_processes_if_needed()
+            self._pty_processes[process_id] = entry
+            process_count = len(self._pty_processes)
 
         if pruned_entry is not None:
             await self._terminate_pty_entry(pruned_entry)
@@ -479,26 +459,12 @@ class UnixLocalSandboxSession(BaseSandboxSession):
 
     async def pty_terminate_all(self) -> None:
         async with self._pty_lock:
-            entries_by_id = {
-                id(entry): entry
-                for entry in (
-                    *self._pty_processes.values(),
-                    *self._unregistered_pty_processes.values(),
-                )
-            }
+            entries = list(self._pty_processes.values())
             self._pty_processes.clear()
             self._reserved_pty_process_ids.clear()
-            self._unregistered_pty_processes.update(entries_by_id)
 
-        first_error: Exception | None = None
-        for entry in entries_by_id.values():
-            try:
-                await self._terminate_pty_entry(entry)
-            except Exception as error:
-                if first_error is None:
-                    first_error = error
-        if first_error is not None:
-            raise first_error
+        for entry in entries:
+            await self._terminate_pty_entry(entry)
 
     async def _resolved_exec_context(self) -> tuple[dict[str, str], str]:
         if self._host_environment_allowlist is None:
@@ -622,33 +588,10 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         process = entry.process
         primary_fd = entry.primary_fd
         entry.primary_fd = None
-        self._unregistered_pty_processes[id(entry)] = entry
 
-        termination_error: OSError | None = None
-        termination_cause: OSError | None = None
-        should_terminate_group = process.returncode is None or entry.group_termination_pending
-        if should_terminate_group and process.pid is None:
-            termination_error = OSError("Cannot terminate PTY process without a PID")
-        if should_terminate_group and process.pid is not None:
-            entry.group_termination_pending = False
-            try:
+        if process.returncode is None and process.pid is not None:
+            with suppress(ProcessLookupError):
                 os.killpg(process.pid, signal.SIGKILL)
-            except OSError as group_error:
-                try:
-                    process.kill()
-                except ProcessLookupError:
-                    if not isinstance(group_error, ProcessLookupError):
-                        entry.group_termination_pending = True
-                        termination_error = group_error
-                except OSError as process_error:
-                    if not isinstance(group_error, ProcessLookupError):
-                        entry.group_termination_pending = True
-                    termination_error = process_error
-                    termination_cause = group_error
-                else:
-                    entry.group_termination_pending = False
-            else:
-                entry.group_termination_pending = False
 
         for task in entry.pump_tasks:
             task.cancel()
@@ -662,16 +605,13 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                 self._schedule_fd_close(primary_fd)
             entry.output_closed.set()
             entry.output_notify.set()
-        else:
-            if primary_fd is not None:
-                _close_fd_quietly(primary_fd)
-            await asyncio.gather(*entry.pump_tasks, return_exceptions=True)
-            if entry.wait_task is not None:
-                await asyncio.gather(entry.wait_task, return_exceptions=True)
+            return
 
-        if termination_error is not None:
-            raise termination_error from termination_cause
-        self._unregistered_pty_processes.pop(id(entry), None)
+        if primary_fd is not None:
+            _close_fd_quietly(primary_fd)
+        await asyncio.gather(*entry.pump_tasks, return_exceptions=True)
+        if entry.wait_task is not None:
+            await asyncio.gather(entry.wait_task, return_exceptions=True)
 
     def _schedule_fd_close(self, fd: int) -> None:
         task = asyncio.create_task(asyncio.to_thread(_close_fd_quietly, fd))

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -163,6 +163,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
     _running: bool
     _pty_lock: asyncio.Lock
     _pty_processes: dict[int, _UnixPtyProcessEntry]
+    _unregistered_pty_processes: dict[int, _UnixPtyProcessEntry]
     _reserved_pty_process_ids: set[int]
     _fd_close_tasks: set[asyncio.Task[None]]
     _host_environment_allowlist: frozenset[str] | None
@@ -172,6 +173,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         self._running = False
         self._pty_lock = asyncio.Lock()
         self._pty_processes = {}
+        self._unregistered_pty_processes = {}
         self._reserved_pty_process_ids = set()
         self._fd_close_tasks = set()
         self._host_environment_allowlist = None
@@ -381,6 +383,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                 asyncio.create_task(self._pump_process_stream(entry, process.stderr)),
             ]
 
+        self._unregistered_pty_processes[id(entry)] = entry
         registered = False
         try:
             entry.wait_task = asyncio.create_task(self._watch_process_exit(entry))
@@ -391,6 +394,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                 self._reserved_pty_process_ids.add(process_id)
                 pruned_entry = self._prune_pty_processes_if_needed()
                 self._pty_processes[process_id] = entry
+                self._unregistered_pty_processes.pop(id(entry), None)
                 process_count = len(self._pty_processes)
                 registered = True
         except asyncio.CancelledError as cancellation:
@@ -474,11 +478,17 @@ class UnixLocalSandboxSession(BaseSandboxSession):
 
     async def pty_terminate_all(self) -> None:
         async with self._pty_lock:
-            entries = list(self._pty_processes.values())
+            entries_by_id = {
+                id(entry): entry
+                for entry in (
+                    *self._pty_processes.values(),
+                    *self._unregistered_pty_processes.values(),
+                )
+            }
             self._pty_processes.clear()
             self._reserved_pty_process_ids.clear()
 
-        for entry in entries:
+        for entry in entries_by_id.values():
             await self._terminate_pty_entry(entry)
 
     async def _resolved_exec_context(self) -> tuple[dict[str, str], str]:
@@ -604,9 +614,22 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         primary_fd = entry.primary_fd
         entry.primary_fd = None
 
+        termination_failed = process.returncode is None and process.pid is None
         if process.returncode is None and process.pid is not None:
-            with suppress(OSError):
+            try:
                 os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+                except OSError:
+                    termination_failed = True
+
+        if termination_failed:
+            self._unregistered_pty_processes[id(entry)] = entry
+        else:
+            self._unregistered_pty_processes.pop(id(entry), None)
 
         for task in entry.pump_tasks:
             task.cancel()

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -53,6 +53,7 @@ from ..session.pty_types import (
     PTY_PROCESSES_MAX,
     PTY_PROCESSES_WARNING,
     PtyExecUpdate,
+    _settle_pty_cleanup,
     allocate_pty_process_id,
     clamp_pty_yield_time_ms,
     process_id_to_prune_from_meta,
@@ -354,7 +355,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                     env=env,
                     preexec_fn=_preexec,
                 )
-            except Exception:
+            except BaseException:
                 with suppress(OSError):
                     os.close(primary_fd)
                 with suppress(OSError):
@@ -380,15 +381,22 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                 asyncio.create_task(self._pump_process_stream(entry, process.stderr)),
             ]
 
-        entry.wait_task = asyncio.create_task(self._watch_process_exit(entry))
+        registered = False
+        try:
+            entry.wait_task = asyncio.create_task(self._watch_process_exit(entry))
 
-        pruned_entry: _UnixPtyProcessEntry | None = None
-        async with self._pty_lock:
-            process_id = allocate_pty_process_id(self._reserved_pty_process_ids)
-            self._reserved_pty_process_ids.add(process_id)
-            pruned_entry = self._prune_pty_processes_if_needed()
-            self._pty_processes[process_id] = entry
-            process_count = len(self._pty_processes)
+            pruned_entry: _UnixPtyProcessEntry | None = None
+            async with self._pty_lock:
+                process_id = allocate_pty_process_id(self._reserved_pty_process_ids)
+                self._reserved_pty_process_ids.add(process_id)
+                pruned_entry = self._prune_pty_processes_if_needed()
+                self._pty_processes[process_id] = entry
+                process_count = len(self._pty_processes)
+                registered = True
+        except BaseException:
+            if not registered:
+                await _settle_pty_cleanup(self._terminate_pty_entry(entry))
+            raise
 
         if pruned_entry is not None:
             await self._terminate_pty_entry(pruned_entry)

--- a/src/agents/sandbox/session/pty_types.py
+++ b/src/agents/sandbox/session/pty_types.py
@@ -21,12 +21,22 @@ PTY_PROCESS_ID_MAX_EXCLUSIVE = 100_000
 
 async def _settle_pty_cleanup(cleanup: Awaitable[None]) -> None:
     cleanup_task = asyncio.ensure_future(cleanup)
+    cancellation: asyncio.CancelledError | None = None
     while not cleanup_task.done():
         try:
             await asyncio.shield(cleanup_task)
-        except asyncio.CancelledError:
-            continue
-    await cleanup_task
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+
+    try:
+        cleanup_task.result()
+    except BaseException:
+        if cancellation is not None:
+            raise cancellation from None
+        raise
+    if cancellation is not None:
+        raise cancellation from None
 
 
 @dataclass(frozen=True)

--- a/src/agents/sandbox/session/pty_types.py
+++ b/src/agents/sandbox/session/pty_types.py
@@ -21,22 +21,23 @@ PTY_PROCESS_ID_MAX_EXCLUSIVE = 100_000
 
 async def _settle_pty_cleanup(cleanup: Awaitable[None]) -> None:
     cleanup_task = asyncio.ensure_future(cleanup)
-    cancellation: asyncio.CancelledError | None = None
-    while not cleanup_task.done():
+    completion = asyncio.create_task(asyncio.wait((cleanup_task,)))
+    caller_cancelled = False
+    while not completion.done():
         try:
-            await asyncio.shield(cleanup_task)
-        except asyncio.CancelledError as exc:
-            if cancellation is None:
-                cancellation = exc
+            await asyncio.shield(completion)
+        except asyncio.CancelledError:
+            caller_cancelled = True
 
+    completion.result()
     try:
         cleanup_task.result()
     except BaseException:
-        if cancellation is not None:
-            raise cancellation from None
+        if caller_cancelled:
+            raise asyncio.CancelledError() from None
         raise
-    if cancellation is not None:
-        raise cancellation from None
+    if caller_cancelled:
+        raise asyncio.CancelledError() from None
 
 
 @dataclass(frozen=True)

--- a/src/agents/sandbox/session/pty_types.py
+++ b/src/agents/sandbox/session/pty_types.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import random
-from collections.abc import Sequence
+from collections.abc import Awaitable, Sequence
 from dataclasses import dataclass
 
 from ..util.token_truncation import formatted_truncate_text_with_token_count
@@ -16,6 +17,16 @@ PTY_PROCESSES_PROTECTED_RECENT = 8
 
 PTY_PROCESS_ID_MIN = 1_000
 PTY_PROCESS_ID_MAX_EXCLUSIVE = 100_000
+
+
+async def _settle_pty_cleanup(cleanup: Awaitable[None]) -> None:
+    cleanup_task = asyncio.ensure_future(cleanup)
+    while not cleanup_task.done():
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            continue
+    await cleanup_task
 
 
 @dataclass(frozen=True)

--- a/src/agents/sandbox/session/pty_types.py
+++ b/src/agents/sandbox/session/pty_types.py
@@ -19,25 +19,30 @@ PTY_PROCESS_ID_MIN = 1_000
 PTY_PROCESS_ID_MAX_EXCLUSIVE = 100_000
 
 
-async def _settle_pty_cleanup(cleanup: Awaitable[None]) -> None:
+async def _settle_pty_cleanup(
+    cleanup: Awaitable[None],
+    *,
+    initial_cancellation: asyncio.CancelledError | None = None,
+) -> None:
     cleanup_task = asyncio.ensure_future(cleanup)
     completion = asyncio.create_task(asyncio.wait((cleanup_task,)))
-    caller_cancelled = False
+    cancellation = initial_cancellation
     while not completion.done():
         try:
             await asyncio.shield(completion)
-        except asyncio.CancelledError:
-            caller_cancelled = True
+        except asyncio.CancelledError as error:
+            if cancellation is None:
+                cancellation = error
 
     completion.result()
     try:
         cleanup_task.result()
     except BaseException:
-        if caller_cancelled:
-            raise asyncio.CancelledError() from None
+        if cancellation is not None:
+            raise cancellation from None
         raise
-    if caller_cancelled:
-        raise asyncio.CancelledError() from None
+    if cancellation is not None:
+        raise cancellation from None
 
 
 @dataclass(frozen=True)

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -1781,11 +1781,12 @@ class TestPtyExec:
         with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
             task = asyncio.create_task(session.pty_exec_start("echo", "hello"))
             await connect_started.wait()
-            task.cancel()
+            task.cancel("connect-cancel")
 
-            with pytest.raises(asyncio.CancelledError):
+            with pytest.raises(asyncio.CancelledError) as exc_info:
                 await task
 
+            assert exc_info.value.args == ("connect-cancel",)
             assert task.cancelled()
 
         assert fake_aiohttp.session is not None
@@ -1831,12 +1832,13 @@ class TestPtyExec:
         with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
             task = asyncio.create_task(session.pty_exec_start("echo", "hello"))
             await cleanup_started.wait()
-            task.cancel()
+            task.cancel("cleanup-cancel")
             allow_cleanup.set()
 
-            with pytest.raises(asyncio.CancelledError):
+            with pytest.raises(asyncio.CancelledError) as exc_info:
                 await task
 
+            assert exc_info.value.args == ("cleanup-cancel",)
         assert fake_aiohttp.session is not None
         assert fake_aiohttp.session._closed
         assert session._pty_sessions == {}

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -1842,6 +1842,56 @@ class TestPtyExec:
         assert session._pty_sessions == {}
         assert session._reserved_pty_process_ids == set()
 
+    @pytest.mark.asyncio
+    async def test_pty_exec_start_preserves_cancellation_when_cleanup_fails(
+        self, fake_sandbox: _FakeSandboxInstance
+    ) -> None:
+        from agents.extensions.sandbox.blaxel import sandbox as mod
+
+        cleanup_started = asyncio.Event()
+        allow_cleanup = asyncio.Event()
+
+        class _FailingCleanupSession:
+            def __init__(self) -> None:
+                self._closed = False
+
+            async def ws_connect(self, url: str) -> None:
+                _ = url
+                raise asyncio.TimeoutError()
+
+            async def close(self) -> None:
+                cleanup_started.set()
+                await allow_cleanup.wait()
+                self._closed = True
+                raise RuntimeError("synthetic cleanup failure")
+
+        class _FailingCleanupAiohttp:
+            WSMsgType = _FakeAiohttp.WSMsgType
+
+            def __init__(self) -> None:
+                self.session: _FailingCleanupSession | None = None
+
+            def ClientSession(self) -> _FailingCleanupSession:
+                self.session = _FailingCleanupSession()
+                return self.session
+
+        fake_aiohttp = _FailingCleanupAiohttp()
+        session = _make_session(fake_sandbox)
+
+        with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
+            task = asyncio.create_task(session.pty_exec_start("echo", "hello"))
+            await cleanup_started.wait()
+            task.cancel()
+            allow_cleanup.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert fake_aiohttp.session is not None
+        assert fake_aiohttp.session._closed
+        assert session._pty_sessions == {}
+        assert session._reserved_pty_process_ids == set()
+
     @pytest.mark.parametrize(
         ("messages", "expected_output"),
         [

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -1786,6 +1786,8 @@ class TestPtyExec:
             with pytest.raises(asyncio.CancelledError):
                 await task
 
+            assert task.cancelled()
+
         assert fake_aiohttp.session is not None
         assert fake_aiohttp.session._closed
         assert session._pty_sessions == {}

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -5,6 +5,7 @@ import io
 import json
 import logging
 import shlex
+import sys
 import tarfile
 import time
 import uuid
@@ -1786,7 +1787,8 @@ class TestPtyExec:
             with pytest.raises(asyncio.CancelledError) as exc_info:
                 await task
 
-            assert exc_info.value.args == ("connect-cancel",)
+            if sys.version_info >= (3, 11):
+                assert exc_info.value.args == ("connect-cancel",)
             assert task.cancelled()
 
         assert fake_aiohttp.session is not None
@@ -1838,7 +1840,8 @@ class TestPtyExec:
             with pytest.raises(asyncio.CancelledError) as exc_info:
                 await task
 
-            assert exc_info.value.args == ("cleanup-cancel",)
+            if sys.version_info >= (3, 11):
+                assert exc_info.value.args == ("cleanup-cancel",)
         assert fake_aiohttp.session is not None
         assert fake_aiohttp.session._closed
         assert session._pty_sessions == {}

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -1791,6 +1791,55 @@ class TestPtyExec:
         assert session._pty_sessions == {}
         assert session._reserved_pty_process_ids == set()
 
+    @pytest.mark.asyncio
+    async def test_pty_exec_start_preserves_cancellation_during_cleanup(
+        self, fake_sandbox: _FakeSandboxInstance
+    ) -> None:
+        from agents.extensions.sandbox.blaxel import sandbox as mod
+
+        cleanup_started = asyncio.Event()
+        allow_cleanup = asyncio.Event()
+
+        class _TimeoutSession:
+            def __init__(self) -> None:
+                self._closed = False
+
+            async def ws_connect(self, url: str) -> None:
+                _ = url
+                raise asyncio.TimeoutError()
+
+            async def close(self) -> None:
+                cleanup_started.set()
+                await allow_cleanup.wait()
+                self._closed = True
+
+        class _TimeoutAiohttp:
+            WSMsgType = _FakeAiohttp.WSMsgType
+
+            def __init__(self) -> None:
+                self.session: _TimeoutSession | None = None
+
+            def ClientSession(self) -> _TimeoutSession:
+                self.session = _TimeoutSession()
+                return self.session
+
+        fake_aiohttp = _TimeoutAiohttp()
+        session = _make_session(fake_sandbox)
+
+        with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
+            task = asyncio.create_task(session.pty_exec_start("echo", "hello"))
+            await cleanup_started.wait()
+            task.cancel()
+            allow_cleanup.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert fake_aiohttp.session is not None
+        assert fake_aiohttp.session._closed
+        assert session._pty_sessions == {}
+        assert session._reserved_pty_process_ids == set()
+
     @pytest.mark.parametrize(
         ("messages", "expected_output"),
         [

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -1745,6 +1745,52 @@ class _FakeAiohttp:
 
 
 class TestPtyExec:
+    @pytest.mark.asyncio
+    async def test_pty_exec_start_cancellation_closes_unregistered_http_session(
+        self, fake_sandbox: _FakeSandboxInstance
+    ) -> None:
+        from agents.extensions.sandbox.blaxel import sandbox as mod
+
+        connect_started = asyncio.Event()
+
+        class _BlockingSession:
+            def __init__(self) -> None:
+                self._closed = False
+
+            async def ws_connect(self, url: str) -> None:
+                _ = url
+                connect_started.set()
+                await asyncio.Event().wait()
+
+            async def close(self) -> None:
+                self._closed = True
+
+        class _BlockingAiohttp:
+            WSMsgType = _FakeAiohttp.WSMsgType
+
+            def __init__(self) -> None:
+                self.session: _BlockingSession | None = None
+
+            def ClientSession(self) -> _BlockingSession:
+                self.session = _BlockingSession()
+                return self.session
+
+        fake_aiohttp = _BlockingAiohttp()
+        session = _make_session(fake_sandbox)
+
+        with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
+            task = asyncio.create_task(session.pty_exec_start("echo", "hello"))
+            await connect_started.wait()
+            task.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert fake_aiohttp.session is not None
+        assert fake_aiohttp.session._closed
+        assert session._pty_sessions == {}
+        assert session._reserved_pty_process_ids == set()
+
     @pytest.mark.parametrize(
         ("messages", "expected_output"),
         [

--- a/tests/sandbox/test_pty_types.py
+++ b/tests/sandbox/test_pty_types.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import asyncio
+
+import pytest
+
 from agents.sandbox.session.pty_types import (
     PTY_EMPTY_YIELD_TIME_MS_MIN,
     PTY_YIELD_TIME_MS_MIN,
+    _settle_pty_cleanup,
     allocate_pty_process_id,
     clamp_pty_yield_time_ms,
     process_id_to_prune_from_meta,
@@ -37,3 +42,38 @@ def test_process_id_to_prune_from_meta_prefers_exited_unprotected_sessions() -> 
     meta.append((2002, 2.0, False))
 
     assert process_id_to_prune_from_meta(meta) == 2001
+
+
+@pytest.mark.asyncio
+async def test_settle_pty_cleanup_preserves_cancel_reason_when_cleanup_fails() -> None:
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+
+    async def cleanup() -> None:
+        cleanup_started.set()
+        await cleanup_release.wait()
+        raise RuntimeError("synthetic cleanup failure")
+
+    task = asyncio.create_task(_settle_pty_cleanup(cleanup()))
+    await cleanup_started.wait()
+    task.cancel("route-A")
+    cleanup_release.set()
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await task
+
+    assert exc_info.value.args == ("route-A",)
+
+
+@pytest.mark.asyncio
+async def test_settle_pty_cleanup_preserves_initial_cancel_reason_when_cleanup_fails() -> None:
+    async def cleanup() -> None:
+        raise RuntimeError("synthetic cleanup failure")
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await _settle_pty_cleanup(
+            cleanup(),
+            initial_cancellation=asyncio.CancelledError("startup-cancel"),
+        )
+
+    assert exc_info.value.args == ("startup-cancel",)

--- a/tests/sandbox/test_pty_types.py
+++ b/tests/sandbox/test_pty_types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 
 import pytest
 
@@ -62,7 +63,8 @@ async def test_settle_pty_cleanup_preserves_cancel_reason_when_cleanup_fails() -
     with pytest.raises(asyncio.CancelledError) as exc_info:
         await task
 
-    assert exc_info.value.args == ("route-A",)
+    if sys.version_info >= (3, 11):
+        assert exc_info.value.args == ("route-A",)
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -245,6 +245,7 @@ class TestUnixLocalPty:
 
         def killpg(pid: int, signum: signal.Signals) -> None:
             killpg_calls.append((pid, signum))
+            raise PermissionError("synthetic cleanup failure")
 
         monkeypatch.setattr(unix_local_module.asyncio, "create_subprocess_exec", create_subprocess)
         monkeypatch.setattr(unix_local_module.os, "killpg", killpg)
@@ -255,11 +256,12 @@ class TestUnixLocalPty:
             )
             await process_started.wait()
             await asyncio.sleep(0)
-            task.cancel()
+            task.cancel("startup-cancel")
 
-            with pytest.raises(asyncio.CancelledError):
+            with pytest.raises(asyncio.CancelledError) as exc_info:
                 await task
 
+            assert exc_info.value.args == ("startup-cancel",)
             assert killpg_calls == [(1234, signal.SIGKILL)]
             assert session._pty_processes == {}
             assert session._reserved_pty_process_ids == set()

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -217,6 +217,84 @@ async def test_unix_local_rejects_host_path_before_creating_workspace(
 @pytest.mark.review_optional
 class TestUnixLocalPty:
     @pytest.mark.asyncio
+    async def test_pty_start_cancellation_cleans_up_before_registration(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(unix_local_module.sys, "platform", "linux")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        session = _RecordingUnixLocalSession(workspace)
+        process_started = asyncio.Event()
+        killpg_calls: list[tuple[int, signal.Signals]] = []
+
+        class _Process:
+            pid = 1234
+            returncode = None
+            stdout = None
+            stderr = None
+
+            async def wait(self) -> None:
+                return None
+
+        async def create_subprocess(*args: object, **kwargs: object) -> _Process:
+            _ = (args, kwargs)
+            process_started.set()
+            return _Process()
+
+        def killpg(pid: int, signum: signal.Signals) -> None:
+            killpg_calls.append((pid, signum))
+
+        monkeypatch.setattr(unix_local_module.asyncio, "create_subprocess_exec", create_subprocess)
+        monkeypatch.setattr(unix_local_module.os, "killpg", killpg)
+        await session._pty_lock.acquire()
+        try:
+            task = asyncio.create_task(
+                session.pty_exec_start("echo", "hello", shell=False, yield_time_s=0.01)
+            )
+            await process_started.wait()
+            await asyncio.sleep(0)
+            task.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert killpg_calls == [(1234, signal.SIGKILL)]
+            assert session._pty_processes == {}
+            assert session._reserved_pty_process_ids == set()
+        finally:
+            session._pty_lock.release()
+
+    @pytest.mark.asyncio
+    async def test_tty_start_cancellation_closes_open_file_descriptors(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(unix_local_module.sys, "platform", "linux")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        session = _RecordingUnixLocalSession(workspace)
+        close_calls: list[int] = []
+
+        def openpty() -> tuple[int, int]:
+            return 101, 102
+
+        async def create_subprocess(*args: object, **kwargs: object) -> None:
+            _ = (args, kwargs)
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(unix_local_module.os, "openpty", openpty)
+        monkeypatch.setattr(unix_local_module.os, "close", close_calls.append)
+        monkeypatch.setattr(unix_local_module.asyncio, "create_subprocess_exec", create_subprocess)
+
+        with pytest.raises(asyncio.CancelledError):
+            await session.pty_exec_start("echo", "hello", shell=False, tty=True)
+
+        assert close_calls == [101, 102]
+
+    @pytest.mark.asyncio
     async def test_tty_fd_close_is_owned_without_blocking_termination(
         self,
         tmp_path: Path,

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -234,6 +234,7 @@ class TestUnixLocalPty:
         process_wait_cancelled = asyncio.Event()
         pump_task_count = 0
         cancelled_pump_task_count = 0
+        process_kill_calls = 0
         killpg_calls: list[tuple[int, signal.Signals]] = []
 
         class _Stream:
@@ -265,14 +266,22 @@ class TestUnixLocalPty:
                     process_wait_cancelled.set()
                     raise
 
+            def kill(self) -> None:
+                nonlocal process_kill_calls
+                process_kill_calls += 1
+                raise PermissionError("synthetic direct cleanup failure")
+
+        process = _Process()
+
         async def create_subprocess(*args: object, **kwargs: object) -> _Process:
             _ = (args, kwargs)
             process_started.set()
-            return _Process()
+            return process
 
         def killpg(pid: int, signum: signal.Signals) -> None:
             killpg_calls.append((pid, signum))
-            raise PermissionError("synthetic cleanup failure")
+            if len(killpg_calls) == 1:
+                raise PermissionError("synthetic cleanup failure")
 
         monkeypatch.setattr(unix_local_module.asyncio, "create_subprocess_exec", create_subprocess)
         monkeypatch.setattr(unix_local_module.os, "killpg", killpg)
@@ -292,12 +301,22 @@ class TestUnixLocalPty:
             if sys.version_info >= (3, 11):
                 assert exc_info.value.args == ("startup-cancel",)
             assert killpg_calls == [(1234, signal.SIGKILL)]
+            assert process_kill_calls == 1
             assert pump_tasks_cancelled.is_set()
             assert process_wait_cancelled.is_set()
             assert session._pty_processes == {}
             assert session._reserved_pty_process_ids == set()
+            retained_entries = tuple(session._unregistered_pty_processes.values())
+            assert len(retained_entries) == 1
+            assert retained_entries[0].process is process
         finally:
             session._pty_lock.release()
+
+        await session.pty_terminate_all()
+
+        assert killpg_calls == [(1234, signal.SIGKILL), (1234, signal.SIGKILL)]
+        assert process_kill_calls == 1
+        assert session._unregistered_pty_processes == {}
 
     @pytest.mark.asyncio
     async def test_tty_start_cancellation_closes_open_file_descriptors(

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -255,7 +255,7 @@ class TestUnixLocalPty:
 
         class _Process:
             pid = 1234
-            returncode = None
+            returncode: int | None = None
             stdout = _Stream()
             stderr = _Stream()
 
@@ -322,6 +322,7 @@ class TestUnixLocalPty:
         assert len(retained_entries) == 1
         assert retained_entries[0].process is process
 
+        process.returncode = -signal.SIGKILL
         allow_group_kill = True
         await session.pty_terminate_all()
 

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import io
 import signal
-import sys
 import tarfile
 import threading
 import time
@@ -218,123 +217,6 @@ async def test_unix_local_rejects_host_path_before_creating_workspace(
 @pytest.mark.review_optional
 class TestUnixLocalPty:
     @pytest.mark.asyncio
-    async def test_pty_start_cancellation_cleans_up_before_registration(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setattr(unix_local_module.sys, "platform", "linux")
-        workspace = tmp_path / "workspace"
-        workspace.mkdir()
-        session = _RecordingUnixLocalSession(workspace)
-        process_started = asyncio.Event()
-        pump_tasks_started = asyncio.Event()
-        pump_tasks_cancelled = asyncio.Event()
-        process_wait_started = asyncio.Event()
-        process_wait_cancelled = asyncio.Event()
-        pump_task_count = 0
-        cancelled_pump_task_count = 0
-        allow_group_kill = False
-        process_kill_calls = 0
-        killpg_calls: list[tuple[int, signal.Signals]] = []
-
-        class _Stream:
-            async def read(self, size: int) -> bytes:
-                nonlocal pump_task_count, cancelled_pump_task_count
-                _ = size
-                pump_task_count += 1
-                if pump_task_count == 2:
-                    pump_tasks_started.set()
-                try:
-                    return await asyncio.Future[bytes]()
-                except asyncio.CancelledError:
-                    cancelled_pump_task_count += 1
-                    if cancelled_pump_task_count == 2:
-                        pump_tasks_cancelled.set()
-                    raise
-
-        class _Process:
-            pid = 1234
-            returncode: int | None = None
-            stdout = _Stream()
-            stderr = _Stream()
-
-            async def wait(self) -> None:
-                process_wait_started.set()
-                try:
-                    await asyncio.Future()
-                except asyncio.CancelledError:
-                    process_wait_cancelled.set()
-                    raise
-
-            def kill(self) -> None:
-                nonlocal process_kill_calls
-                process_kill_calls += 1
-                raise PermissionError("synthetic direct cleanup failure")
-
-        process = _Process()
-
-        async def create_subprocess(*args: object, **kwargs: object) -> _Process:
-            _ = (args, kwargs)
-            process_started.set()
-            return process
-
-        def killpg(pid: int, signum: signal.Signals) -> None:
-            killpg_calls.append((pid, signum))
-            if not allow_group_kill:
-                raise PermissionError("synthetic cleanup failure")
-
-        monkeypatch.setattr(unix_local_module.asyncio, "create_subprocess_exec", create_subprocess)
-        monkeypatch.setattr(unix_local_module.os, "killpg", killpg)
-        await session._pty_lock.acquire()
-        try:
-            task = asyncio.create_task(
-                session.pty_exec_start("echo", "hello", shell=False, yield_time_s=0.01)
-            )
-            await process_started.wait()
-            await pump_tasks_started.wait()
-            await process_wait_started.wait()
-            task.cancel("startup-cancel")
-
-            with pytest.raises(asyncio.CancelledError) as exc_info:
-                await task
-
-            if sys.version_info >= (3, 11):
-                assert exc_info.value.args == ("startup-cancel",)
-            assert killpg_calls == [(1234, signal.SIGKILL)]
-            assert process_kill_calls == 1
-            assert pump_tasks_cancelled.is_set()
-            assert process_wait_cancelled.is_set()
-            assert session._pty_processes == {}
-            assert session._reserved_pty_process_ids == set()
-            retained_entries = tuple(session._unregistered_pty_processes.values())
-            assert len(retained_entries) == 1
-            assert retained_entries[0].process is process
-        finally:
-            session._pty_lock.release()
-
-        with pytest.raises(PermissionError, match="synthetic direct cleanup failure"):
-            await session.pty_terminate_all()
-
-        assert killpg_calls == [(1234, signal.SIGKILL), (1234, signal.SIGKILL)]
-        assert process_kill_calls == 2
-        retained_entries = tuple(session._unregistered_pty_processes.values())
-        assert len(retained_entries) == 1
-        assert retained_entries[0].process is process
-
-        process.returncode = -signal.SIGKILL
-        allow_group_kill = True
-        await session.pty_terminate_all()
-
-        assert killpg_calls == [
-            (1234, signal.SIGKILL),
-            (1234, signal.SIGKILL),
-            (1234, signal.SIGKILL),
-        ]
-        assert process_kill_calls == 2
-        assert session._unregistered_pty_processes == {}
-
-    @pytest.mark.asyncio
     async def test_tty_start_cancellation_closes_open_file_descriptors(
         self,
         tmp_path: Path,
@@ -396,40 +278,6 @@ class TestUnixLocalPty:
         await asyncio.sleep(0)
 
         assert session._fd_close_tasks == set()
-
-    @pytest.mark.asyncio
-    async def test_pty_termination_preserves_group_error_when_leader_disappears(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        session = _RecordingUnixLocalSession(tmp_path)
-        allow_group_kill = False
-
-        def killpg(pid: int, signum: signal.Signals) -> None:
-            _ = (pid, signum)
-            if not allow_group_kill:
-                raise PermissionError("synthetic group cleanup failure")
-
-        def kill() -> None:
-            raise ProcessLookupError("synthetic missing leader")
-
-        monkeypatch.setattr(unix_local_module.os, "killpg", killpg)
-        process = cast(
-            asyncio.subprocess.Process,
-            SimpleNamespace(returncode=None, pid=1234, kill=kill),
-        )
-        entry = _UnixPtyProcessEntry(process=process, tty=False)
-
-        with pytest.raises(PermissionError, match="synthetic group cleanup failure"):
-            await session._terminate_pty_entry(entry)
-
-        assert tuple(session._unregistered_pty_processes.values()) == (entry,)
-
-        allow_group_kill = True
-        await session.pty_terminate_all()
-
-        assert session._unregistered_pty_processes == {}
 
     @pytest.mark.asyncio
     @pytest.mark.requires_native_macos_sandbox

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -397,6 +397,40 @@ class TestUnixLocalPty:
         assert session._fd_close_tasks == set()
 
     @pytest.mark.asyncio
+    async def test_pty_termination_preserves_group_error_when_leader_disappears(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        session = _RecordingUnixLocalSession(tmp_path)
+        allow_group_kill = False
+
+        def killpg(pid: int, signum: signal.Signals) -> None:
+            _ = (pid, signum)
+            if not allow_group_kill:
+                raise PermissionError("synthetic group cleanup failure")
+
+        def kill() -> None:
+            raise ProcessLookupError("synthetic missing leader")
+
+        monkeypatch.setattr(unix_local_module.os, "killpg", killpg)
+        process = cast(
+            asyncio.subprocess.Process,
+            SimpleNamespace(returncode=None, pid=1234, kill=kill),
+        )
+        entry = _UnixPtyProcessEntry(process=process, tty=False)
+
+        with pytest.raises(PermissionError, match="synthetic group cleanup failure"):
+            await session._terminate_pty_entry(entry)
+
+        assert tuple(session._unregistered_pty_processes.values()) == (entry,)
+
+        allow_group_kill = True
+        await session.pty_terminate_all()
+
+        assert session._unregistered_pty_processes == {}
+
+    @pytest.mark.asyncio
     @pytest.mark.requires_native_macos_sandbox
     async def test_pty_exec_write_poll_and_unknown_session_errors(self, tmp_path: Path) -> None:
         client = UnixLocalSandboxClient()

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -234,6 +234,7 @@ class TestUnixLocalPty:
         process_wait_cancelled = asyncio.Event()
         pump_task_count = 0
         cancelled_pump_task_count = 0
+        allow_group_kill = False
         process_kill_calls = 0
         killpg_calls: list[tuple[int, signal.Signals]] = []
 
@@ -280,7 +281,7 @@ class TestUnixLocalPty:
 
         def killpg(pid: int, signum: signal.Signals) -> None:
             killpg_calls.append((pid, signum))
-            if len(killpg_calls) == 1:
+            if not allow_group_kill:
                 raise PermissionError("synthetic cleanup failure")
 
         monkeypatch.setattr(unix_local_module.asyncio, "create_subprocess_exec", create_subprocess)
@@ -312,10 +313,24 @@ class TestUnixLocalPty:
         finally:
             session._pty_lock.release()
 
-        await session.pty_terminate_all()
+        with pytest.raises(PermissionError, match="synthetic direct cleanup failure"):
+            await session.pty_terminate_all()
 
         assert killpg_calls == [(1234, signal.SIGKILL), (1234, signal.SIGKILL)]
-        assert process_kill_calls == 1
+        assert process_kill_calls == 2
+        retained_entries = tuple(session._unregistered_pty_processes.values())
+        assert len(retained_entries) == 1
+        assert retained_entries[0].process is process
+
+        allow_group_kill = True
+        await session.pty_terminate_all()
+
+        assert killpg_calls == [
+            (1234, signal.SIGKILL),
+            (1234, signal.SIGKILL),
+            (1234, signal.SIGKILL),
+        ]
+        assert process_kill_calls == 2
         assert session._unregistered_pty_processes == {}
 
     @pytest.mark.asyncio

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import io
 import signal
+import sys
 import tarfile
 import threading
 import time
@@ -227,16 +228,42 @@ class TestUnixLocalPty:
         workspace.mkdir()
         session = _RecordingUnixLocalSession(workspace)
         process_started = asyncio.Event()
+        pump_tasks_started = asyncio.Event()
+        pump_tasks_cancelled = asyncio.Event()
+        process_wait_started = asyncio.Event()
+        process_wait_cancelled = asyncio.Event()
+        pump_task_count = 0
+        cancelled_pump_task_count = 0
         killpg_calls: list[tuple[int, signal.Signals]] = []
+
+        class _Stream:
+            async def read(self, size: int) -> bytes:
+                nonlocal pump_task_count, cancelled_pump_task_count
+                _ = size
+                pump_task_count += 1
+                if pump_task_count == 2:
+                    pump_tasks_started.set()
+                try:
+                    return await asyncio.Future[bytes]()
+                except asyncio.CancelledError:
+                    cancelled_pump_task_count += 1
+                    if cancelled_pump_task_count == 2:
+                        pump_tasks_cancelled.set()
+                    raise
 
         class _Process:
             pid = 1234
             returncode = None
-            stdout = None
-            stderr = None
+            stdout = _Stream()
+            stderr = _Stream()
 
             async def wait(self) -> None:
-                return None
+                process_wait_started.set()
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    process_wait_cancelled.set()
+                    raise
 
         async def create_subprocess(*args: object, **kwargs: object) -> _Process:
             _ = (args, kwargs)
@@ -255,14 +282,18 @@ class TestUnixLocalPty:
                 session.pty_exec_start("echo", "hello", shell=False, yield_time_s=0.01)
             )
             await process_started.wait()
-            await asyncio.sleep(0)
+            await pump_tasks_started.wait()
+            await process_wait_started.wait()
             task.cancel("startup-cancel")
 
             with pytest.raises(asyncio.CancelledError) as exc_info:
                 await task
 
-            assert exc_info.value.args == ("startup-cancel",)
+            if sys.version_info >= (3, 11):
+                assert exc_info.value.args == ("startup-cancel",)
             assert killpg_calls == [(1234, signal.SIGKILL)]
+            assert pump_tasks_cancelled.is_set()
+            assert process_wait_cancelled.is_set()
             assert session._pty_processes == {}
             assert session._reserved_pty_process_ids == set()
         finally:


### PR DESCRIPTION
### Summary

Fixes the reachable PTY startup ownership gaps described in #4749.

- Blaxel can create an `aiohttp.ClientSession`, WebSocket, and reader task before registering the entry. Caller cancellation now settles cleanup before propagating.
- UnixLocal now closes both TTY file descriptors when cancellation interrupts `create_subprocess_exec()`.

The UnixLocal process-registration machinery proposed initially has been removed: registration has no suspension point while `_pty_lock` is held, so the lock-contention cancellation window required a synthetic private-lock test and is not reachable through ordinary producers.

### Test plan

- Added deterministic regressions for Blaxel cancellation during connection, cleanup cancellation/error precedence, and UnixLocal TTY descriptor cleanup.
- The startup cancellation regressions fail on the parent commit and pass with this change.
- `pytest -q tests/extensions/sandbox/test_blaxel.py tests/sandbox/test_unix_local.py tests/sandbox/test_pty_types.py` — 271 passed, 2 skipped
- `ruff check` on all six changed source and test files — passed
- `ruff format --check` on all six changed source and test files — passed
- `pyright` on all six changed source and test files — passed
- `git diff --check` — passed

The repository verification wrapper was also attempted. In this local environment it stops before lint/typecheck/tests because the installed uv cannot parse the repository's `exclude-newer = "7 days"` setting and, in locked mode, requests a lockfile rewrite. The lockfile was not changed. Running the equivalent checks directly with the existing virtual environment produced the results above. Targeted Mypy reaches 40 existing errors in eight imported modules outside the three changed source files; no reported error points at a changed file.

### Issue number

Closes #4749

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
