### PR TITLE
fix: handle generic type aliases in final_output_as

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -18,6 +18,7 @@ from .exceptions import (
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
     RunErrorDetails,
+    UserError,
     _await_data_redacted_error_boundary,
     _detach_data_redacted_error_traceback,
     _is_error_data_redacted,
@@ -424,8 +425,18 @@ class RunResultBase(abc.ABC):
         Returns:
             The final output casted to the given type.
         """
-        if raise_if_incorrect_type and not isinstance(self.final_output, cls):
-            raise TypeError(f"Final output is not of type {cls.__name__}")
+        if raise_if_incorrect_type:
+            try:
+                is_correct = isinstance(self.final_output, cls)
+            except TypeError:
+                type_name = getattr(cls, "__name__", repr(cls))
+                raise UserError(
+                    f"final_output_as cannot validate generic type {type_name}. "
+                    "Use raise_if_incorrect_type=False for generic types."
+                ) from None
+            if not is_correct:
+                type_name = getattr(cls, "__name__", repr(cls))
+                raise TypeError(f"Final output is not of type {type_name}")
 
         return cast(T, self.final_output)
 

--- a/tests/test_result_cast.py
+++ b/tests/test_result_cast.py
@@ -103,6 +103,15 @@ def test_bad_cast_with_param_raises():
         result.final_output_as(int, raise_if_incorrect_type=True)
 
 
+def test_bad_cast_with_generic_type_raises_user_error():
+    """Bad casts with generic types (like list[str]) should raise UserError."""
+    from agents.exceptions import UserError
+
+    result = create_run_result(["test"])
+    with pytest.raises(UserError, match="Use raise_if_incorrect_type=False for generic types"):
+        result.final_output_as(list[str], raise_if_incorrect_type=True)
+
+
 def test_run_result_release_agents_breaks_strong_refs() -> None:
     message = _create_message("hello")
     agent = Agent(name="leak-test-agent")


### PR DESCRIPTION
This pull request fixes a bug where calling RunResult.final_output_as(cls, raise_if_incorrect_type=True) with a generic alias (e.g., list[str] or dict[str, int]) crashes with an unhandled internal TypeError.

Because isinstance(obj, list[str]) is not supported in Python, it raises a TypeError which the SDK previously failed to catch, preventing users from receiving a clean, actionable error message. Additionally, it attempted to access cls.__name__ which is invalid on generic aliases.

This PR:
- Wraps the isinstance check in a try/except TypeError block to catch generic alias errors gracefully.
- Replaces direct cls.__name__ access with getattr(cls, '__name__', repr(cls)) to safely format type names.
- Raises a clear UserError instructing the user to pass raise_if_incorrect_type=False when working with generic types.