### PR TITLE
fix(mcp): cache empty tools lists

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1443,8 +1443,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         transport_cause: Exception | None = None
         try:
             tools: list[MCPTool]
-            # Return from cache if caching is enabled, we have tools, and the cache is not dirty
-            if self.cache_tools_list and not self._cache_dirty and self._tools_list:
+            # Return from cache if caching is enabled, the cache is populated, and it is not dirty
+            if self.cache_tools_list and not self._cache_dirty and self._tools_list is not None:
                 tools = self._tools_list
             else:
                 tools = []

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -68,6 +68,33 @@ async def test_server_caching_works(
 @patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
 @patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
 @patch("mcp.client.session.ClientSession.list_tools")
+async def test_server_caching_works_with_empty_tools(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    """An empty tools list is a populated cache and must not be fetched again."""
+    server = MCPServerStdio(
+        params={
+            "command": tee,
+        },
+        cache_tools_list=True,
+    )
+    mock_list_tools.return_value = ListToolsResult(tools=[])
+
+    async with server:
+        first_result = await server.list_tools()
+        assert first_result == []
+        assert server.cached_tools == []
+
+        second_result = await server.list_tools()
+        assert second_result == []
+
+    assert mock_list_tools.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
 async def test_paginated_tools_are_cached_before_filtering(
     mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
 ):


### PR DESCRIPTION
This pull request fixes MCP tools-list caching when a server returns a valid empty tool list.

With `cache_tools_list=True`, `MCPServer.list_tools()` stores an empty result as `[]`, but the cache-hit check used list truthiness. As a result, every later discovery call fetched the empty list again. The cache-hit check now distinguishes the unpopulated `None` sentinel from a populated empty list.

The regression test exercises the public `MCPServerStdio` context-manager and `list_tools()` boundary, verifies `cached_tools == []`, and confirms that two calls make only one underlying MCP request. Existing invalidation, pagination, filtering, mutation-isolation, and non-empty caching behavior remains covered by the same test module.

Validation:
- `make format`
- `make lint`
- `make typecheck`
- `make tests`

All repository verification commands passed locally.