### PR TITLE
fix(voice): accept every NumPy spelling of a supported TTS dtype

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -107,10 +107,12 @@ class StreamedAudioResult:
         np_array = np.frombuffer(combined_buffer, dtype=np.int16)
 
         # Resolve the configured dtype the way NumPy does so that every spelling of a supported
-        # dtype is accepted, including the strings that dictionary-based settings carry.
+        # dtype is accepted, including the strings that dictionary-based settings carry. NumPy
+        # reports an unparseable dtype as either TypeError or ValueError, and both keep the
+        # SDK-owned error rather than surfacing a NumPy parse failure to the consumer.
         try:
             resolved_dtype = np.dtype(output_dtype)
-        except TypeError:
+        except (TypeError, ValueError):
             raise UserError("Invalid output dtype") from None
 
         if resolved_dtype == np.int16:

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -106,9 +106,16 @@ class StreamedAudioResult:
 
         np_array = np.frombuffer(combined_buffer, dtype=np.int16)
 
-        if output_dtype == np.int16:
+        # Resolve the configured dtype the way NumPy does so that every spelling of a supported
+        # dtype is accepted, including the strings that dictionary-based settings carry.
+        try:
+            resolved_dtype = np.dtype(output_dtype)
+        except TypeError:
+            raise UserError("Invalid output dtype") from None
+
+        if resolved_dtype == np.int16:
             return np_array
-        elif output_dtype == np.float32:
+        elif resolved_dtype == np.float32:
             return (np_array.astype(np.float32) / 32767.0).reshape(-1, 1)
         else:
             raise UserError("Invalid output dtype")

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -108,12 +108,13 @@ class StreamedAudioResult:
 
         # Resolve the configured dtype the way NumPy does so that every spelling of a supported
         # dtype is accepted, including the strings that dictionary-based settings carry. NumPy
-        # reports an unparseable dtype as either TypeError or ValueError, and both keep the
-        # SDK-owned error rather than surfacing a NumPy parse failure to the consumer.
+        # reports an unparseable dtype as either TypeError or ValueError. Both are answered with
+        # the SDK-owned error, keeping the NumPy cause attached because it names the spelling
+        # that failed to parse.
         try:
             resolved_dtype = np.dtype(output_dtype)
-        except (TypeError, ValueError):
-            raise UserError("Invalid output dtype") from None
+        except (TypeError, ValueError) as error:
+            raise UserError("Invalid output dtype") from error
 
         if resolved_dtype == np.int16:
             return np_array

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1332,18 +1332,21 @@ async def test_voicepipeline_float32() -> None:
     [
         ("float32", np.float32),
         ("int16", np.int16),
+        ("f4", np.float32),
         (np.dtype("float32"), np.float32),
     ],
-    ids=["float32-string", "int16-string", "already-supported-spelling"],
+    ids=["float32-string", "int16-string", "alias-spelling", "already-supported-spelling"],
 )
 async def test_voicepipeline_accepts_numpy_dtype_spellings(
     dtype_spelling: npt.DTypeLike, expected_dtype: type[np.int16] | type[np.float32]
 ) -> None:
     """Dictionary settings carry ``dtype`` as the spelling NumPy resolves, not the type object.
 
-    The string cases are the ones that fail before this change. The resolved-dtype case is a
-    pin on the spelling that already worked rather than new coverage, since every accepted
-    spelling now resolves to the same dtype and takes the same branch.
+    The string cases are the ones that fail before this change, and the alias holds the
+    property the fix rests on: the value is resolved the way NumPy resolves it rather than
+    matched against a fixed set of names. The resolved-dtype case is a pin on the spelling
+    that already worked rather than new coverage, since every accepted spelling now resolves
+    to the same dtype and takes the same branch.
     """
     fake_stt = QueuedSTTModel(["first"])
     workflow = QueuedVoiceWorkflow([["out_1"]])
@@ -1372,20 +1375,22 @@ async def test_voicepipeline_accepts_numpy_dtype_spellings(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "dtype_spelling",
+    ("dtype_spelling", "expected_cause"),
     [
-        "int32",
-        {"names": ["x"], "formats": []},
-        np.dtype(np.int16).newbyteorder("S"),
+        ("int32", None),
+        ({"names": ["x"], "formats": []}, ValueError),
+        ("not-a-dtype", TypeError),
+        (np.dtype(np.int16).newbyteorder("S"), None),
     ],
     ids=[
         "resolvable-but-unsupported",
         "unresolvable-structured-dtype",
+        "unparseable-string",
         "non-native-byte-order",
     ],
 )
 async def test_voicepipeline_rejects_unsupported_output_dtype(
-    dtype_spelling: npt.DTypeLike,
+    dtype_spelling: npt.DTypeLike, expected_cause: type[Exception] | None
 ) -> None:
     """An unsupported dtype keeps the SDK error, whether or not NumPy can parse it.
 
@@ -1394,6 +1399,10 @@ async def test_voicepipeline_rejects_unsupported_output_dtype(
     converted rather than relabeled, and returning them as they are would hand back
     different values than the caller asked to read. That case is swapped from the running
     host's own order so the expectation holds on a big-endian machine too.
+
+    A value NumPy cannot parse keeps the parse failure attached as the cause, since it names
+    the spelling that failed. A value NumPy resolves to an unsupported dtype has no cause,
+    because nothing was raised on the way to rejecting it.
     """
     fake_stt = QueuedSTTModel(["first"])
     workflow = QueuedVoiceWorkflow([["out_1"]])
@@ -1406,9 +1415,14 @@ async def test_voicepipeline_rejects_unsupported_output_dtype(
     )
     result = await pipeline.run(AudioInput(buffer=np.zeros(2, dtype=np.int16)))
 
-    with pytest.raises(UserError, match="Invalid output dtype"):
+    with pytest.raises(UserError, match="Invalid output dtype") as raised:
         async for _ in result.stream():
             pass
+
+    if expected_cause is None:
+        assert raised.value.__cause__ is None
+    else:
+        assert isinstance(raised.value.__cause__, expected_cause)
 
 
 @pytest.mark.asyncio

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -15,6 +15,7 @@ import pytest
 
 import agents._debug as _debug
 from agents import trace
+from agents.exceptions import UserError
 from tests.testing_processor import fetch_events, fetch_ordered_spans, fetch_span_errors
 
 try:
@@ -1323,6 +1324,63 @@ async def test_voicepipeline_float32() -> None:
         "session_ended",
     ]
     await fake_tts.verify_audio("out_1", audio_chunks[0], dtype=np.float32)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("dtype_spelling", "expected_dtype"),
+    [
+        ("float32", np.float32),
+        ("int16", np.int16),
+        (np.dtype("float32"), np.float32),
+    ],
+    ids=["float32-string", "int16-string", "float32-dtype-instance"],
+)
+async def test_voicepipeline_accepts_numpy_dtype_spellings(
+    dtype_spelling: npt.DTypeLike, expected_dtype: type[np.int16] | type[np.float32]
+) -> None:
+    """Dictionary settings carry ``dtype`` as the spelling NumPy resolves, not the type object."""
+    fake_stt = QueuedSTTModel(["first"])
+    workflow = QueuedVoiceWorkflow([["out_1"]])
+    fake_tts = ZeroPcmTTSModel()
+    pipeline = VoicePipeline(
+        workflow=workflow,
+        stt_model=fake_stt,
+        tts_model=fake_tts,
+        config={"tts_settings": {"buffer_size": 1, "dtype": dtype_spelling}},
+    )
+    result = await pipeline.run(AudioInput(buffer=np.zeros(2, dtype=np.int16)))
+
+    events: list[str] = []
+    audio_dtypes: list[np.dtype[Any]] = []
+    async for event in result.stream():
+        if isinstance(event, VoiceStreamEventAudio):
+            assert event.data is not None
+            audio_dtypes.append(event.data.dtype)
+            events.append("audio")
+        elif isinstance(event, VoiceStreamEventLifecycle):
+            events.append(event.event)
+
+    assert events == ["turn_started", "audio", "turn_ended", "session_ended"]
+    assert audio_dtypes == [np.dtype(expected_dtype)]
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_rejects_unsupported_output_dtype() -> None:
+    fake_stt = QueuedSTTModel(["first"])
+    workflow = QueuedVoiceWorkflow([["out_1"]])
+    fake_tts = ZeroPcmTTSModel()
+    pipeline = VoicePipeline(
+        workflow=workflow,
+        stt_model=fake_stt,
+        tts_model=fake_tts,
+        config={"tts_settings": {"buffer_size": 1, "dtype": "int32"}},
+    )
+    result = await pipeline.run(AudioInput(buffer=np.zeros(2, dtype=np.int16)))
+
+    with pytest.raises(UserError, match="Invalid output dtype"):
+        async for _ in result.stream():
+            pass
 
 
 @pytest.mark.asyncio

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1334,12 +1334,17 @@ async def test_voicepipeline_float32() -> None:
         ("int16", np.int16),
         (np.dtype("float32"), np.float32),
     ],
-    ids=["float32-string", "int16-string", "float32-dtype-instance"],
+    ids=["float32-string", "int16-string", "already-supported-spelling"],
 )
 async def test_voicepipeline_accepts_numpy_dtype_spellings(
     dtype_spelling: npt.DTypeLike, expected_dtype: type[np.int16] | type[np.float32]
 ) -> None:
-    """Dictionary settings carry ``dtype`` as the spelling NumPy resolves, not the type object."""
+    """Dictionary settings carry ``dtype`` as the spelling NumPy resolves, not the type object.
+
+    The string cases are the ones that fail before this change. The resolved-dtype case is a
+    pin on the spelling that already worked rather than new coverage, since every accepted
+    spelling now resolves to the same dtype and takes the same branch.
+    """
     fake_stt = QueuedSTTModel(["first"])
     workflow = QueuedVoiceWorkflow([["out_1"]])
     fake_tts = ZeroPcmTTSModel()

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1371,7 +1371,7 @@ async def test_voicepipeline_accepts_numpy_dtype_spellings(
     [
         "int32",
         {"names": ["x"], "formats": []},
-        ">i2",
+        np.dtype(np.int16).newbyteorder("S"),
     ],
     ids=[
         "resolvable-but-unsupported",
@@ -1387,7 +1387,8 @@ async def test_voicepipeline_rejects_unsupported_output_dtype(
     A non-native byte order is rejected on purpose. The emitted samples are read from the
     PCM stream in native order, so honoring a byte-swapped request would need the samples
     converted rather than relabeled, and returning them as they are would hand back
-    different values than the caller asked to read.
+    different values than the caller asked to read. That case is swapped from the running
+    host's own order so the expectation holds on a big-endian machine too.
     """
     fake_stt = QueuedSTTModel(["first"])
     workflow = QueuedVoiceWorkflow([["out_1"]])

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1371,13 +1371,24 @@ async def test_voicepipeline_accepts_numpy_dtype_spellings(
     [
         "int32",
         {"names": ["x"], "formats": []},
+        ">i2",
     ],
-    ids=["resolvable-but-unsupported", "unresolvable-structured-dtype"],
+    ids=[
+        "resolvable-but-unsupported",
+        "unresolvable-structured-dtype",
+        "non-native-byte-order",
+    ],
 )
 async def test_voicepipeline_rejects_unsupported_output_dtype(
     dtype_spelling: npt.DTypeLike,
 ) -> None:
-    """An unsupported dtype keeps the SDK error, whether or not NumPy can parse it."""
+    """An unsupported dtype keeps the SDK error, whether or not NumPy can parse it.
+
+    A non-native byte order is rejected on purpose. The emitted samples are read from the
+    PCM stream in native order, so honoring a byte-swapped request would need the samples
+    converted rather than relabeled, and returning them as they are would hand back
+    different values than the caller asked to read.
+    """
     fake_stt = QueuedSTTModel(["first"])
     workflow = QueuedVoiceWorkflow([["out_1"]])
     fake_tts = ZeroPcmTTSModel()

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1366,7 +1366,18 @@ async def test_voicepipeline_accepts_numpy_dtype_spellings(
 
 
 @pytest.mark.asyncio
-async def test_voicepipeline_rejects_unsupported_output_dtype() -> None:
+@pytest.mark.parametrize(
+    "dtype_spelling",
+    [
+        "int32",
+        {"names": ["x"], "formats": []},
+    ],
+    ids=["resolvable-but-unsupported", "unresolvable-structured-dtype"],
+)
+async def test_voicepipeline_rejects_unsupported_output_dtype(
+    dtype_spelling: npt.DTypeLike,
+) -> None:
+    """An unsupported dtype keeps the SDK error, whether or not NumPy can parse it."""
     fake_stt = QueuedSTTModel(["first"])
     workflow = QueuedVoiceWorkflow([["out_1"]])
     fake_tts = ZeroPcmTTSModel()
@@ -1374,7 +1385,7 @@ async def test_voicepipeline_rejects_unsupported_output_dtype() -> None:
         workflow=workflow,
         stt_model=fake_stt,
         tts_model=fake_tts,
-        config={"tts_settings": {"buffer_size": 1, "dtype": "int32"}},
+        config={"tts_settings": {"buffer_size": 1, "dtype": dtype_spelling}},
     )
     result = await pipeline.run(AudioInput(buffer=np.zeros(2, dtype=np.int16)))
 


### PR DESCRIPTION
### Summary

This pull request fixes `StreamedAudioResult` rejecting supported `TTSModelSettings.dtype` spellings.

`dtype` is typed as `npt.DTypeLike`, and dictionary settings such as `config={"tts_settings": {"dtype": "float32"}}` keep the value as the string `"float32"`. `_transform_audio_buffer` compared that value with `== np.int16` / `== np.float32`, which is `False` for strings, so the pipeline raised `UserError("Invalid output dtype")` inside the TTS task after the text-to-speech request had already been sent. Only the `np.float32` / `np.int16` type objects and `np.dtype` instances worked.

The buffer transform now resolves the configured value with `np.dtype()` before comparing, so every spelling of a supported dtype produces audio in that dtype. NumPy reports an unparseable dtype as either `TypeError` or `ValueError`, and both are caught so the `UserError` boundary is preserved either way. The emitted array shapes are unchanged.

A non-native byte order such as `">i2"` is still rejected, deliberately. Samples are read off the PCM stream in native order, so honoring a byte-swapped request would mean converting them rather than relabeling them, and returning the array unchanged would hand the caller different values than it asked to read. That is left alone here and pinned by a test.

### Test plan

- `test_voicepipeline_accepts_numpy_dtype_spellings` runs `VoicePipeline` with dictionary TTS settings for `"float32"`, `"int16"`, and `np.dtype("float32")` and asserts the emitted audio dtype and lifecycle events. The string cases fail on `main`.
- `test_voicepipeline_rejects_unsupported_output_dtype` covers a dtype that resolves but is unsupported (`"int32"`), one NumPy cannot parse (a malformed structured dtype), and a non-native byte order (`">i2"`). The structured-dtype case fails without the `ValueError` catch.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`; formatting, lint, type checking, and the full test suite passed.

### Issue number

Fixes #4777

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
