### PR TITLE
Validate dynamic prompt identifiers

### DIFF
--- a/src/agents/prompts.py
+++ b/src/agents/prompts.py
@@ -72,8 +72,8 @@ class PromptUtil:
                 resolved_prompt = await func_result
             else:
                 resolved_prompt = func_result
-            if not isinstance(resolved_prompt, dict):
-                raise UserError("Dynamic prompt function must return a Prompt")
+            if not isinstance(resolved_prompt, dict) or "id" not in resolved_prompt:
+                raise UserError("Dynamic prompt function must return a Prompt with an id")
 
         return {
             "id": resolved_prompt["id"],

--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from openai import omit
 
-from agents import Agent, Prompt, RunConfig, RunContextWrapper, Runner
+from agents import Agent, Prompt, RunConfig, RunContextWrapper, Runner, UserError
 from agents.models.interface import Model, ModelProvider
 from agents.models.openai_responses import OpenAIResponsesModel
 from agents.prompts import GenerateDynamicPromptData
@@ -86,6 +86,17 @@ async def test_dynamic_prompt_is_resolved_correctly():
     resolved = await agent.get_prompt(context_wrapper)
 
     assert resolved == {"id": "dyn_prompt", "version": "2", "variables": None}
+
+
+@pytest.mark.asyncio
+async def test_dynamic_prompt_without_id_raises_user_error():
+    def dynamic_prompt_fn(_data):
+        return {}
+
+    agent = Agent(name="test", prompt=dynamic_prompt_fn)
+
+    with pytest.raises(UserError, match="Dynamic prompt function must return a Prompt with an id"):
+        await agent.get_prompt(RunContextWrapper(context=None))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Dynamic prompt callbacks can currently return a mapping without the required `id`, which leaks a raw `KeyError` while the SDK serializes the prompt. This validates the callback result at the prompt boundary and raises a caller-facing `UserError` with a clear message instead.

The change preserves the existing behavior for valid prompt mappings and adds a regression test for a missing identifier.

### Test plan

- `uv run pytest -q tests/test_agent_prompt.py` — 7 passed
- `/usr/bin/env -u OPENAI_API_KEY OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1 UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` — formatting, lint, type checking, and the complete test suite passed
- Two independent implementation reviews — clean

### Issue number

No linked issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
