### PR TITLE
fix(realtime): reject unknown G.711 format aliases

### DIFF
--- a/src/agents/realtime/_util.py
+++ b/src/agents/realtime/_util.py
@@ -26,7 +26,7 @@ def _is_g711_format(format: RealtimeAudioFormat | None) -> bool:
     how the session was configured and which path delivered it.
     """
     if isinstance(format, str):
-        return format.lower() in _G711_FORMAT_NAMES or format.lower().startswith("g711")
+        return format.lower() in _G711_FORMAT_NAMES
     if isinstance(format, AudioPCMU | AudioPCMA):
         return True
     if isinstance(format, Mapping):

--- a/tests/realtime/test_playback_tracker.py
+++ b/tests/realtime/test_playback_tracker.py
@@ -305,3 +305,12 @@ class TestPlaybackTracker:
         playback_tracker.on_play_bytes("item_1", 0, b"\x00" * 4000)
 
         assert playback_tracker.get_state()["elapsed_ms"] == 500.0
+
+    def test_unknown_g711_prefixed_format_uses_pcm_fallback(self):
+        """An unsupported string must not be mistaken for a valid G.711 format."""
+        playback_tracker = RealtimePlaybackTracker()
+        playback_tracker.set_audio_format("g711_custom")
+
+        playback_tracker.on_play_bytes("item_1", 0, b"\x00" * 48000)
+
+        assert playback_tracker.get_state()["elapsed_ms"] == 1000.0


### PR DESCRIPTION
### Summary

This pull request fixes realtime playback timing for unsupported audio-format strings that merely begin with `g711`.

`calculate_audio_length_ms` previously classified every `g711*` string as G.711 even though the SDK normalizer accepts only six specific spellings and the timing helper documents PCM16 as the fallback for unknown formats. As a result, 48,000 bytes tagged as `g711_custom` were reported as 6,000 ms instead of the 1,000 ms PCM16 fallback.

The fix restricts string classification to the existing accepted-name set. All supported G.711 strings, mappings, typed `AudioPCMU` / `AudioPCMA` objects, case variants, PCM16 behavior, and empty-buffer behavior remain unchanged.

### Test plan

- `uv run pytest -q tests/realtime/test_playback_tracker.py` — 22 passed
- `uv run ruff format` / `uv run ruff check --fix` / `uv run ruff check` — passed
- `uv run mypy src` — passed (308 source files)
- `uv run pyright --project pyrightconfig.json --threads 4` — 0 errors, 0 warnings
- `uv run python .github/scripts/run_serial_tests.py` — passed
- Full parallel suite: 8,317 passed and 81 skipped; 25 unrelated Windows-host failures remained because this account cannot create symlinks, no OpenAI API key is configured, and one example reads UTF-8 content with the host's GBK default encoding. None of the failures involve the changed realtime files or regression test.

### Issue number

N/A — no matching issue or pull request was found.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
