### PR TITLE
fix(sessions): keep Conversations history limits local

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -100,7 +100,6 @@ class OpenAIConversationsSession(SessionABC):
         else:
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
-                limit=session_limit,
                 order="desc",
             ):
                 # calling model_dump() to make this serializable

--- a/tests/memory/test_openai_conversations_session_pagination.py
+++ b/tests/memory/test_openai_conversations_session_pagination.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from agents.memory.openai_conversations_session import OpenAIConversationsSession
+
+
+class _ConversationItem:
+    def __init__(self, index: int) -> None:
+        self.index = index
+
+    def model_dump(self, *, exclude_unset: bool) -> dict[str, Any]:
+        assert exclude_unset is True
+        return {"id": f"item-{self.index}", "role": "user", "content": str(self.index)}
+
+
+@pytest.mark.asyncio
+async def test_get_items_keeps_large_limit_out_of_provider_page_size() -> None:
+    client = MagicMock()
+    captured: dict[str, Any] = {}
+
+    def list_items(**kwargs: Any):
+        captured.update(kwargs)
+
+        async def iterate():
+            for index in range(199, -1, -1):
+                yield _ConversationItem(index)
+
+        return iterate()
+
+    client.conversations.items.list = MagicMock(side_effect=list_items)
+    session = OpenAIConversationsSession(conversation_id="conv-1", openai_client=client)
+
+    items = await session.get_items(limit=150)
+
+    assert captured == {"conversation_id": "conv-1", "order": "desc"}
+    assert [item["id"] for item in items] == [f"item-{index}" for index in range(50, 200)]

--- a/tests/memory/test_openai_conversations_session_pagination.py
+++ b/tests/memory/test_openai_conversations_session_pagination.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -37,4 +37,6 @@ async def test_get_items_keeps_large_limit_out_of_provider_page_size() -> None:
     items = await session.get_items(limit=150)
 
     assert captured == {"conversation_id": "conv-1", "order": "desc"}
-    assert [item["id"] for item in items] == [f"item-{index}" for index in range(50, 200)]
+    assert [cast(dict[str, Any], item)["id"] for item in items] == [
+        f"item-{index}" for index in range(50, 200)
+    ]


### PR DESCRIPTION
### Summary

This pull request fixes large `OpenAIConversationsSession.get_items(limit=N)` calls by keeping the SDK history limit local instead of forwarding it as the Conversations API page-size parameter.

The previous #4721 established the underlying failure, but its hard-coded provider page-size cap was closed in favor of a narrower maintainer-requested approach: omit `limit` from `conversations.items.list()`, let the OpenAI client handle provider pagination, stop locally once the requested number of items has been collected, then reverse the descending results back into chronological order.

This preserves the existing `Session.get_items(limit=N)` behavior without duplicating provider-owned pagination limits in the Agents SDK.

### Test plan

- Added a focused regression that requests 150 items from a 200-item descending stream.
- Verifies the provider call receives no `limit` argument.
- Verifies the SDK still returns exactly the newest 150 items in chronological order.

### Issue number

Closes #4757

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR