### PR TITLE
fix(voice): normalize PCM16 float output correctly

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -109,7 +109,7 @@ class StreamedAudioResult:
         if output_dtype == np.int16:
             return np_array
         elif output_dtype == np.float32:
-            return (np_array.astype(np.float32) / 32767.0).reshape(-1, 1)
+            return (np_array.astype(np.float32) / 32768.0).reshape(-1, 1)
         else:
             raise UserError("Invalid output dtype")
 

--- a/tests/voice/test_audio_result_pcm.py
+++ b/tests/voice/test_audio_result_pcm.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from agents.voice import StreamedAudioResult, TTSModelSettings, VoicePipelineConfig
+
+from .pipeline_test_models import ZeroPcmTTSModel
+
+
+def test_streamed_audio_result_normalizes_pcm16_full_scale_to_float32() -> None:
+    result = StreamedAudioResult(
+        ZeroPcmTTSModel(),
+        TTSModelSettings(dtype=np.float32),
+        VoicePipelineConfig(),
+    )
+    samples = np.array([-32768, 32767], dtype=np.int16)
+
+    transformed = result._transform_audio_buffer([samples.tobytes()], np.float32)
+
+    assert transformed.dtype == np.float32
+    assert transformed.shape == (2, 1)
+    assert transformed[0, 0] == -1.0
+    assert transformed[1, 0] == np.float32(32767 / 32768)
+    assert np.all(transformed >= -1.0)
+    assert np.all(transformed <= 1.0)


### PR DESCRIPTION
### Summary

This pull request fixes PCM16-to-float32 normalization in `StreamedAudioResult`.

The existing conversion divided signed 16-bit samples by `32767.0`, which maps the valid minimum PCM16 sample `-32768` to approximately `-1.00003`. Using `32768.0` keeps the complete PCM16 range within the normalized float interval: `-32768` maps to `-1.0` and `32767` maps to approximately `0.99997`. This also matches the existing PCM16 normalization used by the realtime CLI example when computing audio RMS.

The int16 output path, float32 output shape, buffering, and streaming behavior are unchanged.

### Test plan

- Added a focused regression covering both PCM16 full-scale endpoints.
- Verified the float32 result remains within `[-1.0, 1.0]` and preserves the expected `(n, 1)` shape.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR