### PR TITLE
fix(sessions): accept base SessionSettings overrides on subclasses

### DIFF
--- a/src/agents/memory/session_settings.py
+++ b/src/agents/memory/session_settings.py
@@ -48,7 +48,8 @@ class SessionSettings:
             if isinstance(override, dict)
             else None
         )
-        override = _coerce_session_settings(override, settings_type=type(self))
+        if type(override) is not SessionSettings:
+            override = _coerce_session_settings(override, settings_type=type(self))
 
         changes = {
             field.name: getattr(override, field.name, None)
@@ -76,9 +77,6 @@ def _coerce_session_settings(
     *,
     settings_type: type[SessionSettings],
 ) -> SessionSettings:
-    """Normalize SDK-owned session settings while preserving compatible typed instances."""
-    if type(value) is SessionSettings or isinstance(value, settings_type):
-        return value
     return coerce_dataclass_config(value, settings_type, parameter_name="session")
 
 

--- a/src/agents/memory/session_settings.py
+++ b/src/agents/memory/session_settings.py
@@ -51,10 +51,10 @@ class SessionSettings:
         override = _coerce_session_settings(override, settings_type=type(self))
 
         changes = {
-            field.name: getattr(override, field.name)
+            field.name: getattr(override, field.name, None)
             for field in fields(self)
             if (override_fields is None or field.name in override_fields)
-            and getattr(override, field.name) is not None
+            and getattr(override, field.name, None) is not None
         }
 
         return replace(self, **changes)
@@ -76,6 +76,9 @@ def _coerce_session_settings(
     *,
     settings_type: type[SessionSettings],
 ) -> SessionSettings:
+    """Normalize SDK-owned session settings while preserving compatible typed instances."""
+    if type(value) is SessionSettings or isinstance(value, settings_type):
+        return value
     return coerce_dataclass_config(value, settings_type, parameter_name="session")
 
 

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from pydantic.dataclasses import dataclass
 
 from agents import Agent, RunConfig, Runner, SessionSettings, SQLiteSession, TResponseInputItem
 from agents.memory.sqlite_session import _await_mutation
@@ -960,6 +961,106 @@ async def test_session_settings_resolve():
     # Resolving with None returns self
     final_none = base.resolve(None)
     assert final_none.limit == 100
+
+
+@dataclass
+class _TenantSessionSettings(SessionSettings):
+    tenant: str = "default"
+
+
+@dataclass
+class _OtherSessionSettings(SessionSettings):
+    tenant: str = "other"
+
+
+def test_session_settings_resolve_accepts_base_override_on_subclass():
+    """A SessionSettings subclass accepts a base-class override and keeps its own fields."""
+    settings = _TenantSessionSettings(limit=1, tenant="acme")
+
+    resolved = settings.resolve(SessionSettings(limit=5))
+
+    assert isinstance(resolved, _TenantSessionSettings)
+    assert resolved.limit == 5
+    assert resolved.tenant == "acme"
+
+
+def test_session_settings_resolve_rejects_sibling_subclass_override():
+    """Unrelated settings subclasses cannot silently copy overlapping fields."""
+    settings = _TenantSessionSettings(limit=1, tenant="acme")
+
+    with pytest.raises(TypeError, match="must be a _TenantSessionSettings instance or a dict"):
+        settings.resolve(_OtherSessionSettings(limit=5, tenant="other"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "override",
+    [SessionSettings(limit=5), {"limit": 5}],
+    ids=["instance", "dict"],
+)
+async def test_runner_session_settings_override_applies_to_subclassed_settings(
+    override: SessionSettings | dict[str, Any],
+):
+    """A base SessionSettings override from RunConfig applies to a session whose settings
+    are a SessionSettings subclass."""
+    session = SQLiteSession(
+        "subclass_override_test",
+        session_settings=_TenantSessionSettings(tenant="acme"),
+    )
+    try:
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": f"Turn {i}"} for i in range(10)
+        ]
+        await session.add_items(items)
+
+        model = ScriptedModel()
+        model.enqueue([get_text_message("Got it")])
+        agent = Agent(name="test", model=model)
+
+        await Runner.run(
+            agent,
+            "New question",
+            session=session,
+            run_config=RunConfig(session_settings=override),
+        )
+
+        # The override's limit applies: only the last 5 history items plus the new question.
+        history_items = [
+            item for item in model.calls[-1].input if item.get("content") != "New question"
+        ]
+        assert len(history_items) == 5
+    finally:
+        session.close()
+
+
+@pytest.mark.asyncio
+async def test_runner_session_settings_override_rejects_sibling_subclass():
+    """Runner rejects an unrelated settings subclass before invoking the model."""
+    session = SQLiteSession(
+        "sibling_subclass_override_test",
+        session_settings=_TenantSessionSettings(tenant="acme"),
+    )
+    try:
+        model = ScriptedModel()
+        model.enqueue([get_text_message("Got it")])
+        agent = Agent(name="test", model=model)
+
+        with pytest.raises(
+            TypeError,
+            match="must be a _TenantSessionSettings instance or a dict",
+        ):
+            await Runner.run(
+                agent,
+                "New question",
+                session=session,
+                run_config=RunConfig(
+                    session_settings=_OtherSessionSettings(limit=5, tenant="other")
+                ),
+            )
+
+        assert not model.calls
+    finally:
+        session.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import PureWindowsPath
 from typing import Any, cast
 
 import pytest
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from agents import (
     Agent,
@@ -38,6 +40,16 @@ class DummyProvider(ModelProvider):
         # record the requested model name and return our test model
         self.last_requested = model_name
         return self.model_to_return
+
+
+@pydantic_dataclass
+class _DeclaredSessionSettings(SessionSettings):
+    tenant: str = "default"
+
+
+@dataclass
+class _DeclaredSessionRunConfig(RunConfig):
+    session_settings: _DeclaredSessionSettings | None = None
 
 
 def test_run_config_normalizes_first_party_dictionary_settings() -> None:
@@ -97,6 +109,22 @@ def test_run_config_preserves_typed_configuration_instances() -> None:
 
     assert config.model_settings is settings
     assert config.session_settings is session_settings
+
+
+def test_run_config_subclass_uses_declared_session_settings_type() -> None:
+    config = cast(Any, _DeclaredSessionRunConfig)(session_settings={"limit": 5, "tenant": "acme"})
+
+    assert isinstance(config.session_settings, _DeclaredSessionSettings)
+    assert config.session_settings.limit == 5
+    assert config.session_settings.tenant == "acme"
+
+
+def test_run_config_subclass_rejects_base_session_settings_instance() -> None:
+    with pytest.raises(
+        TypeError,
+        match="must be a _DeclaredSessionSettings instance or a dict",
+    ):
+        cast(Any, _DeclaredSessionRunConfig)(session_settings=SessionSettings(limit=5))
 
 
 def test_run_config_accepts_output_guardrail_blocked_message_customizers() -> None:


### PR DESCRIPTION
### Summary

`SessionSettings.resolve()` rejected a base `SessionSettings` override when the stored settings object was a subclass. This also broke the public `Runner.run(..., run_config=RunConfig(session_settings=...))` path because a dict override is first normalized to the base class.

This change preserves the concrete session-settings subtype while allowing the exact base `SessionSettings` override specifically at the `resolve()` overlay boundary. It also keeps the existing construction boundary intact: a `RunConfig` field narrowed to a custom settings subtype still normalizes dictionaries to that subtype and rejects incompatible base or sibling instances before session history is read or the model is invoked.

### Value

- Makes typed and dictionary overrides work for custom `SessionSettings` subclasses.
- Preserves subclass-only fields and the concrete result type.
- Preserves declared-subtype validation for custom `RunConfig` subclasses.
- Prevents silent cross-copying between unrelated settings subclasses.
- Fails before model execution for invalid overrides, avoiding observable model-side effects.

### Implementation

- Recognize an exact base `SessionSettings` object only inside `SessionSettings.resolve()` before subtype coercion.
- Keep `_coerce_session_settings()` delegated to `coerce_dataclass_config`, preserving strict declared-type normalization everywhere else.
- Read missing subclass-only override fields as `None`, so the stored subclass value is retained.

### Test plan

- Added direct regressions for base-class override acceptance and sibling-subclass rejection.
- Added Runner-level coverage for typed and dictionary overrides plus sibling rejection, including an assertion that the model is not invoked.
- Added `RunConfig` subclass coverage proving dictionaries normalize to the declared settings subtype and incompatible base instances are rejected.
- Final focused modules: `107 passed`.
- Formatting, Ruff, optional-truthiness check, mypy, pyright, and serial tests passed.
- Full parallel suite on Windows: `8329 passed, 81 skipped, 19 failed`; the 19 failures match the untouched baseline on this host. Two locale-dependent failures pass with `PYTHONUTF8=1`; the remaining 17 require Windows symbolic-link privileges unavailable to this session.

### Issue number

Closes #4819

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (GNU `make` is unavailable on this Windows host; I ran the equivalent Makefile commands directly)
- [x] I've confirmed all verification steps pass, apart from the 19 documented pre-existing Windows environment failures above
- [ ] If using Codex, I've run `/review` before submitting this PR
