### PR TITLE
fix(chat-completions): tolerate a missing tool call index when buffering streamed tool calls

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -551,13 +551,28 @@ class ChatCmplStreamHandler:
                             is_unindexed_untyped_continuation
                             and (
                                 is_passthrough_continuation_by_id
-                                or (saw_unindexed_passthrough_tool_call and not tool_call_delta.id)
+                                or (
+                                    saw_unindexed_passthrough_tool_call
+                                    and not tool_call_delta.id
+                                    and None not in buffered_calls
+                                )
                             )
                         )
                         if is_passthrough_continuation_by_id and buffered_id_matches:
                             raise ModelBehaviorError(
                                 "Chat Completions tool call delta ID matched both a buffered "
                                 "function call and a passthrough call."
+                            )
+
+                        if (
+                            isinstance(tool_call_delta.index, int)
+                            and tool_call_delta.index in passthrough_tool_call_indexes
+                            and tool_call_delta.id
+                            and buffered_id_matches
+                        ):
+                            raise ModelBehaviorError(
+                                "Chat Completions tool call delta supplied an index already used "
+                                "by a passthrough call and an ID owned by a buffered function call."
                             )
 
                         unindexed_buffered_call = buffered_calls.get(None)

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -318,11 +318,6 @@ class ChatCmplStreamHandler:
             if tool_call_delta.id and buffered_call.call_id == tool_call_delta.id
         ]
 
-        if len(matching_indexes) > 1:
-            raise ModelBehaviorError(
-                "Chat Completions tool call delta matched multiple buffered calls."
-            )
-
         if isinstance(tool_call_index, int):
             if matching_indexes and matching_indexes[0] != tool_call_index:
                 raise ModelBehaviorError(
@@ -435,7 +430,7 @@ class ChatCmplStreamHandler:
         cls,
         template_chunk: ChatCompletionChunk,
         buffered_calls: dict[int | None, _BufferedToolCall],
-        passthrough_tool_call_indexes: set[int],
+        passthrough_tool_call_indexes: set[int | None],
     ) -> ChatCompletionChunk:
         ordered_calls = sorted(
             buffered_calls.values(),
@@ -444,9 +439,9 @@ class ChatCmplStreamHandler:
                 call.index if isinstance(call.index, int) else 0,
             ),
         )
-        used_indexes = passthrough_tool_call_indexes | {
-            call.index for call in ordered_calls if isinstance(call.index, int)
-        }
+        used_indexes = {
+            index for index in passthrough_tool_call_indexes if isinstance(index, int)
+        } | {call.index for call in ordered_calls if isinstance(call.index, int)}
         fallback_index = max(used_indexes, default=-1) + 1
         tool_call_deltas = [
             cls._buffered_tool_call_delta(buffered_call, fallback_index=fallback_index)
@@ -466,7 +461,7 @@ class ChatCmplStreamHandler:
     ) -> AsyncIterator[ChatCompletionChunk]:
         """Buffer streamed function tool-call deltas until they are complete."""
         buffered_calls: dict[int | None, _BufferedToolCall] = {}
-        passthrough_tool_call_indexes: set[int] = set()
+        passthrough_tool_call_indexes: set[int | None] = set()
         saw_passthrough_tool_call = False
         last_chunk: ChatCompletionChunk | None = None
 
@@ -480,6 +475,8 @@ class ChatCmplStreamHandler:
             passthrough_choices: list[Choice] = []
             for choice in chunk.choices:
                 if choice.index != 0:
+                    if choice.delta and choice.delta.tool_calls:
+                        saw_passthrough_tool_call = True
                     passthrough_choices.append(choice)
                     continue
 
@@ -488,11 +485,33 @@ class ChatCmplStreamHandler:
                 if tool_call_deltas := (delta.tool_calls if delta and delta.tool_calls else None):
                     remaining_tool_calls: list[ChoiceDeltaToolCall] = []
                     for tool_call_delta in tool_call_deltas:
