### PR TITLE
Support CR-only apply diffs

### DIFF
--- a/src/agents/apply_diff.py
+++ b/src/agents/apply_diff.py
@@ -66,27 +66,31 @@ def apply_diff(input: str, diff: str, mode: ApplyDiffMode = "default") -> str:
 
 
 def _normalize_diff_lines(diff: str) -> list[str]:
-    lines = [line.rstrip("\r") for line in re.split(r"\r?\n", diff)]
+    lines = re.split(r"\r\n|\r|\n", diff)
     if lines and lines[-1] == "":
         lines.pop()
     return lines
 
 
 def _detect_newline_from_text(text: str) -> str:
-    return "\r\n" if "\r\n" in text else "\n"
+    if "\r\n" in text:
+        return "\r\n"
+    if "\n" in text:
+        return "\n"
+    return "\r" if "\r" in text else "\n"
 
 
 def _detect_newline(input: str, diff: str, mode: ApplyDiffMode) -> str:
     # Create-file diffs don't have an input to infer newline style from.
     # Use the diff's newline style if present, otherwise default to LF.
-    if mode != "create" and "\n" in input:
+    if mode != "create" and ("\n" in input or "\r" in input):
         return _detect_newline_from_text(input)
     return _detect_newline_from_text(diff)
 
 
 def _normalize_text_newlines(text: str) -> str:
-    # Normalize CRLF to LF for parsing/matching. Newline style is restored when emitting.
-    return text.replace("\r\n", "\n")
+    # Normalize line endings to LF for parsing/matching. Newline style is restored when emitting.
+    return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
 def _is_done(state: ParserState, prefixes: Sequence[str]) -> bool:

--- a/tests/test_apply_diff.py
+++ b/tests/test_apply_diff.py
@@ -261,6 +261,18 @@ def test_apply_diff_with_crlf_input_and_crlf_diff_preserves_crlf() -> None:
     assert apply_diff(input_text, diff) == "line1\r\nupdated\r\nline3\r\n"
 
 
+def test_apply_diff_with_cr_input_and_cr_diff_preserves_cr() -> None:
+    input_text = "line1\rline2\rline3\r"
+    diff = "\r".join(["@@ line1", "-line2", "+updated", " line3"])
+    assert apply_diff(input_text, diff) == "line1\rupdated\rline3\r"
+
+
+def test_apply_diff_with_mixed_lf_and_cr_input_preserves_lf() -> None:
+    input_text = "line1\nline2\rline3\n"
+    diff = "\n".join(["@@ line1", "-line2", "+updated", " line3"])
+    assert apply_diff(input_text, diff) == "line1\nupdated\nline3\n"
+
+
 def test_apply_diff_create_mode_preserves_crlf_newlines() -> None:
     diff = "\r\n".join(["+hello", "+world", "+"])
     assert apply_diff("", diff, mode="create") == "hello\r\nworld\r\n"


### PR DESCRIPTION
### Summary

`apply_diff` recognizes LF and CRLF separators but treats CR-only input and V4A diff text as a single line, so otherwise valid updates fail to match. This normalizes all three newline forms internally and restores the source convention when emitting the result.

The detector retains the existing CRLF-then-LF precedence for mixed inputs and selects CR only when no LF-family separator is present. Regression coverage includes both CR-only input/diffs and mixed LF/CR compatibility.

### Test plan

- `uv run pytest -q tests/test_apply_diff.py tests/test_apply_diff_helpers.py` — 33 passed
- `.agents/skills/code-change-verification/scripts/run.sh` — formatting, lint, and type checking passed; the full suite reached 9,264 passed and 56 skipped before one unrelated sandbox path-probe test timed out
- `uv run pytest -q tests/sandbox/test_session_utils.py::test_read_path_probe_resolves_symlinks_before_classifying_missing` — still times out in this worktree; the same test passes on the pristine upstream worktree, and it does not exercise `apply_diff`
- Two independent round-two implementation reviews — clean

### Issue number

No linked issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
