### PR TITLE
feat(sandbox): add native OIDC auth support to Modal cloud bucket mounts

### DIFF
--- a/docs/sandbox/clients.md
+++ b/docs/sandbox/clients.md
@@ -138,7 +138,7 @@ Hosted sandbox clients expose provider-specific mount strategies. Choose the bac
 | Backend | Mount notes |
 | --- | --- |
 | Docker | Supports `S3Mount`, `GCSMount`, `R2Mount`, `AzureBlobMount`, `BoxMount`, and `S3FilesMount` with local strategies such as `InContainerMountStrategy` and `DockerVolumeMountStrategy`. |
-| `ModalSandboxClient` | Supports cloud bucket mounts by using `ModalCloudBucketMountStrategy` with `S3Mount`, `R2Mount`, and HMAC-authenticated `GCSMount`. You can use inline credentials or a named Modal Secret. |
+| `ModalSandboxClient` | Supports cloud bucket mounts by using `ModalCloudBucketMountStrategy` with `S3Mount`, `R2Mount`, and HMAC-authenticated `GCSMount`. You can use inline credentials, a named Modal Secret, or an AWS IAM role assumed via Modal OIDC (`oidc_auth_role_arn`). |
 | `CloudflareSandboxClient` | Supports bucket mounts by using `CloudflareBucketMountStrategy` with `S3Mount`, `R2Mount`, and HMAC-authenticated `GCSMount`. |
 | `BlaxelSandboxClient` | Supports cloud bucket mounts by pairing `BlaxelCloudBucketMountStrategy` with an `S3Mount`, `R2Mount`, or `GCSMount` entry. Also supports persistent Blaxel Drives with `BlaxelDriveMount` and `BlaxelDriveMountStrategy`, both available from `agents.extensions.sandbox.blaxel`. |
 | `DaytonaSandboxClient` | Supports mounting cloud storage through `rclone` by using `DaytonaCloudBucketMountStrategy`; use it with `S3Mount`, `GCSMount`, `R2Mount`, `AzureBlobMount`, and `BoxMount`. |

--- a/src/agents/extensions/sandbox/modal/mounts.py
+++ b/src/agents/extensions/sandbox/modal/mounts.py
@@ -22,6 +22,7 @@ class ModalCloudBucketMountConfig:
     credentials: dict[str, str] | None = None
     secret_name: str | None = None
     secret_environment_name: str | None = None
+    oidc_auth_role_arn: str | None = None
     read_only: bool = True
 
 
@@ -29,6 +30,7 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
     type: Literal["modal_cloud_bucket"] = "modal_cloud_bucket"
     secret_name: str | None = None
     secret_environment_name: str | None = None
+    oidc_auth_role_arn: str | None = None
 
     def validate_mount(self, mount: Mount) -> None:
         _ = self._build_modal_cloud_bucket_mount_config(mount)
@@ -105,6 +107,11 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                 message="modal cloud bucket secret_name must be a non-empty string",
                 context={"mount_type": mount.type},
             )
+        if self.oidc_auth_role_arn is not None and self.oidc_auth_role_arn == "":
+            raise MountConfigError(
+                message="modal cloud bucket oidc_auth_role_arn must be a non-empty string",
+                context={"mount_type": mount.type},
+            )
         if self.secret_environment_name is not None and self.secret_environment_name == "":
             raise MountConfigError(
                 message="modal cloud bucket secret_environment_name must be a non-empty string",
@@ -114,6 +121,14 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
             raise MountConfigError(
                 message=(
                     "modal cloud bucket secret_environment_name requires secret_name to also be set"
+                ),
+                context={"mount_type": mount.type},
+            )
+        if self.oidc_auth_role_arn is not None and self.secret_name is not None:
+            raise MountConfigError(
+                message=(
+                    "modal cloud bucket mounts do not support both oidc_auth_role_arn "
+                    "and secret_name"
                 ),
                 context={"mount_type": mount.type},
             )
@@ -134,6 +149,14 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                     ),
                     context={"mount_type": mount.type},
                 )
+            if self.oidc_auth_role_arn is not None and s3_credentials:
+                raise MountConfigError(
+                    message=(
+                        "modal cloud bucket mounts do not support both inline credentials "
+                        "and oidc_auth_role_arn"
+                    ),
+                    context={"mount_type": mount.type},
+                )
             return ModalCloudBucketMountConfig(
                 bucket_name=mount.bucket,
                 bucket_endpoint_url=mount.endpoint_url,
@@ -141,6 +164,7 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                 credentials=s3_credentials or None,
                 secret_name=self.secret_name,
                 secret_environment_name=self.secret_environment_name,
+                oidc_auth_role_arn=self.oidc_auth_role_arn,
                 read_only=mount.read_only,
             )
 
@@ -159,6 +183,14 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                     ),
                     context={"mount_type": mount.type},
                 )
+            if self.oidc_auth_role_arn is not None and r2_credentials:
+                raise MountConfigError(
+                    message=(
+                        "modal cloud bucket mounts do not support both inline credentials "
+                        "and oidc_auth_role_arn"
+                    ),
+                    context={"mount_type": mount.type},
+                )
             return ModalCloudBucketMountConfig(
                 bucket_name=mount.bucket,
                 bucket_endpoint_url=(
@@ -167,6 +199,7 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                 credentials=r2_credentials or None,
                 secret_name=self.secret_name,
                 secret_environment_name=self.secret_environment_name,
+                oidc_auth_role_arn=self.oidc_auth_role_arn,
                 read_only=mount.read_only,
             )
 
@@ -194,6 +227,14 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                     ),
                     context={"mount_type": mount.type},
                 )
+            if self.oidc_auth_role_arn is not None and gcs_credentials is not None:
+                raise MountConfigError(
+                    message=(
+                        "modal cloud bucket mounts do not support both inline credentials "
+                        "and oidc_auth_role_arn"
+                    ),
+                    context={"mount_type": mount.type},
+                )
             return ModalCloudBucketMountConfig(
                 bucket_name=mount.bucket,
                 bucket_endpoint_url=mount.endpoint_url or "https://storage.googleapis.com",
@@ -201,6 +242,7 @@ class ModalCloudBucketMountStrategy(MountStrategyBase):
                 credentials=gcs_credentials,
                 secret_name=self.secret_name,
                 secret_environment_name=self.secret_environment_name,
+                oidc_auth_role_arn=self.oidc_auth_role_arn,
                 read_only=mount.read_only,
             )
 

--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -2028,6 +2028,7 @@ class ModalSandboxSession(BaseSandboxSession):
                 bucket_endpoint_url=config.bucket_endpoint_url,
                 key_prefix=config.key_prefix,
                 secret=secret,
+                oidc_auth_role_arn=config.oidc_auth_role_arn,
                 read_only=config.read_only,
             )
         return volumes

--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -263,7 +263,9 @@ _SERIALIZED_FIELDS_BY_STRATEGY_TYPE: dict[str, frozenset[str]] = {
     "cloudflare_bucket_mount": frozenset({"type"}),
     "daytona_cloud_bucket": frozenset({"type", "pattern"}),
     "e2b_cloud_bucket": frozenset({"type", "pattern"}),
-    "modal_cloud_bucket": frozenset({"type", "secret_name", "secret_environment_name"}),
+    "modal_cloud_bucket": frozenset(
+        {"type", "secret_name", "secret_environment_name", "oidc_auth_role_arn"}
+    ),
     "runloop_cloud_bucket": frozenset({"type", "pattern"}),
     "vercel_cloud_bucket": frozenset({"type"}),
 }

--- a/tests/extensions/sandbox/test_modal.py
+++ b/tests/extensions/sandbox/test_modal.py
@@ -382,12 +382,14 @@ def _load_modal_module(
             bucket_endpoint_url: str | None = None,
             key_prefix: str | None = None,
             secret: _FakeSecret | None = None,
+            oidc_auth_role_arn: str | None = None,
             read_only: bool = True,
         ) -> None:
             self.bucket_name = bucket_name
             self.bucket_endpoint_url = bucket_endpoint_url
             self.key_prefix = key_prefix
             self.secret = secret
+            self.oidc_auth_role_arn = oidc_auth_role_arn
             self.read_only = read_only
 
     class _FakeConfig:
