### PR TITLE
fix(tools): parse Google Args blocks with extra blank line

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -241,6 +241,36 @@ def _ensure_blank_line_before_google_sections(doc: str) -> str:
     return "\n".join(output)
 
 
+def _remove_blank_line_after_google_sections(doc: str) -> str:
+    """Remove one blank line below a Google-style parameter section title.
+
+    Griffe skips a recognized section when its title is followed by one blank line and then
+    an indented body, reporting ``Extraneous blank line below section title``. Normalize only
+    the parameter-section aliases consumed by ``generate_func_documentation``; unrelated Google
+    sections and already well-formed docstrings are left unchanged.
+    """
+    lines = doc.splitlines()
+    output: list[str] = []
+    removed = False
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        if (
+            _GOOGLE_SECTION_HEADER_RE.match(line)
+            and index + 2 < len(lines)
+            and not lines[index + 1].strip()
+            and lines[index + 2].startswith((" ", "\t"))
+        ):
+            index += 1
+            removed = True
+        index += 1
+
+    if not removed:
+        return doc
+    return "\n".join(output)
+
+
 def generate_func_documentation(
     func: Callable[..., Any], style: DocstringStyle | None = None
 ) -> FuncDocumentation:
@@ -264,6 +294,7 @@ def generate_func_documentation(
     # Resolve the style against the original docstring before any normalization.
     resolved_style = style or _detect_docstring_style(doc)
     if resolved_style == "google":
+        doc = _remove_blank_line_after_google_sections(doc)
         doc = _ensure_blank_line_before_google_sections(doc)
 
     with _suppress_griffe_logging():

--- a/tests/test_function_schema_google_blank_line.py
+++ b/tests/test_function_schema_google_blank_line.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from agents.function_schema import function_schema, generate_func_documentation
+
+
+def blank_line_below_args_google_function(city: str, units: str) -> str:
+    """Get the weather for a city.
+
+    Args:
+
+        city: The city to get weather for.
+        units: Temperature units to use.
+    """
+    return f"{city} {units}"
+
+
+def test_google_docstring_blank_line_below_args_keeps_parameter_descriptions() -> None:
+    schema = function_schema(blank_line_below_args_google_function, strict_json_schema=False)
+
+    properties = schema.params_json_schema["properties"]
+    assert properties["city"]["description"] == "The city to get weather for."
+    assert properties["units"]["description"] == "Temperature units to use."
+    assert schema.description == "Get the weather for a city."
+    assert "Args:" not in (schema.description or "")
+
+
+@pytest.mark.parametrize("section_name", ["Args", "Arguments", "Params", "Parameters"])
+def test_google_docstring_blank_line_below_parameter_alias(section_name: str) -> None:
+    def documented(value: str) -> str:
+        return value
+
+    documented.__doc__ = (
+        "Describe the value.\n\n"
+        f"{section_name}:\n\n"
+        "    value: The value to return."
+    )
+
+    doc = generate_func_documentation(documented, style="google")
+
+    assert doc.description == "Describe the value."
+    assert doc.param_descriptions == {"value": "The value to return."}
+
+
+@pytest.mark.parametrize("section_name", ["Args", "Arguments", "Params", "Parameters"])
+def test_google_docstring_normalizes_missing_blank_above_and_extra_blank_below(
+    section_name: str,
+) -> None:
+    def documented(value: str) -> str:
+        return value
+
+    documented.__doc__ = (
+        "Describe the value.\n"
+        f"{section_name}:\n\n"
+        "    value: The value to return."
+    )
+
+    doc = generate_func_documentation(documented, style="google")
+
+    assert doc.description == "Describe the value."
+    assert doc.param_descriptions == {"value": "The value to return."}


### PR DESCRIPTION
### Summary

This pull request fixes Google-style function docstrings whose parameter section contains one blank line immediately below `Args:` (or one of its supported aliases).

Griffe treats a recognized section title followed by one blank line and then an indented body as `Extraneous blank line below section title` and skips the section. As a result, `generate_func_documentation()` loses the parameter descriptions and can leave the raw `Args:` block in the tool description.

Merged #3832 fixed Griffe's separate `Missing blank line above section` failure and explicitly left this failure mode out of scope. This change follows the same narrow normalization policy: only the parameter-section aliases consumed by the SDK (`Args`, `Arguments`, `Params`, `Parameters`) are adjusted. One blank line below such a title is removed only when the following line is an indented body, before the existing missing-blank-above normalizer runs. Unrelated Google sections and already well-formed docstrings are unchanged.

### Test plan

- Added an end-to-end `function_schema()` regression for an `Args:` block with the extra blank line, asserting both parameter descriptions and the clean function description.
- Added parametrized coverage for `Args`, `Arguments`, `Params`, and `Parameters` through `generate_func_documentation()`.
- Added regression coverage for the combined malformed form with both a missing blank line above the section and an extra blank line below it.

### Issue number

Closes #4769

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR