### PR TITLE
fix: propagate the serial test runner's exit code on Windows

### DIFF
--- a/.github/scripts/run_serial_tests.py
+++ b/.github/scripts/run_serial_tests.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -46,7 +47,14 @@ def main() -> None:
     marker_expression = (
         "serial and not review_optional" if args.exclude_review_optional else "serial"
     )
-    os.execv(sys.executable, _serial_args(marker_expression=marker_expression))
+    command = _serial_args(marker_expression=marker_expression)
+    if sys.platform == "win32":
+        # Windows has no process replacement: os.execv spawns a child and
+        # terminates this process with 0, so the caller sees success no matter
+        # how pytest exits. Mirror run_integration_tests.py and wait instead.
+        completed = subprocess.run(command, check=False)
+        raise SystemExit(completed.returncode)
+    os.execv(sys.executable, command)
 
 
 if __name__ == "__main__":

--- a/tests/test_run_serial_tests.py
+++ b/tests/test_run_serial_tests.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -96,3 +97,55 @@ def test_serial_command_targets_only_discovered_files(
         "-m",
         "serial",
     ]
+
+
+def test_windows_runner_uses_subprocess_and_propagates_exit_code(
+    serial_test_runner: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[list[str], bool]] = []
+
+    def capture_run(command: list[str], *, check: bool) -> SimpleNamespace:
+        captured.append((command, check))
+        return SimpleNamespace(returncode=23)
+
+    monkeypatch.setattr(serial_test_runner.sys, "platform", "win32")
+    monkeypatch.setattr(subprocess, "run", capture_run)
+    monkeypatch.setattr(serial_test_runner.os, "chdir", lambda _path: None)
+    monkeypatch.setattr(
+        serial_test_runner.os,
+        "execv",
+        lambda *_args: pytest.fail("Windows serial runner must not call os.execv"),
+    )
+    monkeypatch.setattr(sys, "argv", ["run_serial_tests.py"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        serial_test_runner.main()
+
+    assert exc_info.value.code == 23
+    assert len(captured) == 1
+    assert captured[0][1] is False
+
+
+def test_non_windows_runner_still_execs(
+    serial_test_runner: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[list[str]] = []
+
+    monkeypatch.setattr(serial_test_runner.sys, "platform", "linux")
+    monkeypatch.setattr(serial_test_runner.os, "chdir", lambda _path: None)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("POSIX serial runner must not call subprocess.run"),
+    )
+    monkeypatch.setattr(
+        serial_test_runner.os, "execv", lambda _executable, command: captured.append(command)
+    )
+    monkeypatch.setattr(sys, "argv", ["run_serial_tests.py"])
+
+    serial_test_runner.main()
+
+    assert len(captured) == 1
+    assert "serial" in captured[0]


### PR DESCRIPTION
`make tests-serial` exits 0 on Windows whether the serial tests pass or fail.

`.github/scripts/run_serial_tests.py` ends in `os.execv`. Windows has no process replacement: the
CRT spawns a child and terminates the caller with 0. The caller returns in about 100 ms while pytest
keeps running orphaned, so `make tests` and `make check` report success, and pytest's output arrives
afterwards, interleaved into whatever runs next. `AGENTS.md` lists `make tests` in the mandatory
local run order.

`run_integration_tests.py` already handles this at lines 103-106, added in `21a1f9b4`. This applies
the same guarded shape to the serial runner, plus a unit test mirroring
`test_windows_bootstrap_uses_subprocess_and_propagates_exit_code`.

POSIX is unchanged: `os.execv` still runs there, so pytest keeps owning the terminal and its own
signal handling.

CI is unaffected. `make tests` runs on `ubuntu-latest`, and the `windows-latest` job invokes
`uv run pytest` directly, so serial tests already propagate there.

<details><summary>verification</summary>

```
base 2b81a9e3 (2026-08-28), Python 3.13.13, win32 x64, uv 0.12.5

mechanism, isolated (re-run by hand):
  child sys.exit(7) direct  -> shell saw 7
  same child via os.execv   -> shell saw 0

new unit tests, source reverted:
  FAILED test_windows_runner_uses_subprocess_and_propagates_exit_code
  Failed: Windows serial runner must not call os.execv
    .github/scripts/run_serial_tests.py:49: in main
        os.execv(sys.executable, _serial_args(...))

with the fix: 6 passed
ruff check: All checks passed    ruff format: unchanged
staged blobs: run_serial_tests.py CR=0, test_run_serial_tests.py CR=0
```
</details>
