### PR TITLE
fix(voice): decode provider PCM16 as little-endian

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -104,7 +104,9 @@ class StreamedAudioResult:
             # np.int16 needs 2-byte alignment; pad odd-length chunks safely.
             combined_buffer += b"\x00"
 
-        np_array = np.frombuffer(combined_buffer, dtype=np.int16)
+        # TTS providers return PCM16 bytes in little-endian order. Decode that wire format
+        # explicitly, then normalize the result to the native int16 dtype returned to callers.
+        np_array = np.frombuffer(combined_buffer, dtype="<i2").astype(np.int16, copy=False)
 
         if output_dtype == np.int16:
             return np_array

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -73,6 +73,27 @@ def test_streamed_audio_result_odd_length_buffer_int16() -> None:
     assert transformed.tolist() == [1]
 
 
+def test_streamed_audio_result_decodes_pcm16_as_little_endian(monkeypatch) -> None:
+    result = StreamedAudioResult(
+        ZeroPcmTTSModel(),
+        TTSModelSettings(dtype=np.int16),
+        VoicePipelineConfig(),
+    )
+    native_frombuffer = np.frombuffer
+
+    def simulate_big_endian_host(buffer, *, dtype):
+        if dtype is np.int16:
+            dtype = np.dtype(">i2")
+        return native_frombuffer(buffer, dtype=dtype)
+
+    monkeypatch.setattr(np, "frombuffer", simulate_big_endian_host)
+
+    transformed = result._transform_audio_buffer([b"\x01\x02\x03\x04"], np.int16)
+
+    assert transformed.dtype == np.int16
+    assert transformed.tolist() == [0x0201, 0x0403]
+
+
 @pytest.mark.asyncio
 async def test_streamed_audio_result_raises_falsy_task_exception() -> None:
     class FalsyError(RuntimeError):


### PR DESCRIPTION
### Summary

TTS providers return PCM16 bytes in a fixed little-endian wire format, but `StreamedAudioResult` decoded them with native `np.int16`. On big-endian hosts this swapped every non-symmetric sample before returning audio to callers. The decoder now uses explicit `<i2` input and normalizes to native `np.int16`, preserving the existing float32 conversion, chunk framing, odd-byte padding, and output API.

### Test plan

Passed:
- `uv run pytest tests/voice/test_pipeline.py -q` (57 passed)
- `make lint`
- `uv run mypy src/agents/voice/result.py`
- `uv run pyright --project pyrightconfig.json src/agents/voice/result.py`
- `make tests-serial` (77 passed, 4 skipped)
- `git diff --check`

The repository-wide verification wrapper was run. `make format` and lint passed. The repository-wide typecheck remains blocked by 9 pre-existing errors in `src/agents/function_schema.py`, `src/agents/sandbox/apply_patch.py`, `src/agents/models/openai_responses.py`, and `src/agents/extensions/memory/redis_session.py`; none are in this change. The parallel `make tests` run completed with 9300 passed, 14 skipped, and 6 unrelated failures in PTY timing, MCP schema/field compatibility, and the legacy-httpx import test.

### Issue number

Closes #4816

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR