### PR TITLE
fix(memory): don't create a remote conversation when popping an uninitialized OpenAIConversationsSession

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -122,6 +122,10 @@ class OpenAIConversationsSession(SessionABC):
         )
 
     async def pop_item(self) -> TResponseInputItem | None:
+        if self._session_id is None:
+            # Mirrors clear_session: popping from an uninitialized session must not
+            # lazily create a remote conversation.
+            return None
         session_id = await self._get_session_id()
         items = await self.get_items(limit=1)
         if not items:

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -324,6 +324,23 @@ class TestOpenAIConversationsSessionBasicOperations:
             mock_openai_client.conversations.items.delete.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_pop_item_uninitialized_does_not_create_session(self, mock_openai_client):
+        """Test that pop_item on an uninitialized session does not create a remote conversation.
+
+        pop_item is a read-then-delete operation; lazily allocating a conversation
+        for it would leak an empty remote conversation and pin the session to it,
+        like clear_session, which guards the same way.
+        """
+        session = OpenAIConversationsSession(openai_client=mock_openai_client)
+
+        popped_item = await session.pop_item()
+
+        assert popped_item is None
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.items.delete.assert_not_called()
+        assert session._session_id is None
+
+    @pytest.mark.asyncio
     async def test_clear_session(self, mock_openai_client):
         """Test clearing the entire session."""
         session = OpenAIConversationsSession(


### PR DESCRIPTION
### Summary

`OpenAIConversationsSession.pop_item()` called `_get_session_id()` unconditionally, so popping from a session that was never initialized lazily **created an empty server-side conversation** and permanently pinned the session to it, even though the pop itself was a no-op returning `None`. `clear_session()` and `add_items()` already guard against exactly this (both have dedicated no-create tests); `pop_item()` now returns `None` the same way when `self._session_id is None`.

### Test plan

- Added `test_pop_item_uninitialized_does_not_create_session`, mirroring the existing `test_clear_session_uninitialized_does_not_create_session`: asserts `pop_item()` returns `None`, `conversations.create` / `conversations.items.delete` are never called, and `_session_id` stays `None`. The test fails on `main` and passes with this change.
- `uv run pytest tests/memory/ -q` — 204 passed.
- `uv run ruff format --check` / `ruff check` on the changed files — clean.

Note: I could not run `.agents/skills/code-change-verification/scripts/run.sh` end-to-end on my Windows machine (bash-orchestrated multi-step runner assumes a Unix CI environment); the directly equivalent steps (targeted pytest + full tests/memory + ruff format/lint in the `uv sync --locked --all-extras` environment) all pass.

### Issue number

Closes #4781

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR