### PR TITLE
fix(docs): skip reference pages on Windows

### DIFF
--- a/docs/scripts/translate_docs.py
+++ b/docs/scripts/translate_docs.py
@@ -741,7 +741,7 @@ def translate_single_source_file(
     file_path: str, *, check_translation_outdated: bool = True
 ) -> None:
     relative_path = os.path.relpath(file_path, source_dir)
-    if "ref/" in relative_path or not file_path.endswith(".md"):
+    if "ref/" in relative_path.replace("\\", "/") or not file_path.endswith(".md"):
         return
     if check_translation_outdated and not should_translate_based_on_translation(file_path):
         print(f"Skipping {file_path}: The translated one is up-to-date.")

--- a/tests/docs/test_translate_docs.py
+++ b/tests/docs/test_translate_docs.py
@@ -127,3 +127,26 @@ def test_a_heading_with_its_own_attribute_list_is_not_rewritten(translate_docs: 
     translated = "## アルファ {.lead}\n\n## ベータ\n"
 
     assert translate_docs.preserve_heading_anchors(source, translated) == translated
+
+
+def test_ref_pages_are_skipped_with_windows_separators(
+    translate_docs: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    translated: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(translate_docs.os.path, "relpath", lambda *_args: r"ref\voice\model.md")
+    monkeypatch.setattr(translate_docs.os, "makedirs", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        translate_docs,
+        "translate_file",
+        lambda file_path, target_path, lang_code: translated.append(
+            (file_path, target_path, lang_code)
+        ),
+    )
+
+    translate_docs.translate_single_source_file(
+        r"docs\ref\voice\model.md",
+        check_translation_outdated=False,
+    )
+
+    assert translated == []


### PR DESCRIPTION
### Summary

This pull request fixes the documentation translation script's `ref/` exclusion on Windows.

`translate_single_source_file()` filters generated API-reference pages by checking for `"ref/"` in the path returned by `os.path.relpath()`. On Windows that relative path uses backslashes, so `docs\ref\...` does not match and reference pages can be sent through translation even though they are intended to be excluded.

The check now normalizes path separators before applying the existing `ref/` filter. Behaviour on POSIX paths is unchanged, and generated translation files are not modified.

This is the Windows-specific follow-up explicitly noted as out of scope in #4580.

### Test plan

- Added a regression that makes `os.path.relpath()` return a Windows-style `ref\voice\model.md` path.
- Verifies `translate_single_source_file()` returns without invoking `translate_file()`.

### Issue number

Follow-up to #4580.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR