### PR TITLE
fix(models): close the websocket event iterator on a non-streaming terminal failure

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -5,7 +5,15 @@ import contextlib
 import inspect
 import json
 import weakref
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Mapping,
+    Sequence,
+)
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
@@ -1295,18 +1303,24 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
 
         final_response: Response | None = None
         terminal_event_type: str | None = None
-        async for event in self._iter_websocket_response_events(create_kwargs):
-            event_type = getattr(event, "type", None)
-            if isinstance(event, ResponseCompletedEvent):
-                final_response = event.response
-                terminal_event_type = event.type
-            elif event_type in {"response.incomplete", "response.failed"}:
-                terminal_event_type = cast(str, event_type)
-                terminal_response = getattr(event, "response", None)
-                raise response_terminal_failure_error(
-                    terminal_event_type,
-                    terminal_response if isinstance(terminal_response, Response) else None,
-                )
+        # `async for` alone does not close its iterator when the loop body raises, and this
+        # iterator owns the request lock and releases it in its `finally`. Closing it here
+        # keeps that release in the owning task instead of waiting on generator finalization.
+        async with contextlib.aclosing(
+            self._iter_websocket_response_events(create_kwargs)
+        ) as events:
+            async for event in events:
+                event_type = getattr(event, "type", None)
+                if isinstance(event, ResponseCompletedEvent):
+                    final_response = event.response
+                    terminal_event_type = event.type
+                elif event_type in {"response.incomplete", "response.failed"}:
+                    terminal_event_type = cast(str, event_type)
+                    terminal_response = getattr(event, "response", None)
+                    raise response_terminal_failure_error(
+                        terminal_event_type,
+                        terminal_response if isinstance(terminal_response, Response) else None,
+                    )
 
         if final_response is None:
             terminal_event_hint = (
@@ -1321,7 +1335,7 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
 
     async def _iter_websocket_response_events(
         self, create_kwargs: dict[str, Any]
-    ) -> AsyncIterator[ResponseStreamEvent]:
+    ) -> AsyncGenerator[ResponseStreamEvent, None]:
         request_timeout = create_kwargs.get("timeout", omit)
         if _is_openai_omitted_value(request_timeout):
             request_timeout = getattr(self._client, "timeout", None)

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -4991,3 +4992,55 @@ async def test_streamed_span_counts_request_before_terminal_event_close() -> Non
     assert len(spans) == 1
     assert spans[0]["span_data"]["usage"]["requests"] == 1  # type: ignore[index]
     assert spans[0]["span_data"]["usage"]["total_tokens"] == 0  # type: ignore[index]
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_type", ["response.failed", "response.incomplete"])
+async def test_fetch_response_non_streaming_terminal_failure_releases_request_lock(
+    terminal_type: str,
+) -> None:
+    """A terminal failure must close the event iterator so it releases the request lock.
+
+    `_iter_websocket_response_events()` owns `_ws_request_lock` and releases it in its
+    `finally`. A bare `async for` that raises from the loop body leaves the generator
+    suspended, so the lock stays held until generator finalization runs.
+    """
+
+    class _TerminalEvent:
+        type = terminal_type
+        response = None
+
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=AsyncOpenAI(api_key="k"))  # type: ignore[arg-type]
+    lock = model._get_ws_request_lock()
+    closed = False
+
+    async def fake_events(create_kwargs: dict[str, Any]) -> AsyncIterator[Any]:
+        nonlocal closed
+        await lock.acquire()
+        try:
+            yield _TerminalEvent()
+            yield _TerminalEvent()  # pragma: no cover - the first event raises
+        finally:
+            closed = True
+            lock.release()
+
+    model._iter_websocket_response_events = fake_events  # type: ignore[assignment, method-assign]
+
+    with pytest.raises(ModelBehaviorError):
+        await model._fetch_response(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            previous_response_id=None,
+            conversation_id=None,
+            stream=False,
+            prompt=None,
+        )
+
+    # Both must hold before control returns, without waiting on generator finalization.
+    assert closed is True
+    assert lock.locked() is False


### PR DESCRIPTION
### Summary

`OpenAIResponsesWSModel._fetch_response(stream=False)` consumed `_iter_websocket_response_events()` with a bare `async for` and raised from inside the loop body on `response.failed` or `response.incomplete`.

`async for` does not close its iterator when the loop body raises. That iterator owns `_ws_request_lock` and releases it in its `finally` (`openai_responses.py:1458`), so a terminal failure left the generator suspended at its yield and the lock held until generator finalization ran. The next request then waits on `request_lock.acquire()` for a release nothing is scheduled to perform.

Measured on `main` by driving the same consumption shape and checking both the iterator and the lock:

```
iterator finalized right after raise: False
lock still held:                      True
after gc.collect():   finalized False, lock held True
```

Even an explicit `gc.collect()` does not recover it. After the change both flip to finalized and released before control returns to the caller.

This is the non-streaming sibling of #4366, which fixed the streamed runner path and described this same shape: "`async for` does not close its iterator, so the generator chain stays suspended at its yield and the provider's `finally` never runs." The fix reuses the ownership pattern accepted there, `contextlib.aclosing`, rather than introducing a different one.

One type change comes with it: `_iter_websocket_response_events` is an async generator but was annotated `AsyncIterator`, which does not declare `aclose()`, so `aclosing` fails to typecheck against it. The annotation is widened to `AsyncGenerator[ResponseStreamEvent, None]`, which is what the function already returns and remains compatible with the `stream=True` branch.

### Test plan

`tests/models/test_openai_responses.py::test_fetch_response_non_streaming_terminal_failure_releases_request_lock`, parametrized over both terminal event types. It replaces `_iter_websocket_response_events` with a retained async generator that acquires the real `_get_ws_request_lock()`, yields a terminal event, and records whether its `finally` ran. The test asserts `ModelBehaviorError` propagates and that both the iterator is closed and the lock is released before control returns, so it fails if the release is deferred to finalization rather than done in the owning task.

Verified it fails without the source change by reverting `src/`: both cases fail on the lock assertion.

`.agents/skills/code-change-verification/scripts/run.sh` passes end to end: format, lint, typecheck and the full suite.

### Issue number

Fixes #4762

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

@sylvesterkaczmarek wrote up #4762 with the mechanism and the suggested `aclosing` shape already worked out, so the analysis here is his and I only implemented and measured it. Happy to close this if he would rather carry it himself. The part I would most like checked is the annotation widening, since it is the one thing that reaches beyond the reported bug and I would rather narrow it than have it slip in unnoticed. I'm a freshman in college and this is the second lock-ownership bug I have looked at in this codebase, so please push back if `aclosing` is not the pattern you want here.
