### PR TITLE
fix(sandbox): make UnixLocal persist_workspace archives restorable by hydrate_workspace

### DIFF
--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -133,18 +133,40 @@ def _restorable_tar_member(ti: tarfile.TarInfo, *, root: Path) -> tarfile.TarInf
         ti.linkname = ""
         ti.size = os.stat(root / ti.name).st_size
         return ti
-    if ti.issym() and PurePosixPath(ti.linkname).is_absolute():
-        # normpath keeps a leading "//"; Linux resolves it as "/", so collapse it first.
-        normalized_target = Path("/" + os.path.normpath(ti.linkname).lstrip("/"))
-        link_dir = PurePosixPath(ti.name).parent
-        for candidate_root in (root, root.resolve(strict=False)):
-            try:
-                target_rel = normalized_target.relative_to(candidate_root)
-            except ValueError:
-                continue
-            ti.linkname = os.path.relpath(target_rel.as_posix() or ".", start=link_dir.as_posix())
-            break
+    if ti.issym() and ti.linkname.startswith("/"):
+        ti.linkname = _rebase_symlink_target(
+            ti.linkname, link_name=ti.name, roots=(root, root.resolve(strict=False))
+        )
     return ti
+
+
+def _rebase_symlink_target(linkname: str, *, link_name: str, roots: tuple[Path, ...]) -> str:
+    """Rewrite an absolute symlink target under the workspace root as a link-relative one.
+
+    Only the root prefix is replaced; the remaining components are kept verbatim (no
+    normalization), because ``..`` after a symlink component is resolved by the kernel
+    against the link target, so ``<root>/current/../config`` with ``current -> releases/v1``
+    names ``releases/config`` and must stay ``current/../config``. Absolute targets outside
+    the workspace are returned unchanged. A leading ``//`` is collapsed to ``/`` (Linux
+    treats them alike).
+    """
+
+    target = "/" + linkname.lstrip("/")
+    for candidate_root in roots:
+        prefix = candidate_root.as_posix().rstrip("/")
+        if target == prefix:
+            rest = ""
+        elif target.startswith(prefix + "/"):
+            rest = target[len(prefix) + 1 :]
+        else:
+            continue
+        # The link's own directory inside the archive holds no symlink components (the
+        # archive validator rejects members beneath a symlink), so climbing it is exact.
+        climb = "/".join([".."] * len(PurePosixPath(link_name).parent.parts))
+        if rest and climb:
+            return f"{climb}/{rest}"
+        return rest or climb or "."
+    return linkname
 
 
 def _restore_pty_child_signal_defaults() -> None:

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -25,7 +25,7 @@ from collections.abc import Collection, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import partial
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Literal, cast
 
 from ...logger import log_tool_action_warning
@@ -110,6 +110,40 @@ def _mount_path_diagnostic_extra(mount_path: Path) -> dict[str, object]:
 def _close_fd_quietly(fd: int) -> None:
     with suppress(OSError):
         os.close(fd)
+
+
+def _restorable_tar_member(ti: tarfile.TarInfo, *, root: Path) -> tarfile.TarInfo | None:
+    """Rewrite one ``persist_workspace`` member so ``hydrate_workspace`` can restore it.
+
+    The strict extractor used for hydrate refuses hardlink members, special files, and
+    absolute symlink targets. A local workspace legitimately contains all three (``uv`` and
+    ``pnpm`` hardlink installed packages, dev servers leave FIFOs behind, ``ln -s "$PWD/x"``
+    makes an absolute link), and archiving them as-is produced a snapshot that could never be
+    restored. Store hardlinks as regular files, drop FIFOs and device nodes, and make an
+    absolute symlink target that stays under the workspace root relative so it survives the
+    root moving between sessions. Absolute targets outside the workspace are kept unchanged.
+    """
+
+    if ti.isfifo() or ti.ischr() or ti.isblk():
+        return None
+    if ti.islnk():
+        # tarfile turns the second occurrence of an inode into a hardlink member with no
+        # payload; ``TarFile.add`` reads the file contents for a regular member instead.
+        ti.type = tarfile.REGTYPE
+        ti.linkname = ""
+        ti.size = os.stat(root / ti.name).st_size
+        return ti
+    if ti.issym() and PurePosixPath(ti.linkname).is_absolute():
+        normalized_target = Path(os.path.normpath(ti.linkname))
+        link_dir = PurePosixPath(ti.name).parent
+        for candidate_root in (root, root.resolve(strict=False)):
+            try:
+                target_rel = normalized_target.relative_to(candidate_root)
+            except ValueError:
+                continue
+            ti.linkname = os.path.relpath(target_rel.as_posix() or ".", start=link_dir.as_posix())
+            break
+    return ti
 
 
 def _restore_pty_child_signal_defaults() -> None:
@@ -1097,7 +1131,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                             skip_rel_paths=skip,
                             root_name=None,
                         )
-                        else ti
+                        else _restorable_tar_member(ti, root=root)
                     ),
                 )
 

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -134,7 +134,8 @@ def _restorable_tar_member(ti: tarfile.TarInfo, *, root: Path) -> tarfile.TarInf
         ti.size = os.stat(root / ti.name).st_size
         return ti
     if ti.issym() and PurePosixPath(ti.linkname).is_absolute():
-        normalized_target = Path(os.path.normpath(ti.linkname))
+        # normpath keeps a leading "//"; Linux resolves it as "/", so collapse it first.
+        normalized_target = Path("/" + os.path.normpath(ti.linkname).lstrip("/"))
         link_dir = PurePosixPath(ti.name).parent
         for candidate_root in (root, root.resolve(strict=False)):
             try:

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -157,7 +157,9 @@ def _rebase_symlink_target(linkname: str, *, link_name: str, roots: tuple[Path, 
         if target == prefix:
             rest = ""
         elif target.startswith(prefix + "/"):
-            rest = target[len(prefix) + 1 :]
+            # Consume the whole separator run at the boundary (`<root>//a.txt`), keeping
+            # every later component, including `..`, untouched.
+            rest = target[len(prefix) :].lstrip("/")
         else:
             continue
         # The link's own directory inside the archive holds no symlink components (the

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -509,6 +509,35 @@ class TestUnixLocalPersistWorkspaceRestorable:
             assert members["outside"].linkname == str(tmp_path / "elsewhere.txt")
 
     @pytest.mark.asyncio
+    async def test_rebased_symlink_keeps_parent_steps_after_symlink_components(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`<root>/current/../config` with `current -> releases/v1` names `releases/config`;
+        collapsing the `..` lexically would silently retarget the restored link."""
+        workspace = tmp_path / "workspace"
+        (workspace / "releases" / "v1").mkdir(parents=True)
+        (workspace / "releases" / "config").write_text("right", encoding="utf-8")
+        (workspace / "config").write_text("wrong", encoding="utf-8")
+        (workspace / "current").symlink_to("releases/v1")
+        (workspace / "abs_config").symlink_to(workspace / "current" / ".." / "config")
+        (workspace / "releases" / "v1" / "abs_up").symlink_to(
+            workspace / "current" / ".." / "config"
+        )
+        assert (workspace / "abs_config").read_text(encoding="utf-8") == "right"
+
+        blob = await _RecordingUnixLocalSession(workspace).persist_workspace()
+        restored_root = tmp_path / "restored"
+        await _RecordingUnixLocalSession(restored_root).hydrate_workspace(blob)
+
+        assert os.readlink(restored_root / "abs_config") == "current/../config"
+        assert (
+            os.readlink(restored_root / "releases" / "v1" / "abs_up") == "../../current/../config"
+        )
+        assert (restored_root / "abs_config").read_text(encoding="utf-8") == "right"
+        assert (restored_root / "releases" / "v1" / "abs_up").read_text(encoding="utf-8") == "right"
+
+    @pytest.mark.asyncio
     async def test_persisted_workspace_hydrates_into_a_new_root(self, tmp_path: Path) -> None:
         workspace = self._workspace(tmp_path)
         (workspace / "outside").unlink()  # hydrate rejects external targets by design

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -484,6 +484,7 @@ class TestUnixLocalPersistWorkspaceRestorable:
         (workspace / "abs_inside").symlink_to(workspace / "a.txt")
         (workspace / "sub" / "abs_up").symlink_to(workspace / "a.txt")
         (workspace / "rel").symlink_to("a.txt")
+        (workspace / "double_slash").symlink_to("/" + str(workspace / "a.txt"))
         (workspace / "outside").symlink_to(tmp_path / "elsewhere.txt")
         return workspace
 
@@ -504,6 +505,7 @@ class TestUnixLocalPersistWorkspaceRestorable:
             assert members["abs_inside"].linkname == "a.txt"
             assert members["sub/abs_up"].linkname == "../a.txt"
             assert members["rel"].linkname == "a.txt"
+            assert members["double_slash"].linkname == "a.txt"
             assert members["outside"].linkname == str(tmp_path / "elsewhere.txt")
 
     @pytest.mark.asyncio

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import os
 import signal
 import tarfile
 import threading
@@ -468,6 +469,58 @@ class TestUnixLocalUserScopedFilesystem:
         assert session.exec_commands[0][4:6] == ("sh", "-lc")
         assert session.exec_commands[0][-2:] == (str(target), "0")
         assert not any(part.startswith("rm ") for part in session.exec_commands[0])
+
+
+class TestUnixLocalPersistWorkspaceRestorable:
+    """persist_workspace must only emit members that the strict hydrate extractor accepts."""
+
+    @staticmethod
+    def _workspace(tmp_path: Path) -> Path:
+        workspace = tmp_path / "workspace"
+        (workspace / "sub").mkdir(parents=True)
+        (workspace / "a.txt").write_text("shared", encoding="utf-8")
+        os.link(workspace / "a.txt", workspace / "sub" / "hardlink.txt")
+        os.mkfifo(workspace / "dev.fifo")
+        (workspace / "abs_inside").symlink_to(workspace / "a.txt")
+        (workspace / "sub" / "abs_up").symlink_to(workspace / "a.txt")
+        (workspace / "rel").symlink_to("a.txt")
+        (workspace / "outside").symlink_to(tmp_path / "elsewhere.txt")
+        return workspace
+
+    @pytest.mark.asyncio
+    async def test_persist_emits_restorable_members(self, tmp_path: Path) -> None:
+        workspace = self._workspace(tmp_path)
+        session = _RecordingUnixLocalSession(workspace)
+
+        blob = await session.persist_workspace()
+
+        with tarfile.open(fileobj=cast(io.BytesIO, blob), mode="r:*") as tar:
+            members = {member.name.removeprefix("./"): member for member in tar.getmembers()}
+            assert "dev.fifo" not in members
+            hardlink = members["sub/hardlink.txt"]
+            assert hardlink.isreg() and hardlink.size == len("shared")
+            extracted = tar.extractfile(hardlink)
+            assert extracted is not None and extracted.read() == b"shared"
+            assert members["abs_inside"].linkname == "a.txt"
+            assert members["sub/abs_up"].linkname == "../a.txt"
+            assert members["rel"].linkname == "a.txt"
+            assert members["outside"].linkname == str(tmp_path / "elsewhere.txt")
+
+    @pytest.mark.asyncio
+    async def test_persisted_workspace_hydrates_into_a_new_root(self, tmp_path: Path) -> None:
+        workspace = self._workspace(tmp_path)
+        (workspace / "outside").unlink()  # hydrate rejects external targets by design
+        blob = await _RecordingUnixLocalSession(workspace).persist_workspace()
+
+        restored_root = tmp_path / "restored"
+        restored = _RecordingUnixLocalSession(restored_root)
+        await restored.hydrate_workspace(blob)
+
+        assert (restored_root / "sub" / "hardlink.txt").read_text(encoding="utf-8") == "shared"
+        assert not (restored_root / "dev.fifo").exists()
+        assert os.readlink(restored_root / "abs_inside") == "a.txt"
+        assert (restored_root / "abs_inside").read_text(encoding="utf-8") == "shared"
+        assert (restored_root / "sub" / "abs_up").read_text(encoding="utf-8") == "shared"
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -485,6 +485,7 @@ class TestUnixLocalPersistWorkspaceRestorable:
         (workspace / "sub" / "abs_up").symlink_to(workspace / "a.txt")
         (workspace / "rel").symlink_to("a.txt")
         (workspace / "double_slash").symlink_to("/" + str(workspace / "a.txt"))
+        (workspace / "double_sep").symlink_to(str(workspace) + "//a.txt")
         (workspace / "outside").symlink_to(tmp_path / "elsewhere.txt")
         return workspace
 
@@ -506,6 +507,7 @@ class TestUnixLocalPersistWorkspaceRestorable:
             assert members["sub/abs_up"].linkname == "../a.txt"
             assert members["rel"].linkname == "a.txt"
             assert members["double_slash"].linkname == "a.txt"
+            assert members["double_sep"].linkname == "a.txt"
             assert members["outside"].linkname == str(tmp_path / "elsewhere.txt")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request fixes `UnixLocalSandboxSession.persist_workspace()` so the archive it produces can actually be restored by `hydrate_workspace()`.

#### Bug

`persist_workspace()` archives the workspace with `tarfile.add()` as-is, while `hydrate_workspace()` extracts with the strict policy (`safe_extract_tarfile(..., allow_external_symlink_targets=False)`) that refuses hardlink members, FIFOs / device nodes, and absolute symlink targets. Ordinary local workspaces contain all three, so the snapshot is taken successfully and then can never be restored. Reproduced on `main` with a real `UnixLocalSandboxClient` session (persist into one session, hydrate into a fresh one):

| workspace content | hydrate result on `main` |
|---|---|
| `a.txt` + `ln a.txt b.txt` (what `uv` / `pnpm` do for every installed package) | `WorkspaceArchiveWriteError` — `hardlink member not allowed`, member `./b.txt` |
| a FIFO left behind by a dev server (`mkfifo pipe`) | `unsupported member type`, member `./pipe` |
| `ln -s "$PWD/a.txt" abs_inside` (absolute link to a file *inside* the workspace) | `absolute symlink target not allowed: /tmp/sandbox-local-…/a.txt` |
| `python3 -m venv .venv` | `absolute symlink target not allowed: /usr/bin/python3` |

The last row is the intentional #3094 policy and is **not** changed here. The first three are not "external" in any sense, and the absolute-internal link is additionally wrong after restore even if it were accepted, because UnixLocal creates a fresh `/tmp/sandbox-local-*` root per session.

#### Fix

Add a `filter` step to the `tarfile.add()` call in `persist_workspace()` (`_restorable_tar_member`):

- hardlink members become regular file members (`TarFile.add` then reads the payload), so the restored workspace has two files with the same content;
- FIFOs and character/block device members are dropped (sockets already are, by `tarfile`);
- an absolute symlink target under the workspace root (checked against both the configured root and its resolved form, for hosts where `/tmp` is itself a symlink) has only its root prefix replaced by the climb out of the link's own archive directory, e.g. `/tmp/sandbox-local-x/a.txt` from `sub/abs_up` becomes `../a.txt`; the remaining components are kept verbatim, so `<root>/current/../config` stays `current/../config` and still resolves through the `current` symlink after restore;
- everything else, including relative symlinks and absolute targets outside the workspace, is left untouched.

No public signatures change and `hydrate_workspace()` is not modified.

### Test plan

- `tests/sandbox/test_unix_local.py::TestUnixLocalPersistWorkspaceRestorable` inspects the emitted members and round-trips the archive into a new root through `hydrate_workspace()`; both tests fail on `main` and pass with this change.
- `tests/sandbox/test_unix_local.py`, `test_tar_utils.py`, `test_extract.py`, `ruff`, `mypy`, and `pyright` on the changed files pass locally (Linux, Python 3.10).

Verification stack: `make format`/`ruff check` clean, `mypy` and `pyright` clean on the changed files, focused suites plus `tests/sandbox` pass on Linux/Python 3.10. The repository-wide `mypy src` reports pre-existing errors on Python 3.10 (`archive_ops.py` SpooledTemporaryFile typing, `run_loop.py` BaseExceptionGroup export) that are unrelated to this PR, so the full-stack checkbox is left unchecked.

### Issue number

None (found while auditing the UnixLocal / Docker sandbox file operations).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run the verification steps from `.agents/skills/code-change-verification` individually (format, lint, typecheck on changed files, tests)
- [ ] I've confirmed all verification steps pass (see Test plan: pre-existing Python 3.10 `mypy` errors outside this change)
- [ ] If using Codex, I've run `/review` before submitting this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BN4v25msJgrjNgac97g1Az

