### PR TITLE
fix(voice): omit instructions for legacy TTS models

### DIFF
--- a/src/agents/voice/models/openai_tts.py
+++ b/src/agents/voice/models/openai_tts.py
@@ -6,6 +6,7 @@ from openai import AsyncOpenAI, omit
 from ..model import TTSModel, TTSModelSettings
 
 DEFAULT_VOICE: Literal["ash"] = "ash"
+_LEGACY_TTS_MODELS = frozenset({"tts-1", "tts-1-hd"})
 
 
 class OpenAITTSModel(TTSModel):
@@ -39,15 +40,18 @@ class OpenAITTSModel(TTSModel):
         Returns:
             An iterator of audio chunks.
         """
+        extra_body = (
+            None
+            if self.model in _LEGACY_TTS_MODELS
+            else {"instructions": settings.instructions}
+        )
         response = self._client.audio.speech.with_streaming_response.create(
             model=self.model,
             voice=settings.voice or DEFAULT_VOICE,
             input=text,
             response_format="pcm",
             speed=settings.speed if settings.speed is not None else omit,
-            extra_body={
-                "instructions": settings.instructions,
-            },
+            extra_body=extra_body,
         )
 
         async with response as stream:

--- a/tests/voice/test_openai_tts.py
+++ b/tests/voice/test_openai_tts.py
@@ -111,6 +111,37 @@ async def test_openai_tts_custom_voice_and_instructions() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["tts-1", "tts-1-hd"])
+async def test_openai_tts_omits_instructions_for_legacy_models(model: str) -> None:
+    """Legacy TTS models do not support the speech instructions parameter."""
+    chunks = [b"legacy"]
+    captured: dict[str, object] = {}
+
+    def fake_create(
+        *,
+        model: str,
+        voice: str,
+        input: str,
+        response_format: str,
+        speed: Any,
+        extra_body: dict[str, Any] | None,
+    ) -> _FakeStreamResponse:
+        captured["model"] = model
+        captured["extra_body"] = extra_body
+        return _FakeStreamResponse(chunks)
+
+    client = _make_fake_openai_client(fake_create)
+    tts_model = OpenAITTSModel(model=model, openai_client=client)  # type: ignore[arg-type]
+    settings = TTSModelSettings(instructions="Unsupported legacy instruction")
+
+    out = [chunk async for chunk in tts_model.run("hello", settings)]
+
+    assert out == chunks
+    assert captured["model"] == model
+    assert captured["extra_body"] is None
+
+
+@pytest.mark.asyncio
 async def test_openai_tts_forwards_speed() -> None:
     """A configured speed is forwarded to the OpenAI speech API."""
     chunks = [b"y"]


### PR DESCRIPTION
### Summary

This pull request avoids sending speech `instructions` when `OpenAITTSModel` targets `tts-1` or `tts-1-hd`.

The OpenAI speech API schema documents that `instructions` does not work with those two legacy TTS models. The Agents SDK currently injects the setting through `extra_body` for every model, including the legacy pair. The adapter now omits that extra body for `tts-1` and `tts-1-hd`, while preserving instruction forwarding for GPT-based and other TTS model IDs.

Voice selection, PCM output, speed handling, and streaming behaviour are unchanged.

### Test plan

- Added parametrized regression coverage for `tts-1` and `tts-1-hd`.
- Existing tests continue to cover instruction forwarding for non-legacy models.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR