### PR TITLE
fix(approvals): handle JSON recursion limits

### DIFF
--- a/src/agents/_tool_invocation.py
+++ b/src/agents/_tool_invocation.py
@@ -102,7 +102,7 @@ def _normalize_arguments(value: Any) -> Any:
                 ValueError(f"Invalid JSON constant: {constant}")
             ),
         )
-    except (TypeError, ValueError, json.JSONDecodeError):
+    except (TypeError, ValueError, json.JSONDecodeError, RecursionError):
         return value
     return _normalize_value(parsed)
 

--- a/src/agents/util/_approvals.py
+++ b/src/agents/util/_approvals.py
@@ -24,7 +24,7 @@ def parse_function_tool_arguments(arguments: str | None) -> dict[str, Any] | Non
             arguments,
             parse_constant=_reject_nonstandard_json_constant,
         )
-    except ValueError:
+    except (ValueError, RecursionError):
         return None
     return parsed if isinstance(parsed, dict) else None
 

--- a/tests/test_approval_utils.py
+++ b/tests/test_approval_utils.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import sys
+from typing import Any
+
 import pytest
 
+from agents import Runner
 from agents import _tool_invocation
+from agents.tool import FunctionTool
 from agents.util import _approvals
+
+from .utils.hitl import make_function_tool_call, make_model_and_agent
 
 
 def test_parse_function_tool_arguments_treats_recursion_error_as_uninspectable(
@@ -35,3 +42,36 @@ def test_tool_invocation_identity_tolerates_json_recursion_error(
     )
 
     assert identity is not None
+
+
+@pytest.mark.asyncio
+async def test_runner_function_approval_fails_closed_for_json_recursion_depth() -> None:
+    approval_inputs: list[dict[str, Any]] = []
+    tool_inputs: list[str] = []
+
+    async def needs_approval(_ctx: Any, params: dict[str, Any], _call_id: str) -> bool:
+        approval_inputs.append(params)
+        return False
+
+    async def invoke_tool(_ctx: Any, raw_arguments: str) -> str:
+        tool_inputs.append(raw_arguments)
+        return "sent"
+
+    tool = FunctionTool(
+        name="send_email",
+        description="Send an email.",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=invoke_tool,
+        needs_approval=needs_approval,
+    )
+    depth = sys.getrecursionlimit() * 2
+    arguments = '{"value":' * depth + "0" + "}" * depth
+    model, agent = make_model_and_agent(tools=[tool])
+    model.enqueue([make_function_tool_call(tool.name, arguments=arguments, call_id="call-deep")])
+
+    result = await Runner.run(agent, "send an email")
+
+    assert len(result.interruptions) == 1
+    assert result.interruptions[0].tool_name == tool.name
+    assert approval_inputs == []
+    assert tool_inputs == []

--- a/tests/test_approval_utils.py
+++ b/tests/test_approval_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from agents import _tool_invocation
 from agents.util import _approvals
 
 
@@ -14,3 +15,23 @@ def test_parse_function_tool_arguments_treats_recursion_error_as_uninspectable(
     monkeypatch.setattr(_approvals.json, "loads", raise_recursion_error)
 
     assert _approvals.parse_function_tool_arguments('{"value": 1}') is None
+
+
+def test_tool_invocation_identity_tolerates_json_recursion_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_recursion_error(*_args: object, **_kwargs: object) -> object:
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(_tool_invocation.json, "loads", raise_recursion_error)
+
+    identity = _tool_invocation.tool_invocation_identity(
+        {
+            "type": "function_call",
+            "name": "send_email",
+            "call_id": "call-deep",
+            "arguments": '{"value": 1}',
+        }
+    )
+
+    assert identity is not None

--- a/tests/test_approval_utils.py
+++ b/tests/test_approval_utils.py
@@ -5,8 +5,7 @@ from typing import Any
 
 import pytest
 
-from agents import Runner
-from agents import _tool_invocation
+from agents import Runner, _tool_invocation
 from agents.tool import FunctionTool
 from agents.util import _approvals
 

--- a/tests/test_approval_utils.py
+++ b/tests/test_approval_utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from agents.util import _approvals
+
+
+def test_parse_function_tool_arguments_treats_recursion_error_as_uninspectable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_recursion_error(*_args: object, **_kwargs: object) -> object:
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(_approvals.json, "loads", raise_recursion_error)
+
+    assert _approvals.parse_function_tool_arguments('{"value": 1}') is None


### PR DESCRIPTION
### Summary

This pull request keeps function-tool approval handling fail-closed when Python's JSON decoder hits its recursion limit.

There are two JSON parsing points on the affected paths. `parse_function_tool_arguments()` parses arguments for callable approval policies, while the normal Runner path first normalizes function-call arguments in `_normalize_arguments()` when establishing tool invocation identity.

Sufficiently deeply nested model-supplied JSON can cause `json.loads()` to raise `RecursionError` at either point. Both paths now treat that condition as uninspectable input instead of allowing the exception to escape.

`parse_function_tool_arguments()` returns `None`, preserving the existing fail-closed approval behavior. `_normalize_arguments()` falls back to the original argument string, preserving stable invocation handling until the approval parser makes the authorization decision.

Valid JSON behavior and the existing object-only approval argument contract are unchanged.

### Test plan

* Added a focused regression verifying that `parse_function_tool_arguments()` returns `None` when the JSON decoder raises `RecursionError`.
* Added coverage verifying that tool invocation identity normalization tolerates the same decoder failure.
* Added a Runner-level regression using a genuinely deeply nested JSON payload and verifying that the approval callback and tool are not invoked, with the call remaining pending for manual approval.

### Issue number

Closes #4772

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR