### PR TITLE
fix(sandbox): preserve UTF-8 across PTY output windows

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -12,6 +12,7 @@ import the package.
 from __future__ import annotations
 
 import asyncio
+import codecs
 import io
 import json
 import logging
@@ -309,6 +310,9 @@ class _BlaxelPtySessionEntry:
     output_chunks: deque[bytes] = field(default_factory=deque)
     output_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     output_notify: asyncio.Event = field(default_factory=asyncio.Event)
+    output_decoder: codecs.IncrementalDecoder = field(
+        default_factory=lambda: codecs.getincrementaldecoder("utf-8")("replace")
+    )
     last_used: float = field(default_factory=time.monotonic)
     done: bool = False
     exit_code: int | None = None
@@ -969,6 +973,7 @@ class BlaxelSandboxSession(BaseSandboxSession):
             output_chunks=entry.output_chunks,
             output_lock=entry.output_lock,
             output_notify=entry.output_notify,
+            output_decoder=entry.output_decoder,
             is_done=lambda: entry.done,
             yield_time_ms=yield_time_ms,
             max_output_tokens=max_output_tokens,

--- a/src/agents/extensions/sandbox/cloudflare/sandbox.py
+++ b/src/agents/extensions/sandbox/cloudflare/sandbox.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import codecs
 import io
 import json
 import logging
@@ -386,6 +387,9 @@ class _CloudflarePtyProcessEntry:
     output_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     output_notify: asyncio.Event = field(default_factory=asyncio.Event)
     output_closed: asyncio.Event = field(default_factory=asyncio.Event)
+    output_decoder: codecs.IncrementalDecoder = field(
+        default_factory=lambda: codecs.getincrementaldecoder("utf-8")("replace")
+    )
     pump_task: asyncio.Task[None] | None = None
     exit_code: int | None = None
 
@@ -1058,7 +1062,7 @@ class CloudflareSandboxSession(BaseSandboxSession):
                 break
             entry.output_notify.clear()
 
-        text = output.decode("utf-8", errors="replace")
+        text = entry.output_decoder.decode(bytes(output), final=entry.output_closed.is_set())
         truncated_text, original_token_count = truncate_text_by_tokens(text, max_output_tokens)
         return truncated_text.encode("utf-8", errors="replace"), original_token_count
 

--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -12,6 +12,7 @@ import the package.
 from __future__ import annotations
 
 import asyncio
+import codecs
 import io
 import logging
 import math
@@ -387,6 +388,10 @@ class _DaytonaPtySessionEntry:
     output_chunks: deque[bytes] = field(default_factory=deque)
     output_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     output_notify: asyncio.Event = field(default_factory=asyncio.Event)
+    output_closed: asyncio.Event = field(default_factory=asyncio.Event)
+    output_decoder: codecs.IncrementalDecoder = field(
+        default_factory=lambda: codecs.getincrementaldecoder("utf-8")("replace")
+    )
     last_used: float = field(default_factory=time.monotonic)
     done: bool = False
     exit_code: int | None = None
@@ -806,6 +811,7 @@ class DaytonaSandboxSession(BaseSandboxSession):
                 pass
             if not logs_failed:
                 entry.done = True
+            entry.output_closed.set()
             entry.output_notify.set()
 
     async def pty_write_stdin(
@@ -858,7 +864,7 @@ class DaytonaSandboxSession(BaseSandboxSession):
         exit_code = entry.exit_code if entry.done else None
         live_process_id: int | None = process_id
 
-        if entry.done:
+        if entry.done and entry.output_closed.is_set():
             async with self._pty_lock:
                 removed = self._pty_sessions.pop(process_id, None)
                 self._reserved_pty_process_ids.discard(process_id)
@@ -892,7 +898,9 @@ class DaytonaSandboxSession(BaseSandboxSession):
             output_chunks=entry.output_chunks,
             output_lock=entry.output_lock,
             output_notify=entry.output_notify,
+            output_decoder=entry.output_decoder,
             is_done=lambda: entry.done,
+            is_output_closed=entry.output_closed.is_set,
             yield_time_ms=yield_time_ms,
             max_output_tokens=max_output_tokens,
         )

--- a/src/agents/extensions/sandbox/e2b/sandbox.py
+++ b/src/agents/extensions/sandbox/e2b/sandbox.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import codecs
 import inspect
 import io
 import json
@@ -686,7 +687,11 @@ class _E2BPtyProcessEntry:
     tty: bool
     output_chunks: deque[bytes] = field(default_factory=deque)
     output_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    output_decoder: codecs.IncrementalDecoder = field(
+        default_factory=lambda: codecs.getincrementaldecoder("utf-8")("replace")
+    )
     output_notify: asyncio.Event = field(default_factory=asyncio.Event)
+    output_closed: asyncio.Event = field(default_factory=asyncio.Event)
     last_used: float = field(default_factory=time.monotonic)
     exit_code: int | None = None
     wait_task: asyncio.Task[None] | None = None
@@ -1239,7 +1244,9 @@ class E2BSandboxSession(BaseSandboxSession):
                 break
             entry.output_notify.clear()
 
-        text = output.decode("utf-8", errors="replace")
+        # E2B may deliver callback output after the process wait completes. Keep the
+        # decoder open so a character split across that boundary is not replaced.
+        text = entry.output_decoder.decode(bytes(output), final=entry.output_closed.is_set())
         truncated_text, original_token_count = truncate_text_by_tokens(text, max_output_tokens)
         return truncated_text.encode("utf-8", errors="replace"), original_token_count
 
@@ -1259,6 +1266,7 @@ class E2BSandboxSession(BaseSandboxSession):
                 except (TypeError, ValueError):
                     pass
         finally:
+            entry.output_closed.set()
             entry.output_notify.set()
 
     async def _finalize_pty_update(
@@ -1272,7 +1280,7 @@ class E2BSandboxSession(BaseSandboxSession):
         exit_code = self._entry_exit_code(entry)
         live_process_id: int | None = process_id
 
-        if exit_code is not None:
+        if exit_code is not None and entry.output_closed.is_set():
             async with self._pty_lock:
                 removed = self._pty_processes.pop(process_id, None)
                 self._reserved_pty_process_ids.discard(process_id)

--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -14,6 +14,7 @@ we import Modal normally so IDEs can resolve and navigate Modal types.
 from __future__ import annotations
 
 import asyncio
+import codecs
 import functools
 import io
 import json
@@ -489,6 +490,12 @@ class _ModalPtyProcessEntry:
     stderr_iter: AsyncIterator[object] | None = None
     stdout_read_task: asyncio.Task[object] | None = None
     stderr_read_task: asyncio.Task[object] | None = None
+    stdout_closed: bool = False
+    stderr_closed: bool = False
+    output_closed: asyncio.Event = field(default_factory=asyncio.Event)
+    output_decoder: codecs.IncrementalDecoder = field(
+        default_factory=lambda: codecs.getincrementaldecoder("utf-8")("replace")
+    )
 
 
 class ModalSandboxSession(BaseSandboxSession):
@@ -1010,7 +1017,9 @@ class ModalSandboxSession(BaseSandboxSession):
                     break
                 await asyncio.sleep(min(_PTY_POLL_INTERVAL_S, remaining_s))
 
-        text = chunks.decode("utf-8", errors="replace")
+        # Modal can expose process completion before its stream readers have delivered
+        # every buffered byte. Keep decoder state until the entry is discarded.
+        text = entry.output_decoder.decode(bytes(chunks), final=entry.output_closed.is_set())
         truncated_text, original_token_count = truncate_text_by_tokens(text, max_output_tokens)
         return truncated_text.encode("utf-8", errors="replace"), original_token_count
 
@@ -1041,6 +1050,9 @@ class ModalSandboxSession(BaseSandboxSession):
     ) -> bytes:
         stream = entry.process.stdout if stream_name == "stdout" else entry.process.stderr
         if stream is None:
+            setattr(entry, "stdout_closed" if stream_name == "stdout" else "stderr_closed", True)
+            if entry.stdout_closed and entry.stderr_closed:
+                entry.output_closed.set()
             return b""
 
         iter_attr = "stdout_iter" if stream_name == "stdout" else "stderr_iter"
@@ -1072,9 +1084,19 @@ class ModalSandboxSession(BaseSandboxSession):
                 value = task.result()
             except StopAsyncIteration:
                 setattr(entry, iter_attr, None)
+                setattr(
+                    entry, "stdout_closed" if stream_name == "stdout" else "stderr_closed", True
+                )
+                if entry.stdout_closed and entry.stderr_closed:
+                    entry.output_closed.set()
                 return b""
             except Exception:
                 setattr(entry, iter_attr, None)
+                setattr(
+                    entry, "stdout_closed" if stream_name == "stdout" else "stderr_closed", True
+                )
+                if entry.stdout_closed and entry.stderr_closed:
+                    entry.output_closed.set()
                 return b""
 
             return self._coerce_modal_stream_chunk(value)
@@ -1086,11 +1108,18 @@ class ModalSandboxSession(BaseSandboxSession):
         try:
             value = await self._call_modal(read, 16_384, call_timeout=0.2)
         except TypeError:
+            setattr(entry, "stdout_closed" if stream_name == "stdout" else "stderr_closed", True)
             return b""
         except Exception:
+            setattr(entry, "stdout_closed" if stream_name == "stdout" else "stderr_closed", True)
             return b""
 
-        return self._coerce_modal_stream_chunk(value)
+        chunk = self._coerce_modal_stream_chunk(value)
+        if not chunk:
+            setattr(entry, "stdout_closed" if stream_name == "stdout" else "stderr_closed", True)
+            if entry.stdout_closed and entry.stderr_closed:
+                entry.output_closed.set()
+        return chunk
 
     def _coerce_modal_stream_chunk(self, value: object) -> bytes:
         if value is None:
@@ -1113,7 +1142,7 @@ class ModalSandboxSession(BaseSandboxSession):
     ) -> PtyExecUpdate:
         exit_code = await self._peek_exit_code(entry.process)
         live_process_id: int | None = process_id
-        if exit_code is not None:
+        if exit_code is not None and entry.output_closed.is_set():
             async with self._pty_lock:
                 removed = self._pty_processes.pop(process_id, None)
                 self._reserved_pty_process_ids.discard(process_id)

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -1,4 +1,5 @@
 import asyncio
+import codecs
 import errno
 import hashlib
 import io
@@ -254,6 +255,9 @@ class _DockerPtyProcessEntry:
     output_chunks: deque[bytes] = field(default_factory=deque)
     output_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     output_notify: asyncio.Event = field(default_factory=asyncio.Event)
+    output_decoder: codecs.IncrementalDecoder = field(
+        default_factory=lambda: codecs.getincrementaldecoder("utf-8")("replace")
+    )
     output_closed: asyncio.Event = field(default_factory=asyncio.Event)
     reader_thread: threading.Thread | None = None
     wait_task: asyncio.Task[None] | None = None
@@ -1247,6 +1251,7 @@ class DockerSandboxSession(BaseSandboxSession):
             output_chunks=entry.output_chunks,
             output_lock=entry.output_lock,
             output_notify=entry.output_notify,
+            output_decoder=entry.output_decoder,
             is_done=entry.output_closed.is_set,
             yield_time_ms=yield_time_ms,
             max_output_tokens=max_output_tokens,

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -7,6 +7,7 @@ if sys.platform == "win32":  # pragma: no cover
     )
 
 import asyncio
+import codecs
 import errno
 import fcntl
 import io
@@ -147,6 +148,9 @@ class _UnixPtyProcessEntry:
     output_chunks: deque[bytes] = field(default_factory=deque)
     output_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     output_notify: asyncio.Event = field(default_factory=asyncio.Event)
+    output_decoder: codecs.IncrementalDecoder = field(
+        default_factory=lambda: codecs.getincrementaldecoder("utf-8")("replace")
+    )
     output_closed: asyncio.Event = field(default_factory=asyncio.Event)
     pump_tasks: list[asyncio.Task[None]] = field(default_factory=list)
     wait_task: asyncio.Task[None] | None = None
@@ -538,6 +542,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
             output_chunks=entry.output_chunks,
             output_lock=entry.output_lock,
             output_notify=entry.output_notify,
+            output_decoder=entry.output_decoder,
             is_done=entry.output_closed.is_set,
             yield_time_ms=yield_time_ms,
             max_output_tokens=max_output_tokens,

--- a/src/agents/sandbox/session/pty_output.py
+++ b/src/agents/sandbox/session/pty_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import time
 from collections import deque
 from collections.abc import Callable
@@ -13,7 +14,9 @@ async def collect_pty_output(
     output_chunks: deque[bytes],
     output_lock: asyncio.Lock,
     output_notify: asyncio.Event,
+    output_decoder: codecs.IncrementalDecoder | None = None,
     is_done: Callable[[], bool],
+    is_output_closed: Callable[[], bool] | None = None,
     yield_time_ms: int,
     max_output_tokens: int | None,
 ) -> tuple[bytes, int | None]:
@@ -45,6 +48,7 @@ async def collect_pty_output(
             break
         output_notify.clear()
 
-    text = output.decode("utf-8", errors="replace")
+    decoder = output_decoder or codecs.getincrementaldecoder("utf-8")("replace")
+    text = decoder.decode(bytes(output), final=(is_output_closed or is_done)())
     truncated, original_token_count = truncate_text_by_tokens(text, max_output_tokens)
     return truncated.encode("utf-8", errors="replace"), original_token_count

--- a/tests/sandbox/test_pty_output.py
+++ b/tests/sandbox/test_pty_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 from collections import deque
 
 import pytest
@@ -13,6 +14,7 @@ async def test_collect_pty_output_waits_for_notification() -> None:
     output_chunks: deque[bytes] = deque()
     output_lock = asyncio.Lock()
     output_notify = asyncio.Event()
+    output_decoder = codecs.getincrementaldecoder("utf-8")("replace")
     done = False
 
     async def produce_output() -> None:
@@ -28,6 +30,7 @@ async def test_collect_pty_output_waits_for_notification() -> None:
         output_chunks=output_chunks,
         output_lock=output_lock,
         output_notify=output_notify,
+        output_decoder=output_decoder,
         is_done=lambda: done,
         yield_time_ms=500,
         max_output_tokens=None,
@@ -50,6 +53,7 @@ async def test_collect_pty_output_drains_chunks_added_when_done() -> None:
         output_chunks=output_chunks,
         output_lock=asyncio.Lock(),
         output_notify=asyncio.Event(),
+        output_decoder=codecs.getincrementaldecoder("utf-8")("replace"),
         is_done=mark_done,
         yield_time_ms=500,
         max_output_tokens=None,
@@ -57,3 +61,46 @@ async def test_collect_pty_output_drains_chunks_added_when_done() -> None:
 
     assert output == b"before done after done"
     assert original_token_count is None
+
+
+@pytest.mark.asyncio
+async def test_collect_pty_output_preserves_utf8_across_windows() -> None:
+    output_chunks = deque(["é".encode()[:1]])
+    output_decoder = codecs.getincrementaldecoder("utf-8")("replace")
+
+    first, _ = await collect_pty_output(
+        output_chunks=output_chunks,
+        output_lock=asyncio.Lock(),
+        output_notify=asyncio.Event(),
+        output_decoder=output_decoder,
+        is_done=lambda: False,
+        yield_time_ms=0,
+        max_output_tokens=None,
+    )
+    output_chunks.append("é".encode()[1:])
+    second, _ = await collect_pty_output(
+        output_chunks=output_chunks,
+        output_lock=asyncio.Lock(),
+        output_notify=asyncio.Event(),
+        output_decoder=output_decoder,
+        is_done=lambda: True,
+        yield_time_ms=0,
+        max_output_tokens=None,
+    )
+
+    assert first == b""
+    assert second == "é".encode()
+
+
+@pytest.mark.asyncio
+async def test_collect_pty_output_keeps_legacy_call_compatible() -> None:
+    output, _ = await collect_pty_output(
+        output_chunks=deque(["é".encode()]),
+        output_lock=asyncio.Lock(),
+        output_notify=asyncio.Event(),
+        is_done=lambda: True,
+        yield_time_ms=0,
+        max_output_tokens=None,
+    )
+
+    assert output == "é".encode()


### PR DESCRIPTION
### Summary

Fixes UTF-8 corruption when a valid multi-byte character is split between consecutive PTY collection windows. Each PTY entry now owns an incremental UTF-8 decoder, and provider output-close signals are kept separate from process completion where the provider exposes them.

### Test plan

- `uv run --frozen pytest -q tests/sandbox/test_pty_output.py` — 4 passed
- Targeted Ruff check and format check — passed
- `python -m py_compile` on changed runtime modules — passed
- `git diff --check` — passed
- Repository verification script was attempted, but stopped because Windows has no `make` executable. `winget` installation attempts for `ezwinports.make` and `GnuWin32.Make` could not complete from SourceForge in this environment.

The focused regression is fully offline and does not require provider credentials. Provider-specific integration tests were not run because they require external services. The E2B API does not expose a separately verifiable callback-EOF signal in this code path; E2B retains its existing process-wait lifecycle. Same-session concurrent PTY collection is not an explicitly supported API contract and was not changed.

### Issue number

Closes #4744

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run independent implementation review before submitting this PR

AI disclosure: This change was prepared with Codex. The implementation, tests, verification, and limitations were reviewed against the repository guidance before submission.