-                        if tool_call_delta.index in passthrough_tool_call_indexes:
-                            if tool_call_delta.id and any(
+                        matches_buffered_id = bool(
+                            tool_call_delta.id
+                            and any(
                                 buffered_call.call_id == tool_call_delta.id
                                 for buffered_call in buffered_calls.values()
+                            )
+                        )
+                        is_unindexed_function_delta = tool_call_delta.index is None and (
+                            tool_call_delta.function is not None
+                            or tool_call_delta.type == "function"
+                            or matches_buffered_id
+                        )
+                        if (
+                            tool_call_delta.index in passthrough_tool_call_indexes
+                            and not is_unindexed_function_delta
+                        ):
+                            if (
+                                tool_call_delta.index is None
+                                and tool_call_delta.id is None
+                                and tool_call_delta.function is None
+                                and None in buffered_calls
                             ):
+                                raise ModelBehaviorError(
+                                    "Chat Completions tool call delta could not be attributed "
+                                    "safely between buffered and passthrough calls."
+                                )
+                            if matches_buffered_id:
                                 raise ModelBehaviorError(
                                     "Chat Completions tool call index and ID identified different "
                                     "tool call owners."
@@ -500,16 +519,6 @@ class ChatCmplStreamHandler:
                             saw_passthrough_tool_call = True
                             remaining_tool_calls.append(tool_call_delta)
                         elif cls._should_buffer_tool_call_delta(tool_call_delta):
-                            if (
-                                saw_passthrough_tool_call
-                                and tool_call_delta.index is None
-                                and tool_call_delta.id is None
-                                and tool_call_delta.function is None
-                            ):
-                                raise ModelBehaviorError(
-                                    "Chat Completions tool call delta could not be attributed "
-                                    "safely between buffered and passthrough calls."
-                                )
                             cls._accumulate_tool_call_delta(buffered_calls, tool_call_delta)
                         else:
                             if (
@@ -520,8 +529,7 @@ class ChatCmplStreamHandler:
                                     "Chat Completions tool call index identified both a buffered "
                                     "function call and a passthrough call."
                                 )
-                            if isinstance(tool_call_delta.index, int):
-                                passthrough_tool_call_indexes.add(tool_call_delta.index)
+                            passthrough_tool_call_indexes.add(tool_call_delta.index)
                             saw_passthrough_tool_call = True
                             remaining_tool_calls.append(tool_call_delta)
 

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -397,8 +397,13 @@ class ChatCmplStreamHandler:
                     elif len(buffered_calls) == 1:
                         sole_index = next(iter(buffered_calls))
                         sole_name = buffered_calls[sole_index].name
-                        if not sole_name or sole_name == function_name:
+                        if not sole_name:
                             tool_call_index = sole_index
+                        elif sole_name == function_name:
+                            raise ModelBehaviorError(
+                                "Chat Completions tool call delta omitted an index and ID while "
+                                "another buffered call used the same function name."
+                            )
                         else:
                             tool_call_index = None
                     else:

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -157,6 +157,13 @@ class _BufferedToolCall:
     extra_content: dict[str, Any] | None = None
 
 
+def _buffered_tool_call_order(buffered_call: _BufferedToolCall) -> tuple[bool, int]:
+    """Sort indexed tool calls by index and keep an index-less call after them."""
+    if isinstance(buffered_call.index, int):
+        return (False, buffered_call.index)
+    return (True, 0)
+
+
 def _merge_buffered_metadata(
     current: dict[str, Any] | None,
     incoming: dict[str, Any],
@@ -341,6 +348,7 @@ class ChatCmplStreamHandler:
     @staticmethod
     def _buffered_tool_call_delta(
         buffered_call: _BufferedToolCall,
+        fallback_index: int = 0,
     ) -> ChoiceDeltaToolCall:
         if not buffered_call.call_id:
             raise ModelBehaviorError(
@@ -353,7 +361,9 @@ class ChatCmplStreamHandler:
             )
 
         tool_call_delta = ChoiceDeltaToolCall(
-            index=buffered_call.index,
+            # Lenient chunk parsing leaves the index as None when the provider omitted it,
+            # and the replayed delta needs a real index.
+            index=buffered_call.index if isinstance(buffered_call.index, int) else fallback_index,
             id=buffered_call.call_id,
             function=ChoiceDeltaToolCallFunction(
                 name=buffered_call.name,
@@ -376,9 +386,18 @@ class ChatCmplStreamHandler:
         template_chunk: ChatCompletionChunk,
         buffered_calls: dict[int, _BufferedToolCall],
     ) -> ChatCompletionChunk:
+        # OpenAI-compatible providers may omit the tool call index, which lenient chunk
+        # parsing leaves as None. Every index-less delta accumulates under that single key,
+        # so replay the indexed calls in index order and give the index-less call the next
+        # free index instead of failing on a None/int comparison.
+        ordered_calls = sorted(buffered_calls.values(), key=_buffered_tool_call_order)
+        fallback_index = (
+            max((call.index for call in ordered_calls if isinstance(call.index, int)), default=-1)
+            + 1
+        )
         tool_call_deltas = [
-            cls._buffered_tool_call_delta(buffered_call)
-            for _, buffered_call in sorted(buffered_calls.items())
+            cls._buffered_tool_call_delta(buffered_call, fallback_index=fallback_index)
+            for buffered_call in ordered_calls
         ]
         choice = Choice(
             index=0,

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -157,11 +157,25 @@ class _BufferedToolCall:
     extra_content: dict[str, Any] | None = None
 
 
-def _buffered_tool_call_order(buffered_call: _BufferedToolCall) -> tuple[bool, int]:
-    """Sort indexed tool calls by index and keep an index-less call after them."""
-    if isinstance(buffered_call.index, int):
-        return (False, buffered_call.index)
-    return (True, 0)
+def _buffered_tool_calls_in_replay_order(
+    buffered_calls: dict[int | None, _BufferedToolCall],
+) -> list[_BufferedToolCall]:
+    """Sort indexed calls while preserving where the index-less call first appeared."""
+    indexed_calls = sorted(
+        (call for call in buffered_calls.values() if isinstance(call.index, int)),
+        key=lambda call: cast(int, call.index),
+    )
+    if None not in buffered_calls:
+        return indexed_calls
+
+    unindexed_position = 0
+    for index in buffered_calls:
+        if index is None:
+            break
+        unindexed_position += 1
+
+    indexed_calls.insert(unindexed_position, buffered_calls[None])
+    return indexed_calls
 
 
 def _merge_buffered_metadata(
@@ -318,16 +332,55 @@ class ChatCmplStreamHandler:
         tool_call_delta: ChoiceDeltaToolCall,
     ) -> None:
         tool_call_index = tool_call_delta.index
-        if not isinstance(tool_call_index, int) and not tool_call_delta.id:
-            if None in buffered_calls:
-                tool_call_index = None
-            elif len(buffered_calls) == 1:
-                tool_call_index = next(iter(buffered_calls))
-            elif len(buffered_calls) > 1:
+        if not isinstance(tool_call_index, int):
+            matching_indexes = [
+                index
+                for index, buffered_call in buffered_calls.items()
+                if tool_call_delta.id and buffered_call.call_id == tool_call_delta.id
+            ]
+            if len(matching_indexes) == 1:
+                tool_call_index = matching_indexes[0]
+            elif len(matching_indexes) > 1:
                 raise ModelBehaviorError(
-                    "Chat Completions tool call delta omitted an index while multiple "
-                    "function tool calls were being buffered."
+                    "Chat Completions tool call delta omitted an index and the same ID "
+                    "matched multiple buffered calls."
                 )
+            elif tool_call_delta.id and None in buffered_calls and buffered_calls[None].call_id:
+                raise ModelBehaviorError(
+                    "Chat Completions tool call delta omitted an index with a new ID while "
+                    "another index-less call was being buffered."
+                )
+            else:
+                function_name = tool_call_delta.function.name if tool_call_delta.function else None
+                if function_name and None in buffered_calls:
+                    buffered_name = buffered_calls[None].name
+                    if buffered_name and buffered_name != function_name:
+                        raise ModelBehaviorError(
+                            "Chat Completions tool call delta omitted an index and used a "
+                            "different function name from the buffered index-less call."
+                        )
+
+                if not tool_call_delta.id and function_name:
+                    if None in buffered_calls:
+                        tool_call_index = None
+                    elif len(buffered_calls) == 1:
+                        sole_index = next(iter(buffered_calls))
+                        sole_name = buffered_calls[sole_index].name
+                        if not sole_name or sole_name == function_name:
+                            tool_call_index = sole_index
+                        else:
+                            tool_call_index = None
+                    else:
+                        tool_call_index = None
+                elif not tool_call_delta.id and None in buffered_calls:
+                    tool_call_index = None
+                elif not tool_call_delta.id and len(buffered_calls) == 1:
+                    tool_call_index = next(iter(buffered_calls))
+                elif not tool_call_delta.id and len(buffered_calls) > 1:
+                    raise ModelBehaviorError(
+                        "Chat Completions tool call delta omitted an index while multiple "
+                        "function tool calls were being buffered."
+                    )
 
         buffered_call = buffered_calls.setdefault(
             tool_call_index,
@@ -397,7 +450,7 @@ class ChatCmplStreamHandler:
         buffered_calls: dict[int | None, _BufferedToolCall],
         passthrough_tool_call_indexes: set[int],
     ) -> ChatCompletionChunk:
-        ordered_calls = sorted(buffered_calls.values(), key=_buffered_tool_call_order)
+        ordered_calls = _buffered_tool_calls_in_replay_order(buffered_calls)
         occupied_indexes = passthrough_tool_call_indexes | {
             call.index for call in ordered_calls if isinstance(call.index, int)
         }
@@ -421,6 +474,8 @@ class ChatCmplStreamHandler:
         """Buffer streamed function tool-call deltas until they are complete."""
         buffered_calls: dict[int | None, _BufferedToolCall] = {}
         passthrough_tool_call_indexes: set[int] = set()
+        passthrough_tool_call_indexes_by_id: dict[str, int | None] = {}
+        saw_unindexed_passthrough_tool_call = False
         saw_passthrough_tool_call = False
         last_chunk: ChatCompletionChunk | None = None
 
@@ -444,14 +499,84 @@ class ChatCmplStreamHandler:
                 if tool_call_deltas := (delta.tool_calls if delta and delta.tool_calls else None):
                     remaining_tool_calls: list[ChoiceDeltaToolCall] = []
                     for tool_call_delta in tool_call_deltas:
-                        if tool_call_delta.index in passthrough_tool_call_indexes:
+                        is_unindexed_untyped_continuation = (
+                            not isinstance(tool_call_delta.index, int)
+                            and getattr(tool_call_delta, "type", None) is None
+                            and tool_call_delta.function is None
+                        )
+                        buffered_id_matches = [
+                            buffered_call
+                            for buffered_call in buffered_calls.values()
+                            if tool_call_delta.id and buffered_call.call_id == tool_call_delta.id
+                        ]
+                        is_unindexed_passthrough_continuation = (
+                            is_unindexed_untyped_continuation
+                            and (
+                                tool_call_delta.id in passthrough_tool_call_indexes_by_id
+                                or (saw_unindexed_passthrough_tool_call and not tool_call_delta.id)
+                            )
+                        )
+                        if is_unindexed_passthrough_continuation and buffered_id_matches:
+                            raise ModelBehaviorError(
+                                "Chat Completions tool call delta omitted an index and its ID "
+                                "matched both a buffered function call and a passthrough call."
+                            )
+
+                        if (
+                            tool_call_delta.index in passthrough_tool_call_indexes
+                            or is_unindexed_passthrough_continuation
+                        ):
+                            if passthrough_id := tool_call_delta.id:
+                                owner_index = passthrough_tool_call_indexes_by_id.get(
+                                    passthrough_id
+                                )
+                                if isinstance(owner_index, int) and not isinstance(
+                                    tool_call_delta.index, int
+                                ):
+                                    tool_call_delta = tool_call_delta.model_copy(
+                                        update={"index": owner_index}
+                                    )
+                                passthrough_tool_call_indexes_by_id.setdefault(
+                                    passthrough_id,
+                                    tool_call_delta.index
+                                    if isinstance(tool_call_delta.index, int)
+                                    else None,
+                                )
                             saw_passthrough_tool_call = True
                             remaining_tool_calls.append(tool_call_delta)
+                        elif (
+                            is_unindexed_untyped_continuation
+                            and saw_passthrough_tool_call
+                            and (
+                                not tool_call_delta.id
+                                or (
+                                    bool(
+                                        set(tool_call_delta.model_extra or {})
+                                        - {"provider_specific_fields", "extra_content"}
+                                    )
+                                    and not buffered_id_matches
+                                )
+                            )
+                        ):
+                            raise ModelBehaviorError(
+                                "Chat Completions tool call delta omitted an index, type, and "
+                                "function payload after a passthrough call, so it could not be "
+                                "attributed safely."
+                            )
                         elif cls._should_buffer_tool_call_delta(tool_call_delta):
                             cls._accumulate_tool_call_delta(buffered_calls, tool_call_delta)
                         else:
                             if isinstance(tool_call_delta.index, int):
                                 passthrough_tool_call_indexes.add(tool_call_delta.index)
+                            else:
+                                saw_unindexed_passthrough_tool_call = True
+                            if tool_call_delta.id:
+                                passthrough_tool_call_indexes_by_id.setdefault(
+                                    tool_call_delta.id,
+                                    tool_call_delta.index
+                                    if isinstance(tool_call_delta.index, int)
+                                    else None,
+                                )
                             saw_passthrough_tool_call = True
                             remaining_tool_calls.append(tool_call_delta)
 

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -157,27 +157,6 @@ class _BufferedToolCall:
     extra_content: dict[str, Any] | None = None
 
 
-def _buffered_tool_calls_in_replay_order(
-    buffered_calls: dict[int | None, _BufferedToolCall],
-) -> list[_BufferedToolCall]:
-    """Sort indexed calls while preserving where the index-less call first appeared."""
-    indexed_calls = sorted(
-        (call for call in buffered_calls.values() if isinstance(call.index, int)),
-        key=lambda call: cast(int, call.index),
-    )
-    if None not in buffered_calls:
-        return indexed_calls
-
-    unindexed_position = 0
-    for index in buffered_calls:
-        if index is None:
-            break
-        unindexed_position += 1
-
-    indexed_calls.insert(unindexed_position, buffered_calls[None])
-    return indexed_calls
-
-
 def _merge_buffered_metadata(
     current: dict[str, Any] | None,
     incoming: dict[str, Any],
@@ -338,90 +317,61 @@ class ChatCmplStreamHandler:
             for index, buffered_call in buffered_calls.items()
             if tool_call_delta.id and buffered_call.call_id == tool_call_delta.id
         ]
-        if isinstance(tool_call_index, int):
-            if None in matching_indexes:
-                if len(matching_indexes) > 1:
-                    raise ModelBehaviorError(
-                        "Chat Completions tool call delta supplied an index and the same ID "
-                        "matched multiple buffered calls."
-                    )
-                if tool_call_index in buffered_calls:
-                    raise ModelBehaviorError(
-                        "Chat Completions tool call delta supplied an index already used by "
-                        "another buffered call."
-                    )
 
-                buffered_call = buffered_calls.pop(None)
-                buffered_call.index = tool_call_index
-                buffered_calls[tool_call_index] = buffered_call
-            elif (
-                not tool_call_delta.id
-                and None in buffered_calls
-                and tool_call_index not in buffered_calls
-            ):
-                buffered_name = buffered_calls[None].name
-                if not function_name or not buffered_name or function_name == buffered_name:
-                    if len(buffered_calls) > 1:
-                        raise ModelBehaviorError(
-                            "Chat Completions tool call delta supplied a new index without an ID "
-                            "while multiple function calls were being buffered."
-                        )
-                    buffered_call = buffered_calls.pop(None)
-                    buffered_call.index = tool_call_index
-                    buffered_calls[tool_call_index] = buffered_call
-        else:
-            if len(matching_indexes) == 1:
-                tool_call_index = matching_indexes[0]
-            elif len(matching_indexes) > 1:
+        if len(matching_indexes) > 1:
+            raise ModelBehaviorError(
+                "Chat Completions tool call delta matched multiple buffered calls."
+            )
+
+        if isinstance(tool_call_index, int):
+            if matching_indexes and matching_indexes[0] != tool_call_index:
                 raise ModelBehaviorError(
-                    "Chat Completions tool call delta omitted an index and the same ID "
-                    "matched multiple buffered calls."
+                    "Chat Completions tool call index and ID identified different buffered calls."
                 )
-            elif tool_call_delta.id and None in buffered_calls and buffered_calls[None].call_id:
+        elif matching_indexes:
+            tool_call_index = matching_indexes[0]
+        elif tool_call_delta.id:
+            if None in buffered_calls and buffered_calls[None].call_id:
                 raise ModelBehaviorError(
-                    "Chat Completions tool call delta omitted an index with a new ID while "
+                    "Chat Completions tool call delta omitted an index for a new call while "
                     "another index-less call was being buffered."
                 )
-            else:
-                if function_name and None in buffered_calls:
-                    buffered_name = buffered_calls[None].name
-                    if buffered_name and buffered_name != function_name:
-                        raise ModelBehaviorError(
-                            "Chat Completions tool call delta omitted an index and used a "
-                            "different function name from the buffered index-less call."
-                        )
-
-                if not tool_call_delta.id and function_name:
-                    if None in buffered_calls:
-                        tool_call_index = None
-                    elif len(buffered_calls) == 1:
-                        sole_index = next(iter(buffered_calls))
-                        sole_name = buffered_calls[sole_index].name
-                        if not sole_name:
-                            tool_call_index = sole_index
-                        elif sole_name == function_name:
-                            raise ModelBehaviorError(
-                                "Chat Completions tool call delta omitted an index and ID while "
-                                "another buffered call used the same function name."
-                            )
-                        else:
-                            tool_call_index = None
-                    else:
-                        tool_call_index = None
-                elif not tool_call_delta.id and None in buffered_calls:
-                    tool_call_index = None
-                elif not tool_call_delta.id and len(buffered_calls) == 1:
-                    tool_call_index = next(iter(buffered_calls))
-                elif not tool_call_delta.id and len(buffered_calls) > 1:
+            tool_call_index = None
+        elif function_name:
+            if None in buffered_calls:
+                if buffered_calls[None].name:
                     raise ModelBehaviorError(
-                        "Chat Completions tool call delta omitted an index while multiple "
-                        "function tool calls were being buffered."
+                        "Chat Completions tool call delta omitted both index and ID, so its "
+                        "function-call owner could not be attributed safely."
                     )
+            elif any(call.name == function_name for call in buffered_calls.values()):
+                raise ModelBehaviorError(
+                    "Chat Completions tool call delta omitted both index and ID, so its "
+                    "function-call owner could not be attributed safely."
+                )
+            else:
+                tool_call_index = None
+        elif len(buffered_calls) == 1:
+            tool_call_index = next(iter(buffered_calls))
+        elif len(buffered_calls) > 1:
+            raise ModelBehaviorError(
+                "Chat Completions tool call delta omitted both index and ID while multiple "
+                "function calls were being buffered."
+            )
 
         buffered_call = buffered_calls.setdefault(
             tool_call_index,
             _BufferedToolCall(index=tool_call_index),
         )
+
+        if tool_call_delta.id and buffered_call.call_id not in (None, tool_call_delta.id):
+            raise ModelBehaviorError(
+                "Chat Completions tool call delta changed the ID of a buffered call."
+            )
+        if function_name and buffered_call.name not in (None, function_name):
+            raise ModelBehaviorError(
+                "Chat Completions tool call delta changed the name of a buffered function call."
+            )
 
         if tool_call_delta.id:
             buffered_call.call_id = tool_call_delta.id
@@ -449,6 +399,7 @@ class ChatCmplStreamHandler:
     @staticmethod
     def _buffered_tool_call_delta(
         buffered_call: _BufferedToolCall,
+        *,
         fallback_index: int = 0,
     ) -> ChoiceDeltaToolCall:
         if not buffered_call.call_id:
@@ -486,11 +437,17 @@ class ChatCmplStreamHandler:
         buffered_calls: dict[int | None, _BufferedToolCall],
         passthrough_tool_call_indexes: set[int],
     ) -> ChatCompletionChunk:
-        ordered_calls = _buffered_tool_calls_in_replay_order(buffered_calls)
-        occupied_indexes = passthrough_tool_call_indexes | {
+        ordered_calls = sorted(
+            buffered_calls.values(),
+            key=lambda call: (
+                not isinstance(call.index, int),
+                call.index if isinstance(call.index, int) else 0,
+            ),
+        )
+        used_indexes = passthrough_tool_call_indexes | {
             call.index for call in ordered_calls if isinstance(call.index, int)
         }
-        fallback_index = max(occupied_indexes, default=-1) + 1
+        fallback_index = max(used_indexes, default=-1) + 1
         tool_call_deltas = [
             cls._buffered_tool_call_delta(buffered_call, fallback_index=fallback_index)
             for buffered_call in ordered_calls
@@ -510,8 +467,6 @@ class ChatCmplStreamHandler:
         """Buffer streamed function tool-call deltas until they are complete."""
         buffered_calls: dict[int | None, _BufferedToolCall] = {}
         passthrough_tool_call_indexes: set[int] = set()
-        passthrough_tool_call_indexes_by_id: dict[str, int | None] = {}
-        unindexed_passthrough_tool_call_count = 0
         saw_passthrough_tool_call = False
         last_chunk: ChatCompletionChunk | None = None
 
@@ -525,8 +480,6 @@ class ChatCmplStreamHandler:
             passthrough_choices: list[Choice] = []
             for choice in chunk.choices:
                 if choice.index != 0:
-                    if choice.delta and choice.delta.tool_calls:
-                        saw_passthrough_tool_call = True
                     passthrough_choices.append(choice)
                     continue
 
@@ -535,177 +488,40 @@ class ChatCmplStreamHandler:
                 if tool_call_deltas := (delta.tool_calls if delta and delta.tool_calls else None):
                     remaining_tool_calls: list[ChoiceDeltaToolCall] = []
                     for tool_call_delta in tool_call_deltas:
-                        is_untyped_continuation = (
-                            getattr(tool_call_delta, "type", None) is None
-                            and tool_call_delta.function is None
-                        )
-                        is_unindexed_untyped_continuation = (
-                            not isinstance(tool_call_delta.index, int) and is_untyped_continuation
-                        )
-                        passthrough_payload_keys = set(tool_call_delta.model_extra or {}) - {
-                            "provider_specific_fields",
-                            "extra_content",
-                        }
-                        buffered_id_matches = [
-                            buffered_call
-                            for buffered_call in buffered_calls.values()
-                            if tool_call_delta.id and buffered_call.call_id == tool_call_delta.id
-                        ]
-                        is_passthrough_continuation_by_id = (
-                            is_untyped_continuation
-                            and bool(tool_call_delta.id)
-                            and tool_call_delta.id in passthrough_tool_call_indexes_by_id
-                        )
-                        is_idless_passthrough_continuation = (
-                            is_untyped_continuation
-                            and not tool_call_delta.id
-                            and unindexed_passthrough_tool_call_count == 1
-                            and None not in buffered_calls
-                            and (
-                                not isinstance(tool_call_delta.index, int)
-                                or bool(passthrough_payload_keys)
-                            )
-                        )
-                        if is_passthrough_continuation_by_id and buffered_id_matches:
-                            raise ModelBehaviorError(
-                                "Chat Completions tool call delta ID matched both a buffered "
-                                "function call and a passthrough call."
-                            )
-
-                        if (
-                            isinstance(tool_call_delta.index, int)
-                            and tool_call_delta.index in passthrough_tool_call_indexes
-                            and tool_call_delta.id
-                            and buffered_id_matches
-                        ):
-                            raise ModelBehaviorError(
-                                "Chat Completions tool call delta supplied an index already used "
-                                "by a passthrough call and an ID owned by a buffered function call."
-                            )
-
-                        if (
-                            is_idless_passthrough_continuation
-                            and isinstance(tool_call_delta.index, int)
-                            and tool_call_delta.index in buffered_calls
-                        ):
-                            raise ModelBehaviorError(
-                                "Chat Completions passthrough tool call delta supplied an index "
-                                "already used by a buffered function call."
-                            )
-
-                        unindexed_buffered_call = buffered_calls.get(None)
-                        if (
-                            isinstance(tool_call_delta.index, int)
-                            and tool_call_delta.index in passthrough_tool_call_indexes
-                            and unindexed_buffered_call is not None
-                            and (
-                                (
-                                    tool_call_delta.id
-                                    and unindexed_buffered_call.call_id == tool_call_delta.id
-                                )
-                                or (
-                                    not tool_call_delta.id
-                                    and len(buffered_calls) == 1
-                                    and tool_call_delta.function is not None
-                                )
-                            )
-                        ):
-                            raise ModelBehaviorError(
-                                "Chat Completions tool call delta supplied an index already used "
-                                "by a passthrough call."
-                            )
-
-                        if (
-                            tool_call_delta.index in passthrough_tool_call_indexes
-                            or is_passthrough_continuation_by_id
-                            or is_idless_passthrough_continuation
-                        ):
-                            if passthrough_id := tool_call_delta.id:
-                                owner_index = passthrough_tool_call_indexes_by_id.get(
-                                    passthrough_id
-                                )
-                                if isinstance(tool_call_delta.index, int):
-                                    promotes_unindexed_passthrough_owner = (
-                                        is_passthrough_continuation_by_id
-                                        and not isinstance(owner_index, int)
-                                    )
-                                    if isinstance(owner_index, int) and (
-                                        owner_index != tool_call_delta.index
-                                    ):
-                                        raise ModelBehaviorError(
-                                            "Chat Completions passthrough tool call delta supplied "
-                                            "a different index from its buffered ID owner."
-                                        )
-                                    if tool_call_delta.index in buffered_calls:
-                                        raise ModelBehaviorError(
-                                            "Chat Completions passthrough tool call delta supplied "
-                                            "an index already used by a buffered function call."
-                                        )
-                                    passthrough_tool_call_indexes.add(tool_call_delta.index)
-                                    passthrough_tool_call_indexes_by_id[passthrough_id] = (
-                                        tool_call_delta.index
-                                    )
-                                    if promotes_unindexed_passthrough_owner:
-                                        unindexed_passthrough_tool_call_count -= 1
-                                        tool_call_delta = tool_call_delta.model_copy(
-                                            update={"type": "custom"}
-                                        )
-                                elif isinstance(owner_index, int):
-                                    tool_call_delta = tool_call_delta.model_copy(
-                                        update={"index": owner_index}
-                                    )
-                                passthrough_tool_call_indexes_by_id.setdefault(
-                                    passthrough_id,
-                                    tool_call_delta.index
-                                    if isinstance(tool_call_delta.index, int)
-                                    else None,
-                                )
-                            elif (
-                                is_idless_passthrough_continuation
-                                and isinstance(tool_call_delta.index, int)
-                                and tool_call_delta.index not in passthrough_tool_call_indexes
+                        if tool_call_delta.index in passthrough_tool_call_indexes:
+                            if tool_call_delta.id and any(
+                                buffered_call.call_id == tool_call_delta.id
+                                for buffered_call in buffered_calls.values()
                             ):
-                                passthrough_tool_call_indexes.add(tool_call_delta.index)
-                                for passthrough_id, owner_index in list(
-                                    passthrough_tool_call_indexes_by_id.items()
-                                ):
-                                    if owner_index is None:
-                                        passthrough_tool_call_indexes_by_id[passthrough_id] = (
-                                            tool_call_delta.index
-                                        )
-                                unindexed_passthrough_tool_call_count = 0
-                                tool_call_delta = tool_call_delta.model_copy(
-                                    update={"type": "custom"}
+                                raise ModelBehaviorError(
+                                    "Chat Completions tool call index and ID identified different "
+                                    "tool call owners."
                                 )
                             saw_passthrough_tool_call = True
                             remaining_tool_calls.append(tool_call_delta)
-                        elif (
-                            is_unindexed_untyped_continuation
-                            and saw_passthrough_tool_call
-                            and (
-                                not tool_call_delta.id
-                                or (bool(passthrough_payload_keys) and not buffered_id_matches)
-                            )
-                        ):
-                            raise ModelBehaviorError(
-                                "Chat Completions tool call delta omitted an index, type, and "
-                                "function payload after a passthrough call, so it could not be "
-                                "attributed safely."
-                            )
                         elif cls._should_buffer_tool_call_delta(tool_call_delta):
+                            if (
+                                saw_passthrough_tool_call
+                                and tool_call_delta.index is None
+                                and tool_call_delta.id is None
+                                and tool_call_delta.function is None
+                            ):
+                                raise ModelBehaviorError(
+                                    "Chat Completions tool call delta could not be attributed "
+                                    "safely between buffered and passthrough calls."
+                                )
                             cls._accumulate_tool_call_delta(buffered_calls, tool_call_delta)
                         else:
+                            if (
+                                isinstance(tool_call_delta.index, int)
+                                and tool_call_delta.index in buffered_calls
+                            ):
+                                raise ModelBehaviorError(
+                                    "Chat Completions tool call index identified both a buffered "
+                                    "function call and a passthrough call."
+                                )
                             if isinstance(tool_call_delta.index, int):
                                 passthrough_tool_call_indexes.add(tool_call_delta.index)
-                            else:
-                                unindexed_passthrough_tool_call_count += 1
-                            if tool_call_delta.id:
-                                passthrough_tool_call_indexes_by_id.setdefault(
-                                    tool_call_delta.id,
-                                    tool_call_delta.index
-                                    if isinstance(tool_call_delta.index, int)
-                                    else None,
-                                )
                             saw_passthrough_tool_call = True
                             remaining_tool_calls.append(tool_call_delta)
 

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -506,7 +506,7 @@ class ChatCmplStreamHandler:
         buffered_calls: dict[int | None, _BufferedToolCall] = {}
         passthrough_tool_call_indexes: set[int] = set()
         passthrough_tool_call_indexes_by_id: dict[str, int | None] = {}
-        saw_unindexed_passthrough_tool_call = False
+        unindexed_passthrough_tool_call_count = 0
         saw_passthrough_tool_call = False
         last_chunk: ChatCompletionChunk | None = None
 
@@ -537,6 +537,10 @@ class ChatCmplStreamHandler:
                         is_unindexed_untyped_continuation = (
                             not isinstance(tool_call_delta.index, int) and is_untyped_continuation
                         )
+                        passthrough_payload_keys = set(tool_call_delta.model_extra or {}) - {
+                            "provider_specific_fields",
+                            "extra_content",
+                        }
                         buffered_id_matches = [
                             buffered_call
                             for buffered_call in buffered_calls.values()
@@ -547,15 +551,14 @@ class ChatCmplStreamHandler:
                             and bool(tool_call_delta.id)
                             and tool_call_delta.id in passthrough_tool_call_indexes_by_id
                         )
-                        is_unindexed_passthrough_continuation = (
-                            is_unindexed_untyped_continuation
+                        is_idless_passthrough_continuation = (
+                            is_untyped_continuation
+                            and not tool_call_delta.id
+                            and unindexed_passthrough_tool_call_count == 1
+                            and None not in buffered_calls
                             and (
-                                is_passthrough_continuation_by_id
-                                or (
-                                    saw_unindexed_passthrough_tool_call
-                                    and not tool_call_delta.id
-                                    and None not in buffered_calls
-                                )
+                                not isinstance(tool_call_delta.index, int)
+                                or bool(passthrough_payload_keys)
                             )
                         )
                         if is_passthrough_continuation_by_id and buffered_id_matches:
@@ -573,6 +576,16 @@ class ChatCmplStreamHandler:
                             raise ModelBehaviorError(
                                 "Chat Completions tool call delta supplied an index already used "
                                 "by a passthrough call and an ID owned by a buffered function call."
+                            )
+
+                        if (
+                            is_idless_passthrough_continuation
+                            and isinstance(tool_call_delta.index, int)
+                            and tool_call_delta.index in buffered_calls
+                        ):
+                            raise ModelBehaviorError(
+                                "Chat Completions passthrough tool call delta supplied an index "
+                                "already used by a buffered function call."
                             )
 
                         unindexed_buffered_call = buffered_calls.get(None)
@@ -600,7 +613,7 @@ class ChatCmplStreamHandler:
                         if (
                             tool_call_delta.index in passthrough_tool_call_indexes
                             or is_passthrough_continuation_by_id
-                            or is_unindexed_passthrough_continuation
+                            or is_idless_passthrough_continuation
                         ):
                             if passthrough_id := tool_call_delta.id:
                                 owner_index = passthrough_tool_call_indexes_by_id.get(
@@ -628,6 +641,7 @@ class ChatCmplStreamHandler:
                                         tool_call_delta.index
                                     )
                                     if promotes_unindexed_passthrough_owner:
+                                        unindexed_passthrough_tool_call_count -= 1
                                         tool_call_delta = tool_call_delta.model_copy(
                                             update={"type": "custom"}
                                         )
@@ -641,6 +655,23 @@ class ChatCmplStreamHandler:
                                     if isinstance(tool_call_delta.index, int)
                                     else None,
                                 )
+                            elif (
+                                is_idless_passthrough_continuation
+                                and isinstance(tool_call_delta.index, int)
+                                and tool_call_delta.index not in passthrough_tool_call_indexes
+                            ):
+                                passthrough_tool_call_indexes.add(tool_call_delta.index)
+                                for passthrough_id, owner_index in list(
+                                    passthrough_tool_call_indexes_by_id.items()
+                                ):
+                                    if owner_index is None:
+                                        passthrough_tool_call_indexes_by_id[passthrough_id] = (
+                                            tool_call_delta.index
+                                        )
+                                unindexed_passthrough_tool_call_count = 0
+                                tool_call_delta = tool_call_delta.model_copy(
+                                    update={"type": "custom"}
+                                )
                             saw_passthrough_tool_call = True
                             remaining_tool_calls.append(tool_call_delta)
                         elif (
@@ -648,13 +679,7 @@ class ChatCmplStreamHandler:
                             and saw_passthrough_tool_call
                             and (
                                 not tool_call_delta.id
-                                or (
-                                    bool(
-                                        set(tool_call_delta.model_extra or {})
-                                        - {"provider_specific_fields", "extra_content"}
-                                    )
-                                    and not buffered_id_matches
-                                )
+                                or (bool(passthrough_payload_keys) and not buffered_id_matches)
                             )
                         ):
                             raise ModelBehaviorError(
@@ -668,7 +693,7 @@ class ChatCmplStreamHandler:
                             if isinstance(tool_call_delta.index, int):
                                 passthrough_tool_call_indexes.add(tool_call_delta.index)
                             else:
-                                saw_unindexed_passthrough_tool_call = True
+                                unindexed_passthrough_tool_call_count += 1
                             if tool_call_delta.id:
                                 passthrough_tool_call_indexes_by_id.setdefault(
                                     tool_call_delta.id,

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -149,7 +149,7 @@ class StreamingState:
 class _BufferedToolCall:
     """Accumulates a streamed Chat Completions function tool call."""
 
-    index: int
+    index: int | None
     call_id: str | None = None
     name: str | None = None
     arguments: str = ""
@@ -314,12 +314,24 @@ class ChatCmplStreamHandler:
 
     @staticmethod
     def _accumulate_tool_call_delta(
-        buffered_calls: dict[int, _BufferedToolCall],
+        buffered_calls: dict[int | None, _BufferedToolCall],
         tool_call_delta: ChoiceDeltaToolCall,
     ) -> None:
+        tool_call_index = tool_call_delta.index
+        if not isinstance(tool_call_index, int) and not tool_call_delta.id:
+            if None in buffered_calls:
+                tool_call_index = None
+            elif len(buffered_calls) == 1:
+                tool_call_index = next(iter(buffered_calls))
+            elif len(buffered_calls) > 1:
+                raise ModelBehaviorError(
+                    "Chat Completions tool call delta omitted an index while multiple "
+                    "function tool calls were being buffered."
+                )
+
         buffered_call = buffered_calls.setdefault(
-            tool_call_delta.index,
-            _BufferedToolCall(index=tool_call_delta.index),
+            tool_call_index,
+            _BufferedToolCall(index=tool_call_index),
         )
 
         if tool_call_delta.id:
@@ -361,8 +373,6 @@ class ChatCmplStreamHandler:
             )
 
         tool_call_delta = ChoiceDeltaToolCall(
-            # Lenient chunk parsing leaves the index as None when the provider omitted it,
-            # and the replayed delta needs a real index.
             index=buffered_call.index if isinstance(buffered_call.index, int) else fallback_index,
             id=buffered_call.call_id,
             function=ChoiceDeltaToolCallFunction(
@@ -384,17 +394,14 @@ class ChatCmplStreamHandler:
     def _buffered_tool_calls_chunk(
         cls,
         template_chunk: ChatCompletionChunk,
-        buffered_calls: dict[int, _BufferedToolCall],
+        buffered_calls: dict[int | None, _BufferedToolCall],
+        passthrough_tool_call_indexes: set[int],
     ) -> ChatCompletionChunk:
-        # OpenAI-compatible providers may omit the tool call index, which lenient chunk
-        # parsing leaves as None. Every index-less delta accumulates under that single key,
-        # so replay the indexed calls in index order and give the index-less call the next
-        # free index instead of failing on a None/int comparison.
         ordered_calls = sorted(buffered_calls.values(), key=_buffered_tool_call_order)
-        fallback_index = (
-            max((call.index for call in ordered_calls if isinstance(call.index, int)), default=-1)
-            + 1
-        )
+        occupied_indexes = passthrough_tool_call_indexes | {
+            call.index for call in ordered_calls if isinstance(call.index, int)
+        }
+        fallback_index = max(occupied_indexes, default=-1) + 1
         tool_call_deltas = [
             cls._buffered_tool_call_delta(buffered_call, fallback_index=fallback_index)
             for buffered_call in ordered_calls
@@ -412,7 +419,7 @@ class ChatCmplStreamHandler:
         stream: AsyncIterator[ChatCompletionChunk],
     ) -> AsyncIterator[ChatCompletionChunk]:
         """Buffer streamed function tool-call deltas until they are complete."""
-        buffered_calls: dict[int, _BufferedToolCall] = {}
+        buffered_calls: dict[int | None, _BufferedToolCall] = {}
         passthrough_tool_call_indexes: set[int] = set()
         saw_passthrough_tool_call = False
         last_chunk: ChatCompletionChunk | None = None
@@ -477,7 +484,11 @@ class ChatCmplStreamHandler:
         if buffered_calls:
             if last_chunk is None:
                 return
-            yield cls._buffered_tool_calls_chunk(last_chunk, buffered_calls)
+            yield cls._buffered_tool_calls_chunk(
+                last_chunk,
+                buffered_calls,
+                passthrough_tool_call_indexes,
+            )
 
     @staticmethod
     def _merged_provider_data(

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -332,6 +332,7 @@ class ChatCmplStreamHandler:
         tool_call_delta: ChoiceDeltaToolCall,
     ) -> None:
         tool_call_index = tool_call_delta.index
+        function_name = tool_call_delta.function.name if tool_call_delta.function else None
         matching_indexes = [
             index
             for index, buffered_call in buffered_calls.items()
@@ -353,6 +354,21 @@ class ChatCmplStreamHandler:
                 buffered_call = buffered_calls.pop(None)
                 buffered_call.index = tool_call_index
                 buffered_calls[tool_call_index] = buffered_call
+            elif (
+                not tool_call_delta.id
+                and None in buffered_calls
+                and tool_call_index not in buffered_calls
+            ):
+                buffered_name = buffered_calls[None].name
+                if not function_name or not buffered_name or function_name == buffered_name:
+                    if len(buffered_calls) > 1:
+                        raise ModelBehaviorError(
+                            "Chat Completions tool call delta supplied a new index without an ID "
+                            "while multiple function calls were being buffered."
+                        )
+                    buffered_call = buffered_calls.pop(None)
+                    buffered_call.index = tool_call_index
+                    buffered_calls[tool_call_index] = buffered_call
         else:
             if len(matching_indexes) == 1:
                 tool_call_index = matching_indexes[0]
@@ -367,7 +383,6 @@ class ChatCmplStreamHandler:
                     "another index-less call was being buffered."
                 )
             else:
-                function_name = tool_call_delta.function.name if tool_call_delta.function else None
                 if function_name and None in buffered_calls:
                     buffered_name = buffered_calls[None].name
                     if buffered_name and buffered_name != function_name:
@@ -515,36 +530,52 @@ class ChatCmplStreamHandler:
                 if tool_call_deltas := (delta.tool_calls if delta and delta.tool_calls else None):
                     remaining_tool_calls: list[ChoiceDeltaToolCall] = []
                     for tool_call_delta in tool_call_deltas:
-                        is_unindexed_untyped_continuation = (
-                            not isinstance(tool_call_delta.index, int)
-                            and getattr(tool_call_delta, "type", None) is None
+                        is_untyped_continuation = (
+                            getattr(tool_call_delta, "type", None) is None
                             and tool_call_delta.function is None
+                        )
+                        is_unindexed_untyped_continuation = (
+                            not isinstance(tool_call_delta.index, int) and is_untyped_continuation
                         )
                         buffered_id_matches = [
                             buffered_call
                             for buffered_call in buffered_calls.values()
                             if tool_call_delta.id and buffered_call.call_id == tool_call_delta.id
                         ]
+                        is_passthrough_continuation_by_id = (
+                            is_untyped_continuation
+                            and bool(tool_call_delta.id)
+                            and tool_call_delta.id in passthrough_tool_call_indexes_by_id
+                        )
                         is_unindexed_passthrough_continuation = (
                             is_unindexed_untyped_continuation
                             and (
-                                tool_call_delta.id in passthrough_tool_call_indexes_by_id
+                                is_passthrough_continuation_by_id
                                 or (saw_unindexed_passthrough_tool_call and not tool_call_delta.id)
                             )
                         )
-                        if is_unindexed_passthrough_continuation and buffered_id_matches:
+                        if is_passthrough_continuation_by_id and buffered_id_matches:
                             raise ModelBehaviorError(
-                                "Chat Completions tool call delta omitted an index and its ID "
-                                "matched both a buffered function call and a passthrough call."
+                                "Chat Completions tool call delta ID matched both a buffered "
+                                "function call and a passthrough call."
                             )
 
                         unindexed_buffered_call = buffered_calls.get(None)
                         if (
                             isinstance(tool_call_delta.index, int)
                             and tool_call_delta.index in passthrough_tool_call_indexes
-                            and tool_call_delta.id
                             and unindexed_buffered_call is not None
-                            and unindexed_buffered_call.call_id == tool_call_delta.id
+                            and (
+                                (
+                                    tool_call_delta.id
+                                    and unindexed_buffered_call.call_id == tool_call_delta.id
+                                )
+                                or (
+                                    not tool_call_delta.id
+                                    and len(buffered_calls) == 1
+                                    and tool_call_delta.function is not None
+                                )
+                            )
                         ):
                             raise ModelBehaviorError(
                                 "Chat Completions tool call delta supplied an index already used "
@@ -553,15 +584,39 @@ class ChatCmplStreamHandler:
 
                         if (
                             tool_call_delta.index in passthrough_tool_call_indexes
+                            or is_passthrough_continuation_by_id
                             or is_unindexed_passthrough_continuation
                         ):
                             if passthrough_id := tool_call_delta.id:
                                 owner_index = passthrough_tool_call_indexes_by_id.get(
                                     passthrough_id
                                 )
-                                if isinstance(owner_index, int) and not isinstance(
-                                    tool_call_delta.index, int
-                                ):
+                                if isinstance(tool_call_delta.index, int):
+                                    promotes_unindexed_passthrough_owner = (
+                                        is_passthrough_continuation_by_id
+                                        and not isinstance(owner_index, int)
+                                    )
+                                    if isinstance(owner_index, int) and (
+                                        owner_index != tool_call_delta.index
+                                    ):
+                                        raise ModelBehaviorError(
+                                            "Chat Completions passthrough tool call delta supplied "
+                                            "a different index from its buffered ID owner."
+                                        )
+                                    if tool_call_delta.index in buffered_calls:
+                                        raise ModelBehaviorError(
+                                            "Chat Completions passthrough tool call delta supplied "
+                                            "an index already used by a buffered function call."
+                                        )
+                                    passthrough_tool_call_indexes.add(tool_call_delta.index)
+                                    passthrough_tool_call_indexes_by_id[passthrough_id] = (
+                                        tool_call_delta.index
+                                    )
+                                    if promotes_unindexed_passthrough_owner:
+                                        tool_call_delta = tool_call_delta.model_copy(
+                                            update={"type": "custom"}
+                                        )
+                                elif isinstance(owner_index, int):
                                     tool_call_delta = tool_call_delta.model_copy(
                                         update={"index": owner_index}
                                     )

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -450,7 +450,8 @@ class ChatCmplStreamHandler:
                         elif cls._should_buffer_tool_call_delta(tool_call_delta):
                             cls._accumulate_tool_call_delta(buffered_calls, tool_call_delta)
                         else:
-                            passthrough_tool_call_indexes.add(tool_call_delta.index)
+                            if isinstance(tool_call_delta.index, int):
+                                passthrough_tool_call_indexes.add(tool_call_delta.index)
                             saw_passthrough_tool_call = True
                             remaining_tool_calls.append(tool_call_delta)
 

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -332,12 +332,28 @@ class ChatCmplStreamHandler:
         tool_call_delta: ChoiceDeltaToolCall,
     ) -> None:
         tool_call_index = tool_call_delta.index
-        if not isinstance(tool_call_index, int):
-            matching_indexes = [
-                index
-                for index, buffered_call in buffered_calls.items()
-                if tool_call_delta.id and buffered_call.call_id == tool_call_delta.id
-            ]
+        matching_indexes = [
+            index
+            for index, buffered_call in buffered_calls.items()
+            if tool_call_delta.id and buffered_call.call_id == tool_call_delta.id
+        ]
+        if isinstance(tool_call_index, int):
+            if None in matching_indexes:
+                if len(matching_indexes) > 1:
+                    raise ModelBehaviorError(
+                        "Chat Completions tool call delta supplied an index and the same ID "
+                        "matched multiple buffered calls."
+                    )
+                if tool_call_index in buffered_calls:
+                    raise ModelBehaviorError(
+                        "Chat Completions tool call delta supplied an index already used by "
+                        "another buffered call."
+                    )
+
+                buffered_call = buffered_calls.pop(None)
+                buffered_call.index = tool_call_index
+                buffered_calls[tool_call_index] = buffered_call
+        else:
             if len(matching_indexes) == 1:
                 tool_call_index = matching_indexes[0]
             elif len(matching_indexes) > 1:
@@ -520,6 +536,19 @@ class ChatCmplStreamHandler:
                             raise ModelBehaviorError(
                                 "Chat Completions tool call delta omitted an index and its ID "
                                 "matched both a buffered function call and a passthrough call."
+                            )
+
+                        unindexed_buffered_call = buffered_calls.get(None)
+                        if (
+                            isinstance(tool_call_delta.index, int)
+                            and tool_call_delta.index in passthrough_tool_call_indexes
+                            and tool_call_delta.id
+                            and unindexed_buffered_call is not None
+                            and unindexed_buffered_call.call_id == tool_call_delta.id
+                        ):
+                            raise ModelBehaviorError(
+                                "Chat Completions tool call delta supplied an index already used "
+                                "by a passthrough call."
                             )
 
                         if (

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -964,6 +964,95 @@ async def test_buffer_tool_call_stream_orders_missing_index_after_indexed_calls(
     assert _completed_function_calls(buffered_events) == expected_calls
 
 
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_avoids_passthrough_index_for_missing_index() -> None:
+    custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
+        index=0,
+        id="custom-id",
+        type="custom",
+    )
+    custom_chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[custom_tool_call_delta]))],
+    )
+    chunks = (
+        custom_chunk,
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_merges_missing_index_continuation() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": '{"a":'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [{"function": {"arguments": "1}"}}]}),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_ambiguous_missing_index_continuation() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "first_func", "arguments": '{"a":'},
+                    },
+                    {
+                        "index": 1,
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "second_func", "arguments": '{"b":'},
+                    },
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [{"function": {"arguments": "1}"}}]}),
+    )
+
+    with pytest.raises(
+        ModelBehaviorError, match="omitted an index while multiple function tool calls"
+    ):
+        await _collect_buffered_handler_events(*chunks)
+
+
 @pytest.mark.parametrize(
     ("delta", "expected"),
     [

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1206,7 +1206,60 @@ async def test_buffer_tool_call_stream_promotes_indexed_passthrough_continuation
 
 
 @pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_indexed_passthrough_continuation_collision() -> None:
+async def test_buffer_tool_call_stream_promotes_indexed_passthrough_continuation_without_id() -> (
+    None
+):
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "pri"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [{"index": 2, "custom": {"input": "nt("}}]}),
+        _lenient_chunk({"tool_calls": [{"id": "custom-id", "custom": {"input": "1)"}}]}),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    indexed_continuation = buffered_chunks[1].choices[0].delta.tool_calls
+    unindexed_continuation = buffered_chunks[2].choices[0].delta.tool_calls
+    assert indexed_continuation and indexed_continuation[0].index == 2
+    assert unindexed_continuation and unindexed_continuation[0].index == 2
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
+
+
+@pytest.mark.parametrize("continuation_id", [None, "custom-id"])
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_indexed_passthrough_continuation_collision(
+    continuation_id: str | None,
+) -> None:
+    continuation: dict[str, Any] = {
+        "index": 2,
+        "custom": {"input": "nt(1)"},
+    }
+    if continuation_id is not None:
+        continuation["id"] = continuation_id
+
     chunks = (
         _lenient_chunk(
             {
@@ -1231,17 +1284,7 @@ async def test_buffer_tool_call_stream_rejects_indexed_passthrough_continuation_
                 ]
             }
         ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "id": "custom-id",
-                        "custom": {"input": "nt(1)"},
-                    }
-                ]
-            }
-        ),
+        _lenient_chunk({"tool_calls": [continuation]}),
     )
 
     with pytest.raises(ModelBehaviorError, match="index already used by a buffered function"):

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1154,6 +1154,132 @@ async def test_buffer_tool_call_stream_forwards_missing_index_passthrough_contin
     assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
 
 
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_promotes_indexed_passthrough_continuation_by_id() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "pri"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "id": "custom-id",
+                        "custom": {"input": "nt("},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [{"id": "custom-id", "custom": {"input": "1)"}}]}),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    indexed_continuation = buffered_chunks[1].choices[0].delta.tool_calls
+    unindexed_continuation = buffered_chunks[2].choices[0].delta.tool_calls
+    assert indexed_continuation and indexed_continuation[0].index == 2
+    assert unindexed_continuation and unindexed_continuation[0].index == 2
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_indexed_passthrough_continuation_collision() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "pri"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "id": "custom-id",
+                        "custom": {"input": "nt(1)"},
+                    }
+                ]
+            }
+        ),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="index already used by a buffered function"):
+        await _collect_buffered_tool_call_chunks(*chunks)
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_passthrough_continuation_index_change() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "pri"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "id": "custom-id",
+                        "custom": {"input": "nt(1)"},
+                    }
+                ]
+            }
+        ),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="different index from its buffered ID owner"):
+        await _collect_buffered_tool_call_chunks(*chunks)
+
+
 @pytest.mark.parametrize("function_tool_call_index", [1, None], ids=["indexed", "unindexed"])
 @pytest.mark.asyncio
 async def test_buffer_tool_call_stream_forwards_indexed_passthrough_continuation_by_id(
@@ -1531,6 +1657,91 @@ async def test_buffer_tool_call_stream_reconciles_late_index_by_id(
     assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
 
 
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_reconciles_late_index_without_id_for_sole_call() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": '{"a":'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "type": "function",
+                        "function": {"arguments": "1}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    replayed_tool_calls = buffered_chunks[-1].choices[0].delta.tool_calls
+    assert replayed_tool_calls
+    assert [tool_call.index for tool_call in replayed_tool_calls] == [2]
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_keeps_different_named_idless_late_index_distinct() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "first_func", "arguments": '{"a":1}'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "type": "function",
+                        "function": {"name": "second_func", "arguments": '{"b":'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"arguments": "1}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    assert _completed_function_calls(buffered_events) == [
+        ("call_1", "first_func", '{"a":1}'),
+        ("call_2", "second_func", '{"b":1}'),
+    ]
+
+
 @pytest.mark.parametrize(
     "opening_name",
     ["my_func", None],
@@ -1763,6 +1974,24 @@ def test_accumulate_tool_call_delta_rejects_ambiguous_late_index() -> None:
     )
 
     with pytest.raises(ModelBehaviorError, match="same ID matched multiple buffered calls"):
+        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
+
+    assert buffered_calls == expected_calls
+
+
+def test_accumulate_tool_call_delta_rejects_ambiguous_idless_late_index() -> None:
+    unindexed_call = _BufferedToolCall(index=None, call_id="call_1", name="first_func")
+    indexed_call = _BufferedToolCall(index=0, call_id="call_2", name="second_func")
+    buffered_calls = {None: unindexed_call, 0: indexed_call}
+    expected_calls = {None: replace(unindexed_call), 0: replace(indexed_call)}
+    continuation = ChoiceDeltaToolCall.model_construct(
+        index=2,
+        id=None,
+        type="function",
+        function=ChoiceDeltaToolCallFunction(arguments="{}"),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="new index without an ID"):
         ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
 
     assert buffered_calls == expected_calls

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from collections.abc import AsyncIterator
-from dataclasses import replace
 from typing import Any, cast
 
 import httpx2
@@ -120,9 +119,7 @@ async def _collect_buffered_handler_events(*chunks: ChatCompletionChunk) -> list
 
 
 def _lenient_chunk(delta: dict[str, Any], finish_reason: str | None = None) -> ChatCompletionChunk:
-    # Build the chunk the way ``AsyncStream`` does: ``construct_type`` does not validate the
-    # provider payload, so a tool call delta that omits ``index`` keeps ``index=None`` instead
-    # of failing validation. That is the shape OpenAI-compatible providers can produce.
+    """Construct a chunk as AsyncStream does, without validating a missing tool-call index."""
     return cast(
         ChatCompletionChunk,
         construct_type(
@@ -932,7 +929,6 @@ async def test_buffer_tool_call_stream_orders_missing_index_after_indexed_calls(
     chunks = (
         _lenient_chunk(
             {
-                "role": "assistant",
                 "tool_calls": [
                     {
                         "index": 0,
@@ -940,7 +936,7 @@ async def test_buffer_tool_call_stream_orders_missing_index_after_indexed_calls(
                         "type": "function",
                         "function": {"name": "first_func", "arguments": "{}"},
                     }
-                ],
+                ]
             }
         ),
         _lenient_chunk(
@@ -950,82 +946,6 @@ async def test_buffer_tool_call_stream_orders_missing_index_after_indexed_calls(
                         "id": "call_2",
                         "type": "function",
                         "function": {"name": "second_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    unbuffered_events = await _collect_handler_events(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    expected_calls = [("call_1", "first_func", "{}"), ("call_2", "second_func", "{}")]
-    assert _completed_function_calls(unbuffered_events) == expected_calls
-    assert _completed_function_calls(buffered_events) == expected_calls
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_preserves_missing_index_call_arrival_order() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "role": "assistant",
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "first_func", "arguments": "{}"},
-                    }
-                ],
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_2",
-                        "type": "function",
-                        "function": {"name": "second_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    unbuffered_events = await _collect_handler_events(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    expected_calls = [("call_1", "first_func", "{}"), ("call_2", "second_func", "{}")]
-    assert _completed_function_calls(unbuffered_events) == expected_calls
-    assert _completed_function_calls(buffered_events) == expected_calls
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_sorts_indexed_calls_by_index() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 1,
-                        "id": "call_2",
-                        "type": "function",
-                        "function": {"name": "second_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "first_func", "arguments": "{}"},
                     }
                 ]
             }
@@ -1042,21 +962,9 @@ async def test_buffer_tool_call_stream_sorts_indexed_calls_by_index() -> None:
 
 
 @pytest.mark.asyncio
-async def test_buffer_tool_call_stream_avoids_passthrough_index_for_missing_index() -> None:
-    custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
-        index=0,
-        id="custom-id",
-        type="custom",
-    )
-    custom_chunk = ChatCompletionChunk(
-        id="chunk-id",
-        created=1,
-        model="fake",
-        object="chat.completion.chunk",
-        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[custom_tool_call_delta]))],
-    )
+async def test_missing_index_replay_avoids_passthrough_index_collision() -> None:
     chunks = (
-        custom_chunk,
+        _lenient_chunk({"tool_calls": [{"index": 0, "id": "custom-id", "type": "custom"}]}),
         _lenient_chunk(
             {
                 "tool_calls": [
@@ -1068,1115 +976,170 @@ async def test_buffer_tool_call_stream_avoids_passthrough_index_for_missing_inde
                 ]
             }
         ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
-
-
-@pytest.mark.parametrize("function_tool_call_index", [0, None])
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_ignores_missing_passthrough_index(
-    function_tool_call_index: int | None,
-) -> None:
-    custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
-        index=None,
-        id="custom-id",
-        type="custom",
-    )
-    custom_chunk = ChatCompletionChunk(
-        id="chunk-id",
-        created=1,
-        model="fake",
-        object="chat.completion.chunk",
-        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[custom_tool_call_delta]))],
-    )
-    function_tool_call: dict[str, Any] = {
-        "id": "call_1",
-        "type": "function",
-        "function": {"name": "my_func", "arguments": "{}"},
-    }
-    if function_tool_call_index is not None:
-        function_tool_call["index"] = function_tool_call_index
-    chunks = (
-        custom_chunk,
-        _lenient_chunk({"tool_calls": [function_tool_call]}),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
-
-
-@pytest.mark.parametrize("continuation_id", [None, "custom-id"])
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_forwards_missing_index_passthrough_continuation(
-    continuation_id: str | None,
-) -> None:
-    continuation: dict[str, Any] = {"custom": {"input": "nt(1)"}}
-    if continuation_id is not None:
-        continuation["id"] = continuation_id
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "pri"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [continuation]}),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
     )
 
     buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
 
     assert buffered_chunks[0].choices[0].delta.tool_calls == chunks[0].choices[0].delta.tool_calls
-    assert buffered_chunks[1].choices[0].delta.tool_calls == chunks[1].choices[0].delta.tool_calls
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
+    replayed_calls = buffered_chunks[-1].choices[0].delta.tool_calls
+    assert replayed_calls and replayed_calls[0].index == 1
+    assert replayed_calls[0].id == "call_1"
 
 
 @pytest.mark.asyncio
-async def test_buffer_tool_call_stream_promotes_indexed_passthrough_continuation_by_id() -> None:
+async def test_missing_index_continuation_merges_into_sole_buffered_function() -> None:
     chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "pri"},
-                    }
-                ]
-            }
-        ),
         _lenient_chunk(
             {
                 "tool_calls": [
                     {
                         "index": 2,
-                        "id": "custom-id",
-                        "custom": {"input": "nt("},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [{"id": "custom-id", "custom": {"input": "1)"}}]}),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    indexed_continuation = buffered_chunks[1].choices[0].delta.tool_calls
-    unindexed_continuation = buffered_chunks[2].choices[0].delta.tool_calls
-    assert indexed_continuation and indexed_continuation[0].index == 2
-    assert unindexed_continuation and unindexed_continuation[0].index == 2
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_promotes_indexed_passthrough_continuation_without_id() -> (
-    None
-):
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "pri"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [{"index": 2, "custom": {"input": "nt("}}]}),
-        _lenient_chunk({"tool_calls": [{"id": "custom-id", "custom": {"input": "1)"}}]}),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    indexed_continuation = buffered_chunks[1].choices[0].delta.tool_calls
-    unindexed_continuation = buffered_chunks[2].choices[0].delta.tool_calls
-    assert indexed_continuation and indexed_continuation[0].index == 2
-    assert unindexed_continuation and unindexed_continuation[0].index == 2
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
-
-
-@pytest.mark.parametrize("continuation_id", [None, "custom-id"])
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_indexed_passthrough_continuation_collision(
-    continuation_id: str | None,
-) -> None:
-    continuation: dict[str, Any] = {
-        "index": 2,
-        "custom": {"input": "nt(1)"},
-    }
-    if continuation_id is not None:
-        continuation["id"] = continuation_id
-
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "pri"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [continuation]}),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="index already used by a buffered function"):
-        await _collect_buffered_tool_call_chunks(*chunks)
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_passthrough_continuation_index_change() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 1,
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "pri"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "id": "custom-id",
-                        "custom": {"input": "nt(1)"},
-                    }
-                ]
-            }
-        ),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="different index from its buffered ID owner"):
-        await _collect_buffered_tool_call_chunks(*chunks)
-
-
-@pytest.mark.parametrize("function_tool_call_index", [1, None], ids=["indexed", "unindexed"])
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_forwards_indexed_passthrough_continuation_by_id(
-    function_tool_call_index: int | None,
-) -> None:
-    function_tool_call: dict[str, Any] = {
-        "type": "function",
-        "function": {"name": "my_func", "arguments": "{}"},
-    }
-    if function_tool_call_index is not None:
-        function_tool_call["index"] = function_tool_call_index
-        function_tool_call["id"] = "call_1"
-
-    chunks = [
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "pri"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [function_tool_call]}),
-        _lenient_chunk({"tool_calls": [{"id": "custom-id", "custom": {"input": "nt(1)"}}]}),
-    ]
-    if function_tool_call_index is None:
-        chunks.append(_lenient_chunk({"tool_calls": [{"id": "call_1"}]}))
-    chunks.append(_lenient_chunk({}, finish_reason="tool_calls"))
-
-    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    continuation_tool_calls = buffered_chunks[1].choices[0].delta.tool_calls
-    assert continuation_tool_calls
-    assert continuation_tool_calls[0].index == 0
-    assert continuation_tool_calls[0].id == "custom-id"
-    assert continuation_tool_calls[0].model_extra == {"custom": {"input": "nt(1)"}}
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_records_passthrough_id_from_indexed_continuation() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "pri"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {"tool_calls": [{"index": 0, "id": "custom-id", "custom": {"input": "nt("}}]}
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [{"id": "custom-id", "custom": {"input": "1)"}}]}),
-        _lenient_chunk({"tool_calls": [{"id": "call_1"}]}),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    continuation_tool_calls = buffered_chunks[2].choices[0].delta.tool_calls
-    assert continuation_tool_calls
-    assert continuation_tool_calls[0].index == 0
-    assert continuation_tool_calls[0].id == "custom-id"
-    assert continuation_tool_calls[0].model_extra == {"custom": {"input": "1)"}}
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_cross_domain_passthrough_id() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "shared-id",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 1,
-                        "id": "shared-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "print(1)"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "shared-id",
-                        "extra_content": {"google": {"thought_signature": "sig"}},
-                    }
-                ]
-            }
-        ),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="matched both"):
-        await _collect_buffered_tool_call_chunks(*chunks)
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_allows_function_metadata_on_late_id() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "print(1)"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "extra_content": {"google": {"thought_signature": "sig"}},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
-    unbuffered_events = await _collect_handler_events(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    replayed_tool_calls = buffered_chunks[-1].choices[0].delta.tool_calls
-    assert replayed_tool_calls
-    assert cast(Any, replayed_tool_calls[0]).extra_content == {
-        "google": {"thought_signature": "sig"}
-    }
-    expected_calls = [("call_1", "my_func", "{}")]
-    assert _completed_function_calls(unbuffered_events) == expected_calls
-    assert _completed_function_calls(buffered_events) == expected_calls
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_ambiguous_mixed_unindexed_delta() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "print(1)"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {"tool_calls": [{"extra_content": {"google": {"thought_signature": "sig"}}}]}
-        ),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="could not be attributed"):
-        await _collect_buffered_tool_call_chunks(*chunks)
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_conflicting_index_and_id_owners() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "print(1)"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 1,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "extra_content": {"google": {"thought_signature": "sig"}},
-                    }
-                ]
-            }
-        ),
-    )
-
-    buffered = ChatCmplStreamHandler.buffer_tool_call_stream(_completion_stream(*chunks))
-    first_chunk = await anext(buffered)
-    first_tool_calls = first_chunk.choices[0].delta.tool_calls
-    assert first_tool_calls and first_tool_calls[0].id == "custom-id"
-
-    with pytest.raises(ModelBehaviorError, match="index already used by a passthrough call"):
-        await anext(buffered)
-
-
-@pytest.mark.parametrize("continuation_id", [None, "unknown-id"], ids=["without-id", "unknown-id"])
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_ambiguous_unindexed_passthrough_continuation(
-    continuation_id: str | None,
-) -> None:
-    continuation: dict[str, Any] = {"custom": {"input": "nt(1)"}}
-    if continuation_id is not None:
-        continuation["id"] = continuation_id
-
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "pri"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 1,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [continuation]}),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="could not be attributed"):
-        await _collect_buffered_tool_call_chunks(*chunks)
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_merges_arguments_only_missing_index_continuation() -> None:
-    continuation_function = {"arguments": "1}"}
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
                         "id": "call_1",
                         "type": "function",
                         "function": {"name": "my_func", "arguments": '{"a":'},
                     }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [{"function": continuation_function}]}),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_ambiguous_same_named_unindexed_opening() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": '{"b":'},
-                    }
-                ]
-            }
-        ),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="same function name"):
-        await _collect_buffered_tool_call_chunks(*chunks)
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_late_index_used_by_passthrough() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "id": "custom-id",
-                        "type": "custom",
-                        "custom": {"name": "code_exec", "input": "print(1)"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": '{"a":'},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"arguments": "1}"},
-                    }
-                ]
-            }
-        ),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="index already used by a passthrough call"):
-        await _collect_buffered_tool_call_chunks(*chunks)
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_merges_late_id_into_missing_index_call() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": '{"a":'},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"arguments": "1}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    unbuffered_events = await _collect_handler_events(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    expected_calls = [("call_1", "my_func", '{"a":1}')]
-    assert _completed_function_calls(unbuffered_events) == expected_calls
-    assert _completed_function_calls(buffered_events) == expected_calls
-
-
-@pytest.mark.parametrize("continuation_name", [None, "my_func"])
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_reconciles_late_index_by_id(
-    continuation_name: str | None,
-) -> None:
-    continuation_function = {"arguments": "1}"}
-    if continuation_name is not None:
-        continuation_function["name"] = continuation_name
-
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": '{"a":'},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": continuation_function,
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    replayed_tool_calls = buffered_chunks[-1].choices[0].delta.tool_calls
-    assert replayed_tool_calls
-    assert [tool_call.index for tool_call in replayed_tool_calls] == [2]
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_reconciles_late_index_without_id_for_sole_call() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": '{"a":'},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "type": "function",
-                        "function": {"arguments": "1}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    replayed_tool_calls = buffered_chunks[-1].choices[0].delta.tool_calls
-    assert replayed_tool_calls
-    assert [tool_call.index for tool_call in replayed_tool_calls] == [2]
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_keeps_different_named_idless_late_index_distinct() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "first_func", "arguments": '{"a":1}'},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "type": "function",
-                        "function": {"name": "second_func", "arguments": '{"b":'},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 2,
-                        "id": "call_2",
-                        "type": "function",
-                        "function": {"arguments": "1}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    assert _completed_function_calls(buffered_events) == [
-        ("call_1", "first_func", '{"a":1}'),
-        ("call_2", "second_func", '{"b":1}'),
-    ]
-
-
-@pytest.mark.parametrize(
-    "opening_name",
-    ["my_func", None],
-    ids=["same-name", "fills-missing-name"],
-)
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_merges_named_continuation_into_missing_index_slot(
-    opening_name: str | None,
-) -> None:
-    opening_function = {"arguments": '{"a":'}
-    if opening_name is not None:
-        opening_function["name"] = opening_name
-
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "function": opening_function,
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": "1}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [{"id": "call_1"}]}),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    unbuffered_events = await _collect_handler_events(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    expected_calls = [("call_1", "my_func", '{"a":1}')]
-    assert _completed_function_calls(unbuffered_events) == expected_calls
-    assert _completed_function_calls(buffered_events) == expected_calls
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_opens_named_missing_index_call_beside_indexed_call() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "first_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "function": {"name": "second_func", "arguments": '{"b":'},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_2",
-                        "type": "function",
-                        "function": {"arguments": "1}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    unbuffered_events = await _collect_handler_events(*chunks)
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    expected_calls = [
-        ("call_1", "first_func", "{}"),
-        ("call_2", "second_func", '{"b":1}'),
-    ]
-    assert _completed_function_calls(unbuffered_events) == expected_calls
-    assert _completed_function_calls(buffered_events) == expected_calls
-
-
-@pytest.mark.parametrize("continuation_id", [None, "call_2"], ids=["without-id", "with-new-id"])
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_different_name_for_missing_index_slot(
-    continuation_id: str | None,
-) -> None:
-    continuation: dict[str, Any] = {
-        "type": "function",
-        "function": {"name": "second_func", "arguments": "{}"},
-    }
-    if continuation_id is not None:
-        continuation["id"] = continuation_id
-
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "function": {"name": "first_func", "arguments": "{}"},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({"tool_calls": [continuation]}),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="different function name"):
-        await _collect_buffered_handler_events(*chunks)
-
-
-@pytest.mark.parametrize(
-    "continuation_function",
-    [
-        {"arguments": "1}"},
-        {"name": "my_func", "arguments": "1}"},
-    ],
-    ids=["arguments-only", "repeated-name"],
-)
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_merges_missing_index_continuation_by_id(
-    continuation_function: dict[str, str],
-) -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "my_func", "arguments": '{"a":'},
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "type": "function",
-                        "function": continuation_function,
-                    }
-                ]
-            }
-        ),
-        _lenient_chunk({}, finish_reason="tool_calls"),
-    )
-
-    buffered_events = await _collect_buffered_handler_events(*chunks)
-
-    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
-
-
-def test_accumulate_tool_call_delta_rejects_ambiguous_repeated_id() -> None:
-    buffered_calls = {
-        0: _BufferedToolCall(index=0, call_id="call_1", name="first_func"),
-        1: _BufferedToolCall(index=1, call_id="call_1", name="second_func"),
-    }
-    continuation = ChoiceDeltaToolCall.model_construct(
-        index=None,
-        id="call_1",
-        type="function",
-        function=ChoiceDeltaToolCallFunction(arguments="{}"),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="same ID matched multiple buffered calls"):
-        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
-
-
-def test_accumulate_tool_call_delta_rejects_new_id_for_occupied_missing_index() -> None:
-    buffered_calls = {
-        None: _BufferedToolCall(index=None, call_id="call_1", name="first_func"),
-    }
-    new_call = ChoiceDeltaToolCall.model_construct(
-        index=None,
-        id="call_2",
-        type="function",
-        function=ChoiceDeltaToolCallFunction(name="second_func", arguments="{}"),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="new ID while another index-less call"):
-        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, new_call)
-
-
-def test_accumulate_tool_call_delta_rejects_late_index_collision() -> None:
-    unindexed_call = _BufferedToolCall(index=None, call_id="call_1", name="first_func")
-    indexed_call = _BufferedToolCall(index=2, call_id="call_2", name="second_func")
-    buffered_calls = {None: unindexed_call, 2: indexed_call}
-    expected_calls = {None: replace(unindexed_call), 2: replace(indexed_call)}
-    continuation = ChoiceDeltaToolCall.model_construct(
-        index=2,
-        id="call_1",
-        type="function",
-        function=ChoiceDeltaToolCallFunction(arguments="{}"),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="index already used"):
-        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
-
-    assert buffered_calls == expected_calls
-
-
-def test_accumulate_tool_call_delta_rejects_ambiguous_late_index() -> None:
-    unindexed_call = _BufferedToolCall(index=None, call_id="call_1", name="first_func")
-    indexed_call = _BufferedToolCall(index=1, call_id="call_1", name="second_func")
-    buffered_calls = {None: unindexed_call, 1: indexed_call}
-    expected_calls = {None: replace(unindexed_call), 1: replace(indexed_call)}
-    continuation = ChoiceDeltaToolCall.model_construct(
-        index=2,
-        id="call_1",
-        type="function",
-        function=ChoiceDeltaToolCallFunction(arguments="{}"),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="same ID matched multiple buffered calls"):
-        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
-
-    assert buffered_calls == expected_calls
-
-
-def test_accumulate_tool_call_delta_rejects_ambiguous_idless_late_index() -> None:
-    unindexed_call = _BufferedToolCall(index=None, call_id="call_1", name="first_func")
-    indexed_call = _BufferedToolCall(index=0, call_id="call_2", name="second_func")
-    buffered_calls = {None: unindexed_call, 0: indexed_call}
-    expected_calls = {None: replace(unindexed_call), 0: replace(indexed_call)}
-    continuation = ChoiceDeltaToolCall.model_construct(
-        index=2,
-        id=None,
-        type="function",
-        function=ChoiceDeltaToolCallFunction(arguments="{}"),
-    )
-
-    with pytest.raises(ModelBehaviorError, match="new index without an ID"):
-        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
-
-    assert buffered_calls == expected_calls
-
-
-@pytest.mark.asyncio
-async def test_buffer_tool_call_stream_rejects_ambiguous_missing_index_continuation() -> None:
-    chunks = (
-        _lenient_chunk(
-            {
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "first_func", "arguments": '{"a":'},
-                    },
-                    {
-                        "index": 1,
-                        "id": "call_2",
-                        "type": "function",
-                        "function": {"name": "second_func", "arguments": '{"b":'},
-                    },
                 ]
             }
         ),
         _lenient_chunk({"tool_calls": [{"function": {"arguments": "1}"}}]}),
     )
 
-    with pytest.raises(
-        ModelBehaviorError, match="omitted an index while multiple function tool calls"
-    ):
-        await _collect_buffered_handler_events(*chunks)
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    replayed_calls = buffered_chunks[-1].choices[0].delta.tool_calls
+
+    assert replayed_calls and replayed_calls[0].index == 2
+    assert replayed_calls[0].function
+    assert replayed_calls[0].function.arguments == '{"a":1}'
+
+
+@pytest.mark.asyncio
+async def test_missing_index_continuation_uses_a_unique_function_call_id() -> None:
+    opening = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "index": index,
+                    "id": f"call_{index}",
+                    "type": "function",
+                    "function": {"name": f"func_{index}", "arguments": "start"},
+                }
+                for index in range(2)
+            ]
+        }
+    )
+    continuation = _lenient_chunk(
+        {"tool_calls": [{"id": "call_1", "function": {"arguments": "-end"}}]}
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(opening, continuation)
+    replayed_calls = buffered_chunks[-1].choices[0].delta.tool_calls
+
+    assert replayed_calls and [
+        call.function.arguments for call in replayed_calls if call.function
+    ] == [
+        "start",
+        "start-end",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_missing_index_continuation_rejects_multiple_buffered_functions() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": index,
+                        "id": f"call_{index}",
+                        "type": "function",
+                        "function": {"name": f"func_{index}", "arguments": "{}"},
+                    }
+                ]
+            }
+        )
+        for index in range(2)
+    )
+    continuation = _lenient_chunk({"tool_calls": [{"function": {"arguments": "tail"}}]})
+
+    with pytest.raises(ModelBehaviorError, match="multiple function calls"):
+        await _collect_buffered_tool_call_chunks(*chunks, continuation)
+
+
+@pytest.mark.asyncio
+async def test_anonymous_delta_rejects_mixed_unindexed_call_owners() -> None:
+    custom = _lenient_chunk(
+        {"tool_calls": [{"id": "custom-id", "type": "custom", "custom": {"input": "x"}}]}
+    )
+    function = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "my_func", "arguments": "{}"},
+                }
+            ]
+        }
+    )
+    anonymous = _lenient_chunk(
+        {"tool_calls": [{"extra_content": {"google": {"thought_signature": "sig"}}}]}
+    )
+
+    with pytest.raises(ModelBehaviorError, match="could not be attributed safely"):
+        await _collect_buffered_tool_call_chunks(custom, function, anonymous)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_index_and_id_owner_conflict_fails_closed() -> None:
+    custom = _lenient_chunk({"tool_calls": [{"index": 0, "id": "custom-id", "type": "custom"}]})
+    function = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "index": 1,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "my_func", "arguments": "{}"},
+                }
+            ]
+        }
+    )
+    conflicting = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "id": "call_1",
+                    "extra_content": {"google": {"thought_signature": "sig"}},
+                }
+            ]
+        }
+    )
+
+    with pytest.raises(ModelBehaviorError, match="different tool call owners"):
+        await _collect_buffered_tool_call_chunks(custom, function, conflicting)
+
+
+@pytest.mark.asyncio
+async def test_same_name_is_not_used_to_infer_a_missing_index_owner() -> None:
+    indexed = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "same_func", "arguments": "{}"},
+                }
+            ]
+        }
+    )
+    unindexed = _lenient_chunk(
+        {"tool_calls": [{"type": "function", "function": {"name": "same_func"}}]}
+    )
+
+    with pytest.raises(ModelBehaviorError, match="could not be attributed safely"):
+        await _collect_buffered_tool_call_chunks(indexed, unindexed)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import httpx2
 import pytest
