### PR TITLE
Add a Gandr TTS example under examples/voice

### DIFF
--- a/examples/voice/gandr_tts/README.md
+++ b/examples/voice/gandr_tts/README.md
@@ -1,0 +1,33 @@
+# Gandr TTS voice demo
+
+This demo runs the voice pipeline with a third party text-to-speech model. [Gandr](https://gandr.ai) is an OpenAI compatible TTS API, so the swap is an `AsyncOpenAI` client pointed at `https://tts.gandr.ai/v1` plus a small `TTSModel` subclass. Speech-to-text and the agent keep using your OpenAI key.
+
+Run via:
+
+```
+python -m examples.voice.gandr_tts.main
+```
+
+Set two environment variables first:
+
+```
+export OPENAI_API_KEY=...   # transcription and the agent
+export GANDR_API_KEY=...    # speech output
+```
+
+Keys are at [gandr.ai](https://gandr.ai). The free tier is 50,000 tokens.
+
+## How it works
+
+1. We create a `VoicePipeline` with a `SingleAgentVoiceWorkflow` and pass a custom `tts_model`.
+2. `GandrTTSModel` implements the `TTSModel` interface. It calls `POST /v1/audio/speech` through the OpenAI Python client with `response_format="pcm"`. Gandr's pcm output is headerless s16le mono at 24000 Hz, which is what the pipeline streams.
+3. When you speak, the audio is transcribed with your OpenAI key, the agent runs, and the reply is spoken through Gandr.
+
+The same shape works for any OpenAI compatible speech endpoint: point the client at a different `base_url` and implement `TTSModel.run` with the fields that endpoint supports.
+
+## Notes
+
+-   Voices: `gandr-mia`, `gandr-ava`, `gandr-jenny`, `gandr-dane`, `gandr-leo`, `gandr-lewis`. 23 languages.
+-   Requests are capped at 2000 characters. The pipeline's sentence based splitter keeps each chunk well under that.
+-   `TTSModelSettings.instructions` is OpenAI specific and is not sent to Gandr.
+-   Every render is watermarked.

--- a/examples/voice/gandr_tts/main.py
+++ b/examples/voice/gandr_tts/main.py
@@ -1,0 +1,109 @@
+import asyncio
+import os
+from collections.abc import AsyncIterator
+
+import numpy as np
+from openai import AsyncOpenAI
+
+from agents import Agent
+from agents.voice import (
+    AudioInput,
+    SingleAgentVoiceWorkflow,
+    TTSModel,
+    TTSModelSettings,
+    VoicePipeline,
+)
+
+from .util import AudioPlayer, record_audio
+
+"""
+This example runs the voice pipeline with a third party text-to-speech model.
+Run it via: `python -m examples.voice.gandr_tts.main`
+
+Gandr exposes an OpenAI compatible speech endpoint, so the swap is an
+`AsyncOpenAI` client pointed at the Gandr base URL plus a small `TTSModel`
+subclass. Speech-to-text and the agent itself keep using your OpenAI key.
+
+You need two environment variables:
+- OPENAI_API_KEY for transcription and the agent.
+- GANDR_API_KEY for speech output. Keys are at https://gandr.ai; the free
+  tier is 50,000 tokens.
+"""
+
+GANDR_BASE_URL = "https://tts.gandr.ai/v1"
+
+# Other voices: gandr-ava, gandr-jenny, gandr-dane, gandr-leo, gandr-lewis.
+DEFAULT_GANDR_VOICE = "gandr-mia"
+
+
+class GandrTTSModel(TTSModel):
+    """A `TTSModel` that streams speech from the Gandr TTS API.
+
+    Gandr's `POST /v1/audio/speech` endpoint takes the same request shape as
+    OpenAI's, and its `pcm` output is headerless s16le mono at 24000 Hz,
+    which is exactly what the voice pipeline expects. Each request is capped
+    at 2000 characters; the pipeline's sentence based splitter keeps chunks
+    well under that. `TTSModelSettings.instructions` is OpenAI specific and
+    is not sent.
+    """
+
+    def __init__(self, model: str, openai_client: AsyncOpenAI):
+        self.model = model
+        self._client = openai_client
+
+    @property
+    def model_name(self) -> str:
+        return self.model
+
+    async def run(self, text: str, settings: TTSModelSettings) -> AsyncIterator[bytes]:
+        voice = settings.voice if isinstance(settings.voice, str) else DEFAULT_GANDR_VOICE
+        response = self._client.audio.speech.with_streaming_response.create(
+            model=self.model,
+            voice=voice,
+            input=text,
+            response_format="pcm",
+        )
+
+        async with response as stream:
+            async for chunk in stream.iter_bytes(chunk_size=1024):
+                yield chunk
+
+
+agent = Agent(
+    name="Assistant",
+    instructions="You're speaking to a human, so be polite and concise.",
+    model="gpt-5-mini",
+)
+
+
+async def main():
+    if not os.environ.get("GANDR_API_KEY"):
+        raise ValueError("Please set GANDR_API_KEY. Keys are at https://gandr.ai.")
+
+    gandr_client = AsyncOpenAI(
+        base_url=GANDR_BASE_URL,
+        api_key=os.environ["GANDR_API_KEY"],
+    )
+
+    pipeline = VoicePipeline(
+        workflow=SingleAgentVoiceWorkflow(agent),
+        tts_model=GandrTTSModel("tts-1", gandr_client),
+    )
+
+    audio_input = AudioInput(buffer=record_audio())
+
+    result = await pipeline.run(audio_input)
+
+    with AudioPlayer() as player:
+        async for event in result.stream():
+            if event.type == "voice_stream_event_audio":
+                player.add_audio(event.data)
+            elif event.type == "voice_stream_event_lifecycle":
+                print(f"Received lifecycle event: {event.event}")
+
+        # Add 1 second of silence to the end of the stream to avoid cutting off the last audio.
+        player.add_audio(np.zeros(24000 * 1, dtype=np.int16))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/voice/gandr_tts/util.py
+++ b/examples/voice/gandr_tts/util.py
@@ -1,0 +1,69 @@
+import curses
+import time
+
+import numpy as np
+import numpy.typing as npt
+import sounddevice as sd
+
+
+def _record_audio(screen: curses.window) -> npt.NDArray[np.float32]:
+    screen.nodelay(True)  # Non-blocking input
+    screen.clear()
+    screen.addstr(
+        "Press <spacebar> to start recording. Press <spacebar> again to stop recording.\n"
+    )
+    screen.refresh()
+
+    recording = False
+    audio_buffer: list[npt.NDArray[np.float32]] = []
+
+    def _audio_callback(indata, frames, time_info, status):
+        if status:
+            screen.addstr(f"Status: {status}\n")
+            screen.refresh()
+        if recording:
+            audio_buffer.append(indata.copy())
+
+    # Open the audio stream with the callback.
+    with sd.InputStream(samplerate=24000, channels=1, dtype=np.float32, callback=_audio_callback):
+        while True:
+            key = screen.getch()
+            if key == ord(" "):
+                recording = not recording
+                if recording:
+                    screen.addstr("Recording started...\n")
+                else:
+                    screen.addstr("Recording stopped.\n")
+                    break
+                screen.refresh()
+            time.sleep(0.01)
+
+    # Combine recorded audio chunks.
+    if audio_buffer:
+        audio_data = np.concatenate(audio_buffer, axis=0)
+    else:
+        audio_data = np.empty((0,), dtype=np.float32)
+
+    return audio_data
+
+
+def record_audio():
+    # Using curses to record audio in a way that:
+    # - doesn't require accessibility permissions on macos
+    # - doesn't block the terminal
+    audio_data = curses.wrapper(_record_audio)
+    return audio_data
+
+
+class AudioPlayer:
+    def __enter__(self):
+        self.stream = sd.OutputStream(samplerate=24000, channels=1, dtype=np.int16)
+        self.stream.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stream.stop()  # wait for the stream to finish
+        self.stream.close()
+
+    def add_audio(self, audio_data: npt.NDArray[np.int16]):
+        self.stream.write(audio_data)


### PR DESCRIPTION
### Summary

The voice docs describe swapping the speech-to-text and text-to-speech models through the `STTModel` and `TTSModel` interfaces, but `examples/voice` only shows the default OpenAI models. This adds `examples/voice/gandr_tts`, a variant of the static demo that keeps transcription and the agent on OpenAI and streams speech from Gandr, an OpenAI compatible TTS API.

The example shows the general shape for wiring any OpenAI compatible speech endpoint into `VoicePipeline`:

1. Point an `AsyncOpenAI` client at the provider's base URL (`https://tts.gandr.ai/v1` here).
2. Implement `TTSModel.run` with the fields the endpoint supports (`model`, `input`, `voice`, `response_format="pcm"`). Gandr's pcm output is headerless s16le mono at 24000 Hz, which matches what the pipeline streams.
3. Pass the instance as `tts_model=` to `VoicePipeline`. STT falls through to the default `OpenAIVoiceModelProvider` and the user's `OPENAI_API_KEY`.

New files: `examples/voice/gandr_tts/{__init__.py,README.md,main.py,util.py}`. `util.py` is a copy of the static demo's recording and playback helpers so the example stays self contained. No library code changes.

### Test plan

1. `make lint` passes on this branch.
2. Typecheck scope in this repo is `src` for mypy and `src` plus `tests` for pyright, so an examples-only change sits outside it. Running mypy directly on the new directory (`uv run mypy examples/voice/gandr_tts`) reports no issues in the 3 source files.
3. `.agents/skills/code-change-verification/scripts/run.sh` was run in this branch's checkout on a headless Linux box. Lint passed. The test suite finished 7767 passed, 40 skipped, 12 failed, 31 errors; every failure and error also occurs on main in that environment (docker, websocket and sandbox dependent tests) and none references this example. Grepping the full gate log for `gandr` returns nothing.
4. Live streaming check of the new model class from the same box with a real key: `GandrTTSModel("tts-1", AsyncOpenAI(base_url="https://tts.gandr.ai/v1", ...)).run(text, TTSModelSettings())` yielded 132 chunks, 134,400 bytes of pcm in 2.80 s, which plays back as s16le mono at 24000 Hz. The box has no audio hardware, so `sounddevice` was stubbed for the import and the interactive mic loop in `main.py` was not exercised end to end; that loop is unchanged from the static example it copies.

### Issue number

None.

### Checks

- [ ] I've added new tests, if relevant (not relevant: examples only, and audio examples are opt-in for the examples sweep)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass (12 failures and 31 errors in my environment are docker, websocket and sandbox dependent and occur on main there too; details above)
- [ ] If using Codex, I've run `/review` before submitting this PR

Disclosure: I work on Gandr.
