### PR TITLE
fix(models): close websocket event iterator on non-streaming terminal failure

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -5,7 +5,15 @@ import contextlib
 import inspect
 import json
 import weakref
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Mapping,
+    Sequence,
+)
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
@@ -1295,18 +1303,24 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
 
         final_response: Response | None = None
         terminal_event_type: str | None = None
-        async for event in self._iter_websocket_response_events(create_kwargs):
-            event_type = getattr(event, "type", None)
-            if isinstance(event, ResponseCompletedEvent):
-                final_response = event.response
-                terminal_event_type = event.type
-            elif event_type in {"response.incomplete", "response.failed"}:
-                terminal_event_type = cast(str, event_type)
-                terminal_response = getattr(event, "response", None)
-                raise response_terminal_failure_error(
-                    terminal_event_type,
-                    terminal_response if isinstance(terminal_response, Response) else None,
-                )
+        # `async for` alone does not close its iterator when the loop body raises, and this
+        # iterator owns the request lock and releases it in its `finally`. Closing it here
+        # keeps that release in the owning task instead of waiting on generator finalization.
+        async with contextlib.aclosing(
+            self._iter_websocket_response_events(create_kwargs)
+        ) as events:
+            async for event in events:
+                event_type = getattr(event, "type", None)
+                if isinstance(event, ResponseCompletedEvent):
+                    final_response = event.response
+                    terminal_event_type = event.type
+                elif event_type in {"response.incomplete", "response.failed"}:
+                    terminal_event_type = cast(str, event_type)
+                    terminal_response = getattr(event, "response", None)
+                    raise response_terminal_failure_error(
+                        terminal_event_type,
+                        terminal_response if isinstance(terminal_response, Response) else None,
+                    )
 
         if final_response is None:
             terminal_event_hint = (
@@ -1321,7 +1335,7 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
 
     async def _iter_websocket_response_events(
         self, create_kwargs: dict[str, Any]
-    ) -> AsyncIterator[ResponseStreamEvent]:
+    ) -> AsyncGenerator[ResponseStreamEvent, None]:
         request_timeout = create_kwargs.get("timeout", omit)
         if _is_openai_omitted_value(request_timeout):
             request_timeout = getattr(self._client, "timeout", None)

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -4991,3 +4992,55 @@ async def test_streamed_span_counts_request_before_terminal_event_close() -> Non
     assert len(spans) == 1
     assert spans[0]["span_data"]["usage"]["requests"] == 1  # type: ignore[index]
     assert spans[0]["span_data"]["usage"]["total_tokens"] == 0  # type: ignore[index]
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_type", ["response.failed", "response.incomplete"])
+async def test_fetch_response_non_streaming_terminal_failure_releases_request_lock(
+    terminal_type: str,
+) -> None:
+    """A terminal failure must close the event iterator so it releases the request lock.
+
+    `_iter_websocket_response_events()` owns `_ws_request_lock` and releases it in its
+    `finally`. A bare `async for` that raises from the loop body leaves the generator
+    suspended, so the lock stays held until generator finalization runs.
+    """
+
+    class _TerminalEvent:
+        type = terminal_type
+        response = None
+
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=AsyncOpenAI(api_key="k"))  # type: ignore[arg-type]
+    lock = model._get_ws_request_lock()
+    closed = False
+
+    async def fake_events(create_kwargs: dict[str, Any]) -> AsyncIterator[Any]:
+        nonlocal closed
+        await lock.acquire()
+        try:
+            yield _TerminalEvent()
+            yield _TerminalEvent()  # pragma: no cover - the first event raises
+        finally:
+            closed = True
+            lock.release()
+
+    model._iter_websocket_response_events = fake_events  # type: ignore[assignment, method-assign]
+
+    with pytest.raises(ModelBehaviorError):
+        await model._fetch_response(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            previous_response_id=None,
+            conversation_id=None,
+            stream=False,
+            prompt=None,
+        )
+
+    # Both must hold before control returns, without waiting on generator finalization.
+    assert closed is True
+    assert lock.locked() is False


### PR DESCRIPTION
### Summary

This carries forward the fix for #4762 from #4765 under my fork.

`OpenAIResponsesWSModel._fetch_response(stream=False)` consumes `_iter_websocket_response_events()` and raises from inside the loop body on `response.failed` or `response.incomplete`. A bare `async for` does not close the async generator when the loop body raises, so the generator can remain suspended at its `yield` while still owning `_ws_request_lock`. The next request can then block waiting for a lock release that has not been scheduled.

The fix wraps the event iterator in `contextlib.aclosing()` so terminal failures close the generator in the owning task before `_fetch_response()` returns. The iterator annotation is correspondingly made precise as `AsyncGenerator[ResponseStreamEvent, None]`, which exposes `aclose()` while remaining an async iterator for existing consumers.

### Attribution

I identified and documented the failure mechanism and proposed the `aclosing` ownership fix in #4762. `@ayaangazali` implemented and measured the first patch in #4765. This PR carries that exact reviewed implementation forward from commit `58a91140a1558349e3c774d98639f8a738b89b57` so the implementation authorship remains visible in Git history.

### Test plan

The carried regression is parametrized over both `response.failed` and `response.incomplete`. It substitutes a retained async generator that acquires the real `_get_ws_request_lock()`, yields a terminal event, and records whether its `finally` runs. The test asserts `ModelBehaviorError` propagates and that both the iterator is closed and the lock is released before control returns.

In #4765, `@ayaangazali` reported that `.agents/skills/code-change-verification/scripts/run.sh` passed end to end. An independent focused review on the same commit also exercised the new regression and surrounding websocket close/cancellation/connection-reuse tests, reporting 59 passed with no blocking issue; two excluded compatibility tests failed only because optional `httpx` was absent from that review environment.

### Issue number

Fixes #4762

### Checks

- [x] Tests are included
- [ ] Fresh repository checks on this PR head
- [ ] If using Codex, run `/review` before submitting/merging