@@ -4774,3 +4776,121 @@ async def test_modal_direct_persist_redacts_protected_mount_provider_error(
     assert exc_info.value.__context__ is None
     assert source_error.args == ()
     assert source_error.__traceback__ is None
+OIDC_ROLE_ARN = "arn:aws:iam::123456789012:role/modal-s3-reader"
+
+
+@pytest.mark.asyncio
+async def test_modal_sandbox_create_passes_oidc_role_arn_for_cloud_bucket_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, create_calls, _registry_tags = _load_modal_module(monkeypatch)
+
+    client = modal_module.ModalSandboxClient()
+    await client.create(
+        manifest=Manifest(
+            entries={
+                "remote": S3Mount(
+                    bucket="bucket",
+                    prefix="nested/prefix/",
+                    mount_strategy=modal_module.ModalCloudBucketMountStrategy(
+                        oidc_auth_role_arn=OIDC_ROLE_ARN
+                    ),
+                    read_only=False,
+                )
+            }
+        ),
+        options=modal_module.ModalSandboxClientOptions(app_name="sandbox-tests"),
+    )
+
+    assert create_calls
+    volumes = create_calls[0]["volumes"]
+    mount = volumes["/workspace/remote"]
+    assert mount.bucket_name == "bucket"
+    assert mount.key_prefix == "nested/prefix/"
+    assert mount.oidc_auth_role_arn == OIDC_ROLE_ARN
+    assert mount.secret is None
+    assert mount.read_only is False
+
+
+@pytest.mark.asyncio
+async def test_modal_cloud_bucket_mount_strategy_builds_oidc_s3_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    strategy = modal_module.ModalCloudBucketMountStrategy(oidc_auth_role_arn=OIDC_ROLE_ARN)
+    mount = S3Mount(bucket="bucket", mount_strategy=strategy)
+
+    config = strategy._build_modal_cloud_bucket_mount_config(mount)  # noqa: SLF001
+
+    assert config.oidc_auth_role_arn == OIDC_ROLE_ARN
+    assert config.secret_name is None
+    assert config.credentials is None
+
+
+def test_modal_cloud_bucket_mount_strategy_rejects_oidc_with_secret_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    strategy = modal_module.ModalCloudBucketMountStrategy(
+        oidc_auth_role_arn=OIDC_ROLE_ARN,
+        secret_name="named-modal-secret",
+    )
+    with pytest.raises(
+        MountConfigError, match="do not support both oidc_auth_role_arn and secret_name"
+    ):
+        S3Mount(bucket="bucket", mount_strategy=strategy)
+
+
+def test_modal_cloud_bucket_mount_strategy_rejects_oidc_with_inline_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    strategy = modal_module.ModalCloudBucketMountStrategy(oidc_auth_role_arn=OIDC_ROLE_ARN)
+    with pytest.raises(
+        MountConfigError, match="do not support both inline credentials and oidc_auth_role_arn"
+    ):
+        S3Mount(
+            bucket="bucket",
+            access_key_id="access-key",
+            secret_access_key="secret-key",
+            mount_strategy=strategy,
+        )
+
+
+def test_modal_cloud_bucket_mount_strategy_rejects_empty_oidc_role_arn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    strategy = modal_module.ModalCloudBucketMountStrategy(oidc_auth_role_arn="")
+    with pytest.raises(MountConfigError, match="oidc_auth_role_arn must be a non-empty string"):
+        S3Mount(bucket="bucket", mount_strategy=strategy)
+
+
+@pytest.mark.asyncio
+async def test_modal_oidc_role_arn_round_trips_through_session_state_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(
+            root="/workspace",
+            entries={
+                "remote": S3Mount(
+                    bucket="bucket",
+                    mount_strategy=modal_module.ModalCloudBucketMountStrategy(
+                        oidc_auth_role_arn=OIDC_ROLE_ARN
+                    ),
+                )
+            },
+        ),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+    )
+    client = modal_module.ModalSandboxClient()
+    serialized = client.serialize_session_state(state)
+    assert OIDC_ROLE_ARN in repr(serialized)
+    restored = client.deserialize_session_state(serialized)
+    assert restored.mount_authority_redacted is False
+    strategy = restored.manifest.entries["remote"].mount_strategy
+    assert strategy.oidc_auth_role_arn == OIDC_ROLE_ARN


### PR DESCRIPTION
### Summary

Closes #4705

Adds native OIDC authentication support to Modal cloud bucket mounts. `ModalCloudBucketMountStrategy` now accepts an optional `oidc_auth_role_arn`, which is passed through `ModalCloudBucketMountConfig` into `modal.CloudBucketMount(..., oidc_auth_role_arn=...)`. This lets deployments that cannot create long-lived AWS keys mount buckets through an IAM role assumed via Modal OIDC:

```python
ModalCloudBucketMountStrategy(
    oidc_auth_role_arn="arn:aws:iam::123456789012:role/modal-s3-reader",
)
```

Behavior:
- OIDC is mutually exclusive with `secret_name` and inline credentials; conflicting configs raise `MountConfigError` with a clear message.
- An empty-string role ARN is rejected, matching the existing `secret_name` validation style.
- `oidc_auth_role_arn` is added to the mount-strategy serialization allowlist in `_mount_security.py`, so session-state round trips keep the field and do not mark the mount authority as redacted (previously any new strategy field would have forced a resume-time rebind).
- Existing Secret-backed and inline-credential behavior is unchanged; all pre-existing Modal tests pass unmodified.
- English docs updated (`docs/sandbox/clients.md`); translated docs are generated and left untouched.

### Test plan

- New tests in `tests/extensions/sandbox/test_modal.py`:
  - sandbox `create()` passes `oidc_auth_role_arn` to `modal.CloudBucketMount` and leaves `secret` unset
  - strategy builds config with `oidc_auth_role_arn` for S3
  - rejects `oidc_auth_role_arn` + `secret_name`
  - rejects `oidc_auth_role_arn` + inline credentials
  - rejects empty `oidc_auth_role_arn`
  - session-state serialize/deserialize round trip preserves the role ARN without redacting mount authority
- `uv run pytest tests/extensions/sandbox/test_modal.py -q` → 116 passed
- `uv run pytest tests/extensions/sandbox/ -q` → 696 passed, 8 failed / 2 skipped; all 8 failures (runloop example + `test_vercel.py` collection) reproduce identically on clean `main` on this host and are unrelated to this change
- `uv run pytest tests/sandbox/test_mount_security.py -q` → 242 passed; the 2 `test_docker_mount_examples_*` failures reproduce on clean `main` (missing `docker` extra on this host)
- `uv run ruff check` on all changed files → clean
- `uv run mypy` on changed source files → only pre-existing `exception_module` no-redef error, present on clean `main`

Second-agent review: `hermes chat -Q` fresh-context review of the exact diff — result reported in PR run notes.

### Issue number

Closes #4705

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