+from openai._models import construct_type
 from openai.types.chat.chat_completion import ChatCompletion, Choice as ChatCompletionChoice
 from openai.types.chat.chat_completion_chunk import (
     ChatCompletionChunk,
@@ -104,6 +105,44 @@ async def _collect_buffered_tool_call_chunks(
         async for chunk in ChatCmplStreamHandler.buffer_tool_call_stream(
             _completion_stream(*chunks)
         )
+    ]
+
+
+async def _collect_buffered_handler_events(*chunks: ChatCompletionChunk) -> list[Any]:
+    return [
+        event
+        async for event in ChatCmplStreamHandler.handle_stream(
+            _empty_response(),
+            cast(Any, ChatCmplStreamHandler.buffer_tool_call_stream(_completion_stream(*chunks))),
+        )
+    ]
+
+
+def _lenient_chunk(delta: dict[str, Any], finish_reason: str | None = None) -> ChatCompletionChunk:
+    # Build the chunk the way ``AsyncStream`` does: ``construct_type`` does not validate the
+    # provider payload, so a tool call delta that omits ``index`` keeps ``index=None`` instead
+    # of failing validation. That is the shape OpenAI-compatible providers can produce.
+    return cast(
+        ChatCompletionChunk,
+        construct_type(
+            type_=ChatCompletionChunk,
+            value={
+                "id": "chunk-id",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": "fake",
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+            },
+        ),
+    )
+
+
+def _completed_function_calls(events: list[Any]) -> list[tuple[str, str, str]]:
+    completed = cast(ResponseCompletedEvent, events[-1])
+    return [
+        (item.call_id, item.name, item.arguments)
+        for item in completed.response.output
+        if isinstance(item, ResponseFunctionToolCall)
     ]
 
 
@@ -856,6 +895,73 @@ async def test_buffer_tool_call_stream_keeps_passthrough_index_passthrough() -> 
     assert len(buffered_chunks) == 2
     assert buffered_chunks[0].choices[0].delta.tool_calls == [custom_tool_call_delta]
     assert buffered_chunks[1].choices[0].delta.tool_calls == [function_tool_call_delta]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_tolerates_missing_tool_call_index() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": '{"a":'},
+                    }
+                ],
+            }
+        ),
+        _lenient_chunk({"tool_calls": [{"function": {"arguments": "1}"}}]}),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+    first_delta = chunks[0].choices[0].delta
+    assert first_delta.tool_calls and first_delta.tool_calls[0].index is None
+
+    unbuffered_events = await _collect_handler_events(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    expected_calls = [("call_1", "my_func", '{"a":1}')]
+    assert _completed_function_calls(unbuffered_events) == expected_calls
+    assert _completed_function_calls(buffered_events) == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_orders_missing_index_after_indexed_calls() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "first_func", "arguments": "{}"},
+                    }
+                ],
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "second_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    unbuffered_events = await _collect_handler_events(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    expected_calls = [("call_1", "first_func", "{}"), ("call_2", "second_func", "{}")]
+    assert _completed_function_calls(unbuffered_events) == expected_calls
+    assert _completed_function_calls(buffered_events) == expected_calls
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from collections.abc import AsyncIterator
+from dataclasses import replace
 from typing import Any, cast
 
 import httpx2
@@ -1407,6 +1408,50 @@ async def test_buffer_tool_call_stream_merges_missing_index_continuation(
 
 
 @pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_late_index_used_by_passthrough() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "print(1)"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": '{"a":'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"arguments": "1}"},
+                    }
+                ]
+            }
+        ),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="index already used by a passthrough call"):
+        await _collect_buffered_tool_call_chunks(*chunks)
+
+
+@pytest.mark.asyncio
 async def test_buffer_tool_call_stream_merges_late_id_into_missing_index_call() -> None:
     chunks = (
         _lenient_chunk(
@@ -1439,6 +1484,51 @@ async def test_buffer_tool_call_stream_merges_late_id_into_missing_index_call() 
     expected_calls = [("call_1", "my_func", '{"a":1}')]
     assert _completed_function_calls(unbuffered_events) == expected_calls
     assert _completed_function_calls(buffered_events) == expected_calls
+
+
+@pytest.mark.parametrize("continuation_name", [None, "my_func"])
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_reconciles_late_index_by_id(
+    continuation_name: str | None,
+) -> None:
+    continuation_function = {"arguments": "1}"}
+    if continuation_name is not None:
+        continuation_function["name"] = continuation_name
+
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": '{"a":'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 2,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": continuation_function,
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    replayed_tool_calls = buffered_chunks[-1].choices[0].delta.tool_calls
+    assert replayed_tool_calls
+    assert [tool_call.index for tool_call in replayed_tool_calls] == [2]
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
 
 
 @pytest.mark.parametrize(
@@ -1640,6 +1730,42 @@ def test_accumulate_tool_call_delta_rejects_new_id_for_occupied_missing_index() 
 
     with pytest.raises(ModelBehaviorError, match="new ID while another index-less call"):
         ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, new_call)
+
+
+def test_accumulate_tool_call_delta_rejects_late_index_collision() -> None:
+    unindexed_call = _BufferedToolCall(index=None, call_id="call_1", name="first_func")
+    indexed_call = _BufferedToolCall(index=2, call_id="call_2", name="second_func")
+    buffered_calls = {None: unindexed_call, 2: indexed_call}
+    expected_calls = {None: replace(unindexed_call), 2: replace(indexed_call)}
+    continuation = ChoiceDeltaToolCall.model_construct(
+        index=2,
+        id="call_1",
+        type="function",
+        function=ChoiceDeltaToolCallFunction(arguments="{}"),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="index already used"):
+        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
+
+    assert buffered_calls == expected_calls
+
+
+def test_accumulate_tool_call_delta_rejects_ambiguous_late_index() -> None:
+    unindexed_call = _BufferedToolCall(index=None, call_id="call_1", name="first_func")
+    indexed_call = _BufferedToolCall(index=1, call_id="call_1", name="second_func")
+    buffered_calls = {None: unindexed_call, 1: indexed_call}
+    expected_calls = {None: replace(unindexed_call), 1: replace(indexed_call)}
+    continuation = ChoiceDeltaToolCall.model_construct(
+        index=2,
+        id="call_1",
+        type="function",
+        function=ChoiceDeltaToolCallFunction(arguments="{}"),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="same ID matched multiple buffered calls"):
+        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
+
+    assert buffered_calls == expected_calls
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -999,6 +999,41 @@ async def test_buffer_tool_call_stream_avoids_passthrough_index_for_missing_inde
     assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
 
 
+@pytest.mark.parametrize("function_tool_call_index", [0, None])
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_ignores_missing_passthrough_index(
+    function_tool_call_index: int | None,
+) -> None:
+    custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
+        index=None,
+        id="custom-id",
+        type="custom",
+    )
+    custom_chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[custom_tool_call_delta]))],
+    )
+    function_tool_call: dict[str, Any] = {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "my_func", "arguments": "{}"},
+    }
+    if function_tool_call_index is not None:
+        function_tool_call["index"] = function_tool_call_index
+    chunks = (
+        custom_chunk,
+        _lenient_chunk({"tool_calls": [function_tool_call]}),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
+
+
 @pytest.mark.asyncio
 async def test_buffer_tool_call_stream_merges_missing_index_continuation() -> None:
     chunks = (

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1462,6 +1462,89 @@ async def test_buffer_tool_call_stream_allows_function_metadata_on_late_id() -> 
     assert _completed_function_calls(buffered_events) == expected_calls
 
 
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_ambiguous_mixed_unindexed_delta() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "print(1)"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {"tool_calls": [{"extra_content": {"google": {"thought_signature": "sig"}}}]}
+        ),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="could not be attributed"):
+        await _collect_buffered_tool_call_chunks(*chunks)
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_conflicting_index_and_id_owners() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "print(1)"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "extra_content": {"google": {"thought_signature": "sig"}},
+                    }
+                ]
+            }
+        ),
+    )
+
+    buffered = ChatCmplStreamHandler.buffer_tool_call_stream(_completion_stream(*chunks))
+    first_chunk = await anext(buffered)
+    first_tool_calls = first_chunk.choices[0].delta.tool_calls
+    assert first_tool_calls and first_tool_calls[0].id == "custom-id"
+
+    with pytest.raises(ModelBehaviorError, match="index already used by a passthrough call"):
+        await anext(buffered)
+
+
 @pytest.mark.parametrize("continuation_id", [None, "unknown-id"], ids=["without-id", "unknown-id"])
 @pytest.mark.asyncio
 async def test_buffer_tool_call_stream_rejects_ambiguous_unindexed_passthrough_continuation(

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -965,6 +965,82 @@ async def test_buffer_tool_call_stream_orders_missing_index_after_indexed_calls(
 
 
 @pytest.mark.asyncio
+async def test_buffer_tool_call_stream_preserves_missing_index_call_arrival_order() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "first_func", "arguments": "{}"},
+                    }
+                ],
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "second_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    unbuffered_events = await _collect_handler_events(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    expected_calls = [("call_1", "first_func", "{}"), ("call_2", "second_func", "{}")]
+    assert _completed_function_calls(unbuffered_events) == expected_calls
+    assert _completed_function_calls(buffered_events) == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_sorts_indexed_calls_by_index() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "second_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "first_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    assert _completed_function_calls(buffered_events) == [
+        ("call_1", "first_func", "{}"),
+        ("call_2", "second_func", "{}"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_buffer_tool_call_stream_avoids_passthrough_index_for_missing_index() -> None:
     custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
         index=0,
@@ -1034,8 +1110,280 @@ async def test_buffer_tool_call_stream_ignores_missing_passthrough_index(
     assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
 
 
+@pytest.mark.parametrize("continuation_id", [None, "custom-id"])
 @pytest.mark.asyncio
-async def test_buffer_tool_call_stream_merges_missing_index_continuation() -> None:
+async def test_buffer_tool_call_stream_forwards_missing_index_passthrough_continuation(
+    continuation_id: str | None,
+) -> None:
+    continuation: dict[str, Any] = {"custom": {"input": "nt(1)"}}
+    if continuation_id is not None:
+        continuation["id"] = continuation_id
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "pri"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [continuation]}),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    assert buffered_chunks[0].choices[0].delta.tool_calls == chunks[0].choices[0].delta.tool_calls
+    assert buffered_chunks[1].choices[0].delta.tool_calls == chunks[1].choices[0].delta.tool_calls
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
+
+
+@pytest.mark.parametrize("function_tool_call_index", [1, None], ids=["indexed", "unindexed"])
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_forwards_indexed_passthrough_continuation_by_id(
+    function_tool_call_index: int | None,
+) -> None:
+    function_tool_call: dict[str, Any] = {
+        "type": "function",
+        "function": {"name": "my_func", "arguments": "{}"},
+    }
+    if function_tool_call_index is not None:
+        function_tool_call["index"] = function_tool_call_index
+        function_tool_call["id"] = "call_1"
+
+    chunks = [
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "pri"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [function_tool_call]}),
+        _lenient_chunk({"tool_calls": [{"id": "custom-id", "custom": {"input": "nt(1)"}}]}),
+    ]
+    if function_tool_call_index is None:
+        chunks.append(_lenient_chunk({"tool_calls": [{"id": "call_1"}]}))
+    chunks.append(_lenient_chunk({}, finish_reason="tool_calls"))
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    continuation_tool_calls = buffered_chunks[1].choices[0].delta.tool_calls
+    assert continuation_tool_calls
+    assert continuation_tool_calls[0].index == 0
+    assert continuation_tool_calls[0].id == "custom-id"
+    assert continuation_tool_calls[0].model_extra == {"custom": {"input": "nt(1)"}}
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_records_passthrough_id_from_indexed_continuation() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "pri"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {"tool_calls": [{"index": 0, "id": "custom-id", "custom": {"input": "nt("}}]}
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [{"id": "custom-id", "custom": {"input": "1)"}}]}),
+        _lenient_chunk({"tool_calls": [{"id": "call_1"}]}),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    continuation_tool_calls = buffered_chunks[2].choices[0].delta.tool_calls
+    assert continuation_tool_calls
+    assert continuation_tool_calls[0].index == 0
+    assert continuation_tool_calls[0].id == "custom-id"
+    assert continuation_tool_calls[0].model_extra == {"custom": {"input": "1)"}}
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", "{}")]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_cross_domain_passthrough_id() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "shared-id",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "shared-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "print(1)"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "shared-id",
+                        "extra_content": {"google": {"thought_signature": "sig"}},
+                    }
+                ]
+            }
+        ),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="matched both"):
+        await _collect_buffered_tool_call_chunks(*chunks)
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_allows_function_metadata_on_late_id() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "print(1)"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "extra_content": {"google": {"thought_signature": "sig"}},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(*chunks)
+    unbuffered_events = await _collect_handler_events(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    replayed_tool_calls = buffered_chunks[-1].choices[0].delta.tool_calls
+    assert replayed_tool_calls
+    assert cast(Any, replayed_tool_calls[0]).extra_content == {
+        "google": {"thought_signature": "sig"}
+    }
+    expected_calls = [("call_1", "my_func", "{}")]
+    assert _completed_function_calls(unbuffered_events) == expected_calls
+    assert _completed_function_calls(buffered_events) == expected_calls
+
+
+@pytest.mark.parametrize("continuation_id", [None, "unknown-id"], ids=["without-id", "unknown-id"])
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_ambiguous_unindexed_passthrough_continuation(
+    continuation_id: str | None,
+) -> None:
+    continuation: dict[str, Any] = {"custom": {"input": "nt(1)"}}
+    if continuation_id is not None:
+        continuation["id"] = continuation_id
+
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "custom-id",
+                        "type": "custom",
+                        "custom": {"name": "code_exec", "input": "pri"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 1,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [continuation]}),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="could not be attributed"):
+        await _collect_buffered_tool_call_chunks(*chunks)
+
+
+@pytest.mark.parametrize("continuation_name", [None, "my_func"])
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_merges_missing_index_continuation(
+    continuation_name: str | None,
+) -> None:
+    continuation_function = {"arguments": "1}"}
+    if continuation_name is not None:
+        continuation_function["name"] = continuation_name
     chunks = (
         _lenient_chunk(
             {
@@ -1049,13 +1397,249 @@ async def test_buffer_tool_call_stream_merges_missing_index_continuation() -> No
                 ]
             }
         ),
