### PR TITLE
docs: list MongoDB and shared sandbox examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -76,6 +76,7 @@ Check out a variety of sample implementations that use the SDK in the examples s
     -   Advanced SQLite session storage
     -   Redis session storage
     -   SQLAlchemy session storage
+    -   MongoDB session storage (`examples/memory/mongodb_session_example.py`)
     -   Dapr state store session storage
     -   Encrypted session storage
     -   OpenAI Conversations session storage
@@ -111,6 +112,7 @@ Check out a variety of sample implementations that use the SDK in the examples s
     -   Sandbox-backed handoffs (`examples/sandbox/handoffs.py`)
     -   Sandbox memory and snapshot resume (`examples/sandbox/memory.py`)
     -   Sandbox agents exposed as tools (`examples/sandbox/sandbox_agents_as_tools.py`)
+    -   One sandbox session shared by multiple runs with separate `SandboxRunConfig.cwd` values (`examples/sandbox/shared_session_workdirs.py`)
 
 - **[tools](https://github.com/openai/openai-agents-python/tree/main/examples/tools):** Learn how to implement OpenAI-hosted tools and experimental Codex tooling. Examples include:
 


### PR DESCRIPTION
This pull request updates the examples gallery to include two released examples that were missing from their corresponding categories:

  - MongoDB-backed session storage under the memory examples
  - A shared sandbox session with separate `SandboxRunConfig.cwd` values under the sandbox examples

  Both examples are available in v0.22.0. This change only improves their discoverability and does not modify SDK behavior.

  ### Test plan

  - Confirmed both referenced example paths exist
  - Performed a focused Japanese, Korean, and Chinese translation-safety review of the added English text
  - Ran `git diff --check`
  - Ran the documentation reference generator
  - Ran `mkdocs build` successfully