### PR TITLE
fix(docs): check freshness for all translations

### DIFF
--- a/docs/scripts/translate_docs.py
+++ b/docs/scripts/translate_docs.py
@@ -709,14 +709,17 @@ def git_last_commit_timestamp(path: str) -> int:
 
 def should_translate_based_on_translation(file_path: str) -> bool:
     relative_path = os.path.relpath(file_path, source_dir)
-    ja_path = os.path.join(source_dir, "ja", relative_path)
     en_timestamp = git_last_commit_timestamp(file_path)
     if en_timestamp == 0:
         return True
-    ja_timestamp = git_last_commit_timestamp(ja_path)
-    if ja_timestamp == 0:
-        return True
-    return ja_timestamp < en_timestamp
+    for lang_code in languages:
+        translated_path = os.path.join(source_dir, lang_code, relative_path)
+        if not os.path.exists(translated_path):
+            return True
+        translated_timestamp = git_last_commit_timestamp(translated_path)
+        if translated_timestamp == 0 or translated_timestamp < en_timestamp:
+            return True
+    return False
 
 
 def refresh_heading_anchors(file_path: str, relative_path: str) -> None:
@@ -809,7 +812,10 @@ def main():
         "--mode",
         choices=["only-changes", "full"],
         default="only-changes",
-        help="Translation mode. 'only-changes' translates only when the Japanese file is older than the English source.",
+        help=(
+            "Translation mode. 'only-changes' translates when any configured translation is "
+            "missing or older than the English source."
+        ),
     )
     args = parser.parse_args()
 

--- a/tests/docs/test_translate_docs.py
+++ b/tests/docs/test_translate_docs.py
@@ -127,3 +127,70 @@ def test_a_heading_with_its_own_attribute_list_is_not_rewritten(translate_docs: 
     translated = "## アルファ {.lead}\n\n## ベータ\n"
 
     assert translate_docs.preserve_heading_anchors(source, translated) == translated
+
+
+@pytest.mark.parametrize("stale_lang", ["ja", "ko", "zh"])
+@pytest.mark.parametrize("stale_timestamp", [0, 99])
+def test_translation_freshness_checks_every_language(
+    translate_docs: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    stale_lang: str,
+    stale_timestamp: int,
+) -> None:
+    source_path = translate_docs.os.path.join("docs", "agents.md")
+    timestamps = {source_path: 100}
+    for lang_code in translate_docs.languages:
+        timestamps[translate_docs.os.path.join("docs", lang_code, "agents.md")] = 100
+    timestamps[translate_docs.os.path.join("docs", stale_lang, "agents.md")] = stale_timestamp
+
+    monkeypatch.setattr(translate_docs.os.path, "exists", lambda _path: True)
+    monkeypatch.setattr(
+        translate_docs,
+        "git_last_commit_timestamp",
+        lambda path: timestamps.get(path, 0),
+    )
+
+    assert translate_docs.should_translate_based_on_translation(source_path) is True
+
+
+@pytest.mark.parametrize("missing_lang", ["ja", "ko", "zh"])
+def test_translation_freshness_checks_filesystem_for_deleted_translation(
+    translate_docs: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    missing_lang: str,
+) -> None:
+    source_path = translate_docs.os.path.join("docs", "agents.md")
+    missing_path = translate_docs.os.path.join("docs", missing_lang, "agents.md")
+    timestamps = {source_path: 100}
+    for lang_code in translate_docs.languages:
+        timestamps[translate_docs.os.path.join("docs", lang_code, "agents.md")] = 101
+
+    # Git still reports the deletion commit for a missing tracked file. The filesystem
+    # check must win even though that timestamp is newer than the English source.
+    monkeypatch.setattr(translate_docs.os.path, "exists", lambda path: path != missing_path)
+    monkeypatch.setattr(
+        translate_docs,
+        "git_last_commit_timestamp",
+        lambda path: timestamps.get(path, 0),
+    )
+
+    assert translate_docs.should_translate_based_on_translation(source_path) is True
+
+
+def test_translation_freshness_skips_when_all_languages_are_current(
+    translate_docs: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = translate_docs.os.path.join("docs", "agents.md")
+    timestamps = {source_path: 100}
+    for lang_code in translate_docs.languages:
+        timestamps[translate_docs.os.path.join("docs", lang_code, "agents.md")] = 100
+
+    monkeypatch.setattr(translate_docs.os.path, "exists", lambda _path: True)
+    monkeypatch.setattr(
+        translate_docs,
+        "git_last_commit_timestamp",
+        lambda path: timestamps.get(path, 0),
+    )
+
+    assert translate_docs.should_translate_based_on_translation(source_path) is False


### PR DESCRIPTION
### Summary

This pull request fixes `--mode only-changes` in the documentation translation script so freshness is checked across every configured translation instead of Japanese only.

`should_translate_based_on_translation()` currently compares the English source timestamp with `docs/ja/...` and uses that single result to decide whether `translate_single_source_file()` should skip the page for all configured languages. If Japanese is current while Korean or Chinese is missing or stale, the source is incorrectly treated as fully up to date.

The freshness check now walks the configured `languages` mapping and requests translation when any target file is missing, has no Git timestamp, or is older than the English source. The filesystem check deliberately happens before Git history lookup because `git log` can still return the deletion commit for a missing tracked file. The script skips only when every configured translation exists and is current. The CLI help text is updated to describe that behaviour. Generated translated pages are not changed by this PR.

### Test plan

- Added parametrized coverage for stale or history-less translations in each configured language (`ja`, `ko`, `zh`).
- Added regression coverage for a deleted translation whose Git deletion timestamp is newer than the English source, proving filesystem existence takes precedence over Git history.
- Added a negative control confirming the source is skipped when all configured translations exist and are current.

Closes #4763.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR