### PR TITLE
fix: reject prefixItems in strict tool schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -41,6 +41,55 @@ _PREFIX_ITEMS_ERROR = (
     "Use a homogeneous tuple (tuple[T, ...]) or list[T] instead."
 )
 
+_SCHEMA_CHILD_KEYS = frozenset(
+    {
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+_SCHEMA_CHILD_LIST_KEYS = frozenset({"allOf", "anyOf", "oneOf"})
+_SCHEMA_CHILD_MAP_KEYS = frozenset(
+    {"$defs", "definitions", "dependentSchemas", "patternProperties", "properties"}
+)
+
+
+def _reject_prefix_items(schema: object) -> None:
+    """Reject ``prefixItems`` in schema-valued positions without inspecting annotations."""
+    stack = [schema]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, dict):
+            if "prefixItems" in value:
+                raise UserError(_PREFIX_ITEMS_ERROR)
+
+            for key in _SCHEMA_CHILD_KEYS:
+                child = value.get(key)
+                if isinstance(child, dict | list):
+                    stack.append(child)
+
+            for key in _SCHEMA_CHILD_LIST_KEYS:
+                children = value.get(key)
+                if isinstance(children, list):
+                    stack.extend(child for child in children if isinstance(child, dict))
+
+            for key in _SCHEMA_CHILD_MAP_KEYS:
+                children = value.get(key)
+                if isinstance(children, dict):
+                    stack.extend(child for child in children.values() if isinstance(child, dict))
+        elif isinstance(value, list):
+            stack.extend(child for child in value if isinstance(child, dict))
+
+
 _UNVALIDATED_REF_ERROR = (
     "JSON schema contains a reference whose target was not validated for strict mode."
 )
@@ -126,6 +175,7 @@ def ensure_strict_json_schema(
     that the OpenAI API expects.
     """
     _validate_json_schema_depth(schema)
+    _reject_prefix_items(schema)
     if schema == {}:
         return copy.deepcopy(_EMPTY_SCHEMA)
     budget = _NodeBudget(_MAX_SCHEMA_NODES, reject_open_objects=_reject_open_objects)
@@ -171,9 +221,6 @@ def _ensure_strict_json_schema(
 
     if not is_dict(json_schema):
         raise TypeError(f"Expected {json_schema} to be a dictionary; path={path}")
-
-    if "prefixItems" in json_schema:
-        raise UserError(_PREFIX_ITEMS_ERROR)
 
     # Bound the total number of nodes we expand so a malicious `$ref` fan-out cannot expand
     # exponentially and exhaust CPU and memory.

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -36,6 +36,11 @@ _OPEN_OBJECT_ERROR = (
     "to a strict schema without changing its accepted values."
 )
 
+_PREFIX_ITEMS_ERROR = (
+    "JSON schema contains `prefixItems`, which is not supported by strict tool schemas. "
+    "Use a homogeneous tuple (tuple[T, ...]) or list[T] instead."
+)
+
 _UNVALIDATED_REF_ERROR = (
     "JSON schema contains a reference whose target was not validated for strict mode."
 )
@@ -166,6 +171,9 @@ def _ensure_strict_json_schema(
 
     if not is_dict(json_schema):
         raise TypeError(f"Expected {json_schema} to be a dictionary; path={path}")
+
+    if "prefixItems" in json_schema:
+        raise UserError(_PREFIX_ITEMS_ERROR)
 
     # Bound the total number of nodes we expand so a malicious `$ref` fan-out cannot expand
     # exponentially and exhaust CPU and memory.

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -41,55 +41,6 @@ _PREFIX_ITEMS_ERROR = (
     "Use a homogeneous tuple (tuple[T, ...]) or list[T] instead."
 )
 
-_SCHEMA_CHILD_KEYS = frozenset(
-    {
-        "additionalItems",
-        "additionalProperties",
-        "contains",
-        "contentSchema",
-        "else",
-        "if",
-        "items",
-        "not",
-        "propertyNames",
-        "then",
-        "unevaluatedItems",
-        "unevaluatedProperties",
-    }
-)
-_SCHEMA_CHILD_LIST_KEYS = frozenset({"allOf", "anyOf", "oneOf"})
-_SCHEMA_CHILD_MAP_KEYS = frozenset(
-    {"$defs", "definitions", "dependentSchemas", "patternProperties", "properties"}
-)
-
-
-def _reject_prefix_items(schema: object) -> None:
-    """Reject ``prefixItems`` in schema-valued positions without inspecting annotations."""
-    stack = [schema]
-    while stack:
-        value = stack.pop()
-        if isinstance(value, dict):
-            if "prefixItems" in value:
-                raise UserError(_PREFIX_ITEMS_ERROR)
-
-            for key in _SCHEMA_CHILD_KEYS:
-                child = value.get(key)
-                if isinstance(child, dict | list):
-                    stack.append(child)
-
-            for key in _SCHEMA_CHILD_LIST_KEYS:
-                children = value.get(key)
-                if isinstance(children, list):
-                    stack.extend(child for child in children if isinstance(child, dict))
-
-            for key in _SCHEMA_CHILD_MAP_KEYS:
-                children = value.get(key)
-                if isinstance(children, dict):
-                    stack.extend(child for child in children.values() if isinstance(child, dict))
-        elif isinstance(value, list):
-            stack.extend(child for child in value if isinstance(child, dict))
-
-
 _UNVALIDATED_REF_ERROR = (
     "JSON schema contains a reference whose target was not validated for strict mode."
 )
@@ -175,7 +126,6 @@ def ensure_strict_json_schema(
     that the OpenAI API expects.
     """
     _validate_json_schema_depth(schema)
-    _reject_prefix_items(schema)
     if schema == {}:
         return copy.deepcopy(_EMPTY_SCHEMA)
     budget = _NodeBudget(_MAX_SCHEMA_NODES, reject_open_objects=_reject_open_objects)
@@ -221,6 +171,9 @@ def _ensure_strict_json_schema(
 
     if not is_dict(json_schema):
         raise TypeError(f"Expected {json_schema} to be a dictionary; path={path}")
+
+    if "prefixItems" in json_schema:
+        raise UserError(_PREFIX_ITEMS_ERROR)
 
     # Bound the total number of nodes we expand so a malicious `$ref` fan-out cannot expand
     # exponentially and exhaust CPU and memory.

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -486,6 +486,26 @@ def test_var_positional_fixed_length_tuple_annotation_is_rejected(func: Any):
         function_schema(func, use_docstring_info=False)
 
 
+def _fixed_length_tuple_parameter(point: tuple[int, str]) -> str:
+    return repr(point)
+
+
+def test_fixed_length_tuple_parameter_is_rejected_in_strict_mode():
+    with pytest.raises(UserError, match=r"`prefixItems`.*list\[T\]"):
+        function_schema(_fixed_length_tuple_parameter, use_docstring_info=False)
+
+
+def test_fixed_length_tuple_parameter_remains_available_in_non_strict_mode():
+    fs = function_schema(
+        _fixed_length_tuple_parameter,
+        use_docstring_info=False,
+        strict_json_schema=False,
+    )
+
+    point_schema = fs.params_json_schema["properties"]["point"]
+    assert point_schema["prefixItems"] == [{"type": "integer"}, {"type": "string"}]
+
+
 def _var_positional_homogeneous_tuple(*args: tuple[int, ...]) -> int:
     return len(args)
 

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -131,40 +131,6 @@ def test_typeless_root_is_normalized_to_object():
     }
 
 
-def test_prefix_items_property_name_is_not_rejected():
-    schema = {
-        "type": "object",
-        "properties": {"prefixItems": {"type": "string"}},
-    }
-
-    result = ensure_strict_json_schema(schema)
-
-    assert result["properties"]["prefixItems"] == {"type": "string"}
-
-
-@pytest.mark.parametrize("schema_map_keyword", ["dependentSchemas", "patternProperties"])
-def test_prefix_items_is_rejected_in_schema_maps_regardless_of_entry_name(schema_map_keyword):
-    with pytest.raises(UserError, match="`prefixItems`"):
-        ensure_strict_json_schema(
-            {
-                "type": "object",
-                schema_map_keyword: {"default": {"type": "array", "prefixItems": []}},
-            }
-        )
-
-
-def test_prefix_items_in_annotations_is_not_rejected():
-    result = ensure_strict_json_schema(
-        {
-            "type": "string",
-            "default": {"prefixItems": []},
-            "examples": [{"prefixItems": []}],
-        }
-    )
-
-    assert result["default"] == {"prefixItems": []}
-
-
 def test_nullable_object_root_errors():
     with pytest.raises(UserError, match="root of a strict JSON schema"):
         ensure_strict_json_schema(

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -131,6 +131,40 @@ def test_typeless_root_is_normalized_to_object():
     }
 
 
+def test_prefix_items_property_name_is_not_rejected():
+    schema = {
+        "type": "object",
+        "properties": {"prefixItems": {"type": "string"}},
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["properties"]["prefixItems"] == {"type": "string"}
+
+
+@pytest.mark.parametrize("schema_map_keyword", ["dependentSchemas", "patternProperties"])
+def test_prefix_items_is_rejected_in_schema_maps_regardless_of_entry_name(schema_map_keyword):
+    with pytest.raises(UserError, match="`prefixItems`"):
+        ensure_strict_json_schema(
+            {
+                "type": "object",
+                schema_map_keyword: {"default": {"type": "array", "prefixItems": []}},
+            }
+        )
+
+
+def test_prefix_items_in_annotations_is_not_rejected():
+    result = ensure_strict_json_schema(
+        {
+            "type": "string",
+            "default": {"prefixItems": []},
+            "examples": [{"prefixItems": []}],
+        }
+    )
+
+    assert result["default"] == {"prefixItems": []}
+
+
 def test_nullable_object_root_errors():
     with pytest.raises(UserError, match="root of a strict JSON schema"):
         ensure_strict_json_schema(


### PR DESCRIPTION
### Summary

Reject `prefixItems` during strict JSON schema conversion so ordinary fixed-length tuple parameters fail during tool construction with guidance for supported homogeneous tuples and lists. Non-strict schemas retain their existing behavior.

### Test plan

- `uv run --frozen pytest tests/test_function_schema.py tests/test_strict_schema.py tests/test_strict_schema_oneof.py -q` (130 passed)
- `uv run --frozen ruff check src/agents/strict_schema.py tests/test_function_schema.py` (passed)
- `uv run --frozen ruff format --check src/agents/strict_schema.py tests/test_function_schema.py` (passed)
- `uv run --frozen pyright src/agents/strict_schema.py` (0 errors)
- `git diff --check` (passed)

The full pytest suite and single-file mypy check did not complete in the local Windows environment; both remained in dependency/test execution without producing a result and were terminated. No production failure was observed.

### Issue number

Closes #4752

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR