### PR TITLE
feat: add dropped_count property to BatchTraceProcessor

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -580,6 +580,12 @@ class BatchTraceProcessor(TracingProcessor):
         self._thread_start_lock = threading.Lock()
         self._export_lock = threading.Lock()
         self._shutdown_deadline: float | None = None
+        self._dropped_count: int = 0
+
+    @property
+    def dropped_count(self) -> int:
+        """The number of spans or traces dropped due to a full queue."""
+        return self._dropped_count
 
     def _ensure_thread_started(self) -> None:
         # Fast path without holding the lock
@@ -601,6 +607,7 @@ class BatchTraceProcessor(TracingProcessor):
         try:
             self._queue.put_nowait(trace)
         except queue.Full:
+            self._dropped_count += 1
             logger.warning("Queue is full, dropping trace.")
 
     def on_trace_end(self, trace: Trace) -> None:
@@ -618,6 +625,7 @@ class BatchTraceProcessor(TracingProcessor):
         try:
             self._queue.put_nowait(span)
         except queue.Full:
+            self._dropped_count += 1
             logger.warning("Queue is full, dropping span.")
 
     def shutdown(self, timeout: float | None = None):

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -105,6 +105,24 @@ def test_batch_trace_processor_queue_full(mocked_exporter):
     processor.shutdown()
 
 
+def test_batch_trace_processor_dropped_count(mocked_exporter):
+    processor = BatchTraceProcessor(exporter=mocked_exporter, max_queue_size=2, schedule_delay=0.1)
+    
+    # Fill the queue
+    processor.on_trace_start(get_trace(processor))
+    processor.on_trace_start(get_trace(processor))
+    assert processor.dropped_count == 0
+
+    # Next item should be dropped and counter incremented
+    processor.on_trace_start(get_trace(processor))
+    assert processor.dropped_count == 1
+
+    processor.on_span_end(get_span(processor))
+    assert processor.dropped_count == 2
+
+    processor.shutdown()
+
+
 def test_batch_processor_doesnt_enqueue_on_trace_end_or_span_start(mocked_exporter):
     processor = BatchTraceProcessor(exporter=mocked_exporter)
 


### PR DESCRIPTION
This pull request adds a dropped_count property to BatchTraceProcessor to provide visibility into trace data loss.

Previously, when the internal queue of BatchTraceProcessor became full (which can happen under heavy load or if the background export thread falls behind), traces and spans were dropped with only a logger.warning. There was no programmatic way to observe or alert on this data loss.

This PR:
- Adds a _dropped_count instance variable to track the number of dropped items.
- Increments _dropped_count whenever queue.Full is caught during on_trace_start and on_span_end.
- Exposes this metric via a public dropped_count property.