### PR TITLE
test(strict-schema): cover default removal in referenced schemas

### DIFF
--- a/tests/test_strict_schema_default_refs.py
+++ b/tests/test_strict_schema_default_refs.py
@@ -1,0 +1,23 @@
+import copy
+
+from agents.strict_schema import ensure_strict_json_schema
+
+
+def test_default_none_is_removed_from_referenced_property():
+    schema = {
+        "$defs": {
+            "Value": {
+                "type": "string",
+                "default": None,
+            }
+        },
+        "type": "object",
+        "properties": {
+            "value": {"$ref": "#/$defs/Value"},
+        },
+    }
+
+    result = ensure_strict_json_schema(copy.deepcopy(schema))
+
+    assert result["$defs"]["Value"] == {"type": "string"}
+    assert result["properties"]["value"] == {"$ref": "#/$defs/Value"}


### PR DESCRIPTION
## What

Add focused regression coverage for strict-schema normalization when a `$defs` schema contains a `default: None` value and is referenced by a property.

## Why

`ensure_strict_json_schema()` recursively normalizes definition maps as well as referenced properties. This test locks down the existing behavior that `default: None` is removed from the referenced definition while the property-level `$ref` remains intact.

This is intentionally test-only: it does not change runtime behavior.

## Testing

The new test exercises the public `ensure_strict_json_schema()` helper and checks both the normalized `$defs` entry and the preserved `$ref`.

Related context: #4390 discusses strict-schema default handling for non-null defaults; this PR does not attempt to change that behavior.