### PR TITLE
fix(schema): reject unsupported prefixItems in strict mode

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -48,6 +48,11 @@ _SCHEMA_DEPTH_ERROR = (
     "JSON schema is too deeply nested to process safely. Simplify or flatten the schema."
 )
 
+_PREFIX_ITEMS_ERROR = (
+    "JSON schema keyword `prefixItems` is not supported in strict mode. Use a homogeneous array "
+    "type such as `list[T]` or `tuple[T, ...]`, or disable strict JSON schema mode."
+)
+
 
 def _validate_json_schema_depth(schema: object) -> None:
     """Reject container nesting that is unsafe for recursive schema processing."""
@@ -69,6 +74,20 @@ def _copy_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Copy a JSON schema only after verifying recursive copying is safe."""
     _validate_json_schema_depth(schema)
     return copy.deepcopy(schema)
+
+
+def _reject_prefix_items(schema: object) -> None:
+    """Reject unsupported ``prefixItems`` wherever it appears in a schema tree."""
+    annotation_keywords = {"const", "default", "description", "enum", "examples", "title"}
+    stack = [schema]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, dict):
+            if "prefixItems" in value:
+                raise UserError(_PREFIX_ITEMS_ERROR)
+            stack.extend(child for key, child in value.items() if key not in annotation_keywords)
+        elif isinstance(value, list):
+            stack.extend(value)
 
 
 # Keywords that may legally sit alongside a `$ref` without adding validation constraints.
@@ -121,6 +140,7 @@ def ensure_strict_json_schema(
     that the OpenAI API expects.
     """
     _validate_json_schema_depth(schema)
+    _reject_prefix_items(schema)
     if schema == {}:
         return copy.deepcopy(_EMPTY_SCHEMA)
     budget = _NodeBudget(_MAX_SCHEMA_NODES, reject_open_objects=_reject_open_objects)

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -509,6 +509,30 @@ def test_var_positional_supported_annotations_still_build(func: Any):
     assert fs.params_json_schema["properties"]["args"]["type"] == "array"
 
 
+def _fixed_tuple_parameter(point: tuple[int, str]) -> tuple[int, str]:
+    return point
+
+
+def test_fixed_tuple_parameter_is_rejected_in_strict_mode():
+    with pytest.raises(UserError, match=r"prefixItems.*strict mode"):
+        function_schema(_fixed_tuple_parameter, use_docstring_info=False)
+
+
+def test_fixed_tuple_parameter_remains_available_without_strict_mode():
+    fs = function_schema(
+        _fixed_tuple_parameter,
+        use_docstring_info=False,
+        strict_json_schema=False,
+    )
+
+    point_schema = fs.params_json_schema["properties"]["point"]
+    assert point_schema["prefixItems"] == [{"type": "integer"}, {"type": "string"}]
+
+    parsed = fs.params_pydantic_model.model_validate({"point": [1, "north"]})
+    args, kwargs = fs.to_call_args(parsed)
+    assert _fixed_tuple_parameter(*args, **kwargs) == (1, "north")
+
+
 def test_var_keyword_dict_annotation():
     # Case 3:
     # A ``**kwargs: X`` annotation applies to each keyword *value* (PEP 484), so a

--- a/tests/test_output_tool.py
+++ b/tests/test_output_tool.py
@@ -155,6 +155,25 @@ def test_setting_strict_false_works():
     assert output_wrapper.json_schema() == Foo.model_json_schema()
 
 
+def test_fixed_tuple_output_is_rejected_in_strict_mode():
+    with pytest.raises(UserError, match="output type is not valid") as exc_info:
+        AgentOutputSchema(output_type=tuple[int, str])
+
+    assert isinstance(exc_info.value.__cause__, UserError)
+    assert "prefixItems" in str(exc_info.value.__cause__)
+
+
+def test_fixed_tuple_output_remains_available_without_strict_mode():
+    output_wrapper = AgentOutputSchema(
+        output_type=tuple[int, str],
+        strict_json_schema=False,
+    )
+
+    response_schema = output_wrapper.json_schema()["properties"][_WRAPPER_DICT_KEY]
+    assert response_schema["prefixItems"] == [{"type": "integer"}, {"type": "string"}]
+    assert output_wrapper.validate_json('{"response": [1, "north"]}') == (1, "north")
+
+
 _CUSTOM_OUTPUT_SCHEMA_JSON_SCHEMA = {
     "type": "object",
     "properties": {

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -58,6 +58,29 @@ def test_non_dict_schema_errors():
         ensure_strict_json_schema([])  # type: ignore
 
 
+@pytest.mark.parametrize("keyword", ["not", "contains", "dependentSchemas"])
+def test_prefix_items_is_rejected_under_schema_valued_keywords(keyword: str):
+    nested = {"type": "array", "prefixItems": [{"type": "string"}]}
+    if keyword == "dependentSchemas":
+        schema = {"type": "object", "dependentSchemas": {"value": nested}}
+    else:
+        schema = {"type": "array", keyword: nested}
+
+    with pytest.raises(UserError, match="prefixItems.*strict mode"):
+        ensure_strict_json_schema(schema)
+
+
+def test_literal_prefix_items_in_examples_is_not_treated_as_schema():
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "string", "examples": [{"prefixItems": "literal"}]}},
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["properties"]["value"]["examples"] == [{"prefixItems": "literal"}]
+
+
 def test_deeply_nested_schema_is_rejected_before_recursive_conversion():
     with pytest.raises(UserError, match="too deeply nested"):
         ensure_strict_json_schema(_nested_object_schema(1_000))


### PR DESCRIPTION
## Summary

Strict schema construction currently accepts fixed-length tuple schemas that contain `prefixItems`, even though OpenAI Structured Outputs does not support that keyword. This defers a deterministic incompatibility until the provider request is sent.

This change rejects `prefixItems` anywhere in a strict schema tree while preserving homogeneous arrays, variadic tuples (`tuple[T, ...]`), and `strict_json_schema=False` behavior. The traversal covers nested schema-valued keywords such as `not`, `contains`, `dependentSchemas`, `if`, `then`, `else`, `allOf`, and `oneOf`, while avoiding false positives for literal keys inside annotation data such as `examples` and `default`.

## Validation

- Focused regression suite: 144 passed
- Ruff format and lint: passed
- Optional-truthiness check: passed
- `mypy` and `pyright` were attempted but exceeded the local verification window
- Full `make` verification could not start because GNU make is not installed in this Windows environment

Resolves #4752