-        _lenient_chunk({"tool_calls": [{"function": {"arguments": "1}"}}]}),
+        _lenient_chunk({"tool_calls": [{"function": continuation_function}]}),
         _lenient_chunk({}, finish_reason="tool_calls"),
     )
 
     buffered_events = await _collect_buffered_handler_events(*chunks)
 
     assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_merges_late_id_into_missing_index_call() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": '{"a":'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"arguments": "1}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    unbuffered_events = await _collect_handler_events(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    expected_calls = [("call_1", "my_func", '{"a":1}')]
+    assert _completed_function_calls(unbuffered_events) == expected_calls
+    assert _completed_function_calls(buffered_events) == expected_calls
+
+
+@pytest.mark.parametrize(
+    "opening_name",
+    ["my_func", None],
+    ids=["same-name", "fills-missing-name"],
+)
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_merges_named_continuation_into_missing_index_slot(
+    opening_name: str | None,
+) -> None:
+    opening_function = {"arguments": '{"a":'}
+    if opening_name is not None:
+        opening_function["name"] = opening_name
+
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": opening_function,
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "1}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [{"id": "call_1"}]}),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    unbuffered_events = await _collect_handler_events(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    expected_calls = [("call_1", "my_func", '{"a":1}')]
+    assert _completed_function_calls(unbuffered_events) == expected_calls
+    assert _completed_function_calls(buffered_events) == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_opens_named_missing_index_call_beside_indexed_call() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "first_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "second_func", "arguments": '{"b":'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"arguments": "1}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    unbuffered_events = await _collect_handler_events(*chunks)
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    expected_calls = [
+        ("call_1", "first_func", "{}"),
+        ("call_2", "second_func", '{"b":1}'),
+    ]
+    assert _completed_function_calls(unbuffered_events) == expected_calls
+    assert _completed_function_calls(buffered_events) == expected_calls
+
+
+@pytest.mark.parametrize("continuation_id", [None, "call_2"], ids=["without-id", "with-new-id"])
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_different_name_for_missing_index_slot(
+    continuation_id: str | None,
+) -> None:
+    continuation: dict[str, Any] = {
+        "type": "function",
+        "function": {"name": "second_func", "arguments": "{}"},
+    }
+    if continuation_id is not None:
+        continuation["id"] = continuation_id
+
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "first_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({"tool_calls": [continuation]}),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="different function name"):
+        await _collect_buffered_handler_events(*chunks)
+
+
+@pytest.mark.parametrize(
+    "continuation_function",
+    [
+        {"arguments": "1}"},
+        {"name": "my_func", "arguments": "1}"},
+    ],
+    ids=["arguments-only", "repeated-name"],
+)
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_merges_missing_index_continuation_by_id(
+    continuation_function: dict[str, str],
+) -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": '{"a":'},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": continuation_function,
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk({}, finish_reason="tool_calls"),
+    )
+
+    buffered_events = await _collect_buffered_handler_events(*chunks)
+
+    assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
+
+
+def test_accumulate_tool_call_delta_rejects_ambiguous_repeated_id() -> None:
+    buffered_calls = {
+        0: _BufferedToolCall(index=0, call_id="call_1", name="first_func"),
+        1: _BufferedToolCall(index=1, call_id="call_1", name="second_func"),
+    }
+    continuation = ChoiceDeltaToolCall.model_construct(
+        index=None,
+        id="call_1",
+        type="function",
+        function=ChoiceDeltaToolCallFunction(arguments="{}"),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="same ID matched multiple buffered calls"):
+        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, continuation)
+
+
+def test_accumulate_tool_call_delta_rejects_new_id_for_occupied_missing_index() -> None:
+    buffered_calls = {
+        None: _BufferedToolCall(index=None, call_id="call_1", name="first_func"),
+    }
+    new_call = ChoiceDeltaToolCall.model_construct(
+        index=None,
+        id="call_2",
+        type="function",
+        function=ChoiceDeltaToolCallFunction(name="second_func", arguments="{}"),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="new ID while another index-less call"):
+        ChatCmplStreamHandler._accumulate_tool_call_delta(buffered_calls, new_call)
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1629,14 +1629,9 @@ async def test_buffer_tool_call_stream_rejects_ambiguous_unindexed_passthrough_c
         await _collect_buffered_tool_call_chunks(*chunks)
 
 
-@pytest.mark.parametrize("continuation_name", [None, "my_func"])
 @pytest.mark.asyncio
-async def test_buffer_tool_call_stream_merges_missing_index_continuation(
-    continuation_name: str | None,
-) -> None:
+async def test_buffer_tool_call_stream_merges_arguments_only_missing_index_continuation() -> None:
     continuation_function = {"arguments": "1}"}
-    if continuation_name is not None:
-        continuation_function["name"] = continuation_name
     chunks = (
         _lenient_chunk(
             {
@@ -1657,6 +1652,37 @@ async def test_buffer_tool_call_stream_merges_missing_index_continuation(
     buffered_events = await _collect_buffered_handler_events(*chunks)
 
     assert _completed_function_calls(buffered_events) == [("call_1", "my_func", '{"a":1}')]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_ambiguous_same_named_unindexed_opening() -> None:
+    chunks = (
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": "{}"},
+                    }
+                ]
+            }
+        ),
+        _lenient_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "my_func", "arguments": '{"b":'},
+                    }
+                ]
+            }
+        ),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="same function name"):
+        await _collect_buffered_tool_call_chunks(*chunks)
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -118,7 +118,12 @@ async def _collect_buffered_handler_events(*chunks: ChatCompletionChunk) -> list
     ]
 
 
-def _lenient_chunk(delta: dict[str, Any], finish_reason: str | None = None) -> ChatCompletionChunk:
+def _lenient_chunk(
+    delta: dict[str, Any],
+    finish_reason: str | None = None,
+    *,
+    choice_index: int = 0,
+) -> ChatCompletionChunk:
     """Construct a chunk as AsyncStream does, without validating a missing tool-call index."""
     return cast(
         ChatCompletionChunk,
@@ -129,7 +134,9 @@ def _lenient_chunk(delta: dict[str, Any], finish_reason: str | None = None) -> C
                 "object": "chat.completion.chunk",
                 "created": 1,
                 "model": "fake",
-                "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+                "choices": [
+                    {"index": choice_index, "delta": delta, "finish_reason": finish_reason}
+                ],
             },
         ),
     )
@@ -987,6 +994,79 @@ async def test_missing_index_replay_avoids_passthrough_index_collision() -> None
 
 
 @pytest.mark.asyncio
+async def test_unindexed_passthrough_continuation_remains_passthrough() -> None:
+    opening = _lenient_chunk(
+        {"tool_calls": [{"id": "custom-id", "type": "custom", "custom": {"input": "start"}}]}
+    )
+    continuation = _lenient_chunk({"tool_calls": [{"custom": {"input": "-end"}}]})
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(opening, continuation)
+
+    assert [chunk.choices[0].delta.tool_calls for chunk in buffered_chunks] == [
+        opening.choices[0].delta.tool_calls,
+        continuation.choices[0].delta.tool_calls,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_indexed_function_does_not_block_unindexed_passthrough_continuation() -> None:
+    indexed_function = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "my_func", "arguments": "{}"},
+                }
+            ]
+        }
+    )
+    custom_opening = _lenient_chunk(
+        {"tool_calls": [{"id": "custom-id", "type": "custom", "custom": {"input": "start"}}]}
+    )
+    custom_continuation = _lenient_chunk({"tool_calls": [{"custom": {"input": "-end"}}]})
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(
+        indexed_function,
+        custom_opening,
+        custom_continuation,
+    )
+
+    assert [chunk.choices[0].delta.tool_calls for chunk in buffered_chunks[:-1]] == [
+        custom_opening.choices[0].delta.tool_calls,
+        custom_continuation.choices[0].delta.tool_calls,
+    ]
+    replayed_calls = buffered_chunks[-1].choices[0].delta.tool_calls
+    assert replayed_calls and replayed_calls[0].id == "call_1"
+
+
+@pytest.mark.asyncio
+async def test_nonzero_choice_tool_call_suppresses_choice_zero_finish_error() -> None:
+    nonzero_choice = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "my_func", "arguments": "{}"},
+                }
+            ]
+        },
+        choice_index=1,
+    )
+    choice_zero_finish = _lenient_chunk({}, finish_reason="tool_calls")
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(
+        nonzero_choice,
+        choice_zero_finish,
+    )
+
+    assert buffered_chunks == [nonzero_choice]
+
+
+@pytest.mark.asyncio
 async def test_missing_index_continuation_merges_into_sole_buffered_function() -> None:
     chunks = (
         _lenient_chunk(
@@ -1043,6 +1123,27 @@ async def test_missing_index_continuation_uses_a_unique_function_call_id() -> No
 
 
 @pytest.mark.asyncio
+async def test_late_index_for_unindexed_function_is_rejected() -> None:
+    opening = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "my_func", "arguments": '{"a":'},
+                }
+            ]
+        }
+    )
+    late_index = _lenient_chunk(
+        {"tool_calls": [{"index": 0, "id": "call_1", "function": {"arguments": "1}"}}]}
+    )
+
+    with pytest.raises(ModelBehaviorError, match="index and ID identified different"):
+        await _collect_buffered_tool_call_chunks(opening, late_index)
+
+
+@pytest.mark.asyncio
 async def test_missing_index_continuation_rejects_multiple_buffered_functions() -> None:
     chunks = (
         _lenient_chunk(
@@ -1063,6 +1164,55 @@ async def test_missing_index_continuation_rejects_multiple_buffered_functions() 
 
     with pytest.raises(ModelBehaviorError, match="multiple function calls"):
         await _collect_buffered_tool_call_chunks(*chunks, continuation)
+
+
+@pytest.mark.asyncio
+async def test_parallel_unindexed_function_openings_are_rejected() -> None:
+    first = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "first_func", "arguments": "{}"},
+                }
+            ]
+        }
+    )
+    second = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "second_func", "arguments": "{}"},
+                }
+            ]
+        }
+    )
+
+    with pytest.raises(ModelBehaviorError, match="omitted an index for a new call"):
+        await _collect_buffered_tool_call_chunks(first, second)
+
+
+@pytest.mark.asyncio
+async def test_passthrough_call_rejects_a_buffered_function_index() -> None:
+    function = _lenient_chunk(
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "my_func", "arguments": "{}"},
+                }
+            ]
+        }
+    )
+    custom = _lenient_chunk({"tool_calls": [{"index": 0, "id": "custom-id", "type": "custom"}]})
+
+    with pytest.raises(ModelBehaviorError, match="identified both a buffered function call"):
+        await _collect_buffered_tool_call_chunks(function, custom)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request makes buffered Chat Completions resilient when an OpenAI-compatible provider omits `tool_calls[].index` from function-call deltas.

The buffered path now:

- retains one compatibility slot for an unindexed function call and assigns it a collision-free integer index at replay, derived from the indexes already used by passthrough and indexed function calls;
- resolves a missing-index continuation only from a unique repeated call ID or a sole buffered function call;
- preserves existing indexed ordering and forwards passthrough tool-call deltas unchanged, including when they omit an index;
- raises `ModelBehaviorError` before mutation when ownership is ambiguous or conflicting; and
- fails closed when a single buffered index receives conflicting tool-call IDs or function names instead of silently merging them.

The change intentionally does not infer, promote, reindex, or rewrite passthrough ownership. Multiple distinct function calls without enough index or ID information remain unsupported; affected callers can disable `buffer_streamed_tool_calls`.

### Test plan

- `tests/models/test_openai_chatcompletions_stream.py`: **123 passed**.
- Ruff format/check, optional-truthiness validation, mypy, pyright, and the serial test gate pass.
- The Windows parallel suite completed with **8,337 passed and 81 skipped**. Its 19 failures match the unchanged merge-base platform baseline: 17 require Windows symlink privileges and 2 read a UTF-8 example file with the system GBK default. The two encoding tests pass with `PYTHONUTF8=1`.

### Issue number

Closes #4823

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (`make` is unavailable on this Windows host, so I ran the Makefile-equivalent commands directly)
- [ ] I've confirmed every repository-wide test passes locally (blocked only by the reproducible Windows platform conditions described above)
- [x] If using Codex, I've run `/review` before submitting this PR and addressed the findings
