### PR TITLE
fix(sandbox): detect directory modes correctly

### DIFF
--- a/src/agents/sandbox/types.py
+++ b/src/agents/sandbox/types.py
@@ -51,7 +51,7 @@ class Permissions(BaseModel):
             owner=(mode >> 6) & 0b111,
             group=(mode >> 3) & 0b111,
             other=(mode >> 0) & 0b111,
-            directory=bool(mode & stat.S_IFDIR),
+            directory=stat.S_ISDIR(mode),
         )
 
     @classmethod

--- a/tests/sandbox/test_types.py
+++ b/tests/sandbox/test_types.py
@@ -1,3 +1,5 @@
+import stat
+
 from agents.sandbox.types import Group, Permissions, User
 
 
@@ -13,6 +15,27 @@ def test_permissions_is_hashable() -> None:
     assert hash(perms) != hash(different)
     assert {perms, other, different} == {perms, different}
     assert {perms: "value"}[other] == "value"
+
+
+def test_permissions_from_mode_uses_posix_file_type_predicate() -> None:
+    file_types = [
+        stat.S_IFDIR,
+        stat.S_IFREG,
+        stat.S_IFSOCK,
+        stat.S_IFBLK,
+        stat.S_IFCHR,
+        stat.S_IFIFO,
+        stat.S_IFLNK,
+    ]
+
+    for file_type in file_types:
+        mode = file_type | 0o750
+        permissions = Permissions.from_mode(mode)
+
+        assert permissions.directory is stat.S_ISDIR(mode)
+        assert permissions.owner == 0o7
+        assert permissions.group == 0o5
+        assert permissions.other == 0o0
 
 
 def test_user_and_group_remain_hashable() -> None:


### PR DESCRIPTION
### Summary

This pull request fixes POSIX file-type detection in `Permissions.from_mode()`.

The current implementation uses `bool(mode & stat.S_IFDIR)` to decide whether a native mode represents a directory. POSIX file types are mutually exclusive values under `S_IFMT`, not independent bit flags, so that expression also evaluates true for some non-directory types. In particular, sockets (`S_IFSOCK`) and block devices (`S_IFBLK`) share the `S_IFDIR` bit and are incorrectly surfaced with `directory=True`.

The fix uses Python's standard `stat.S_ISDIR(mode)` predicate. The existing owner/group/other permission-bit decoding is unchanged.

### Test plan

- Added coverage for directory, regular file, socket, block device, character device, FIFO, and symlink mode values.
- The regression asserts `Permissions.from_mode(mode).directory` matches `stat.S_ISDIR(mode)` for each file type.
- The same test verifies rwx permission bits are preserved.

### Issue number

Closes #4767

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR