### PR TITLE
fix(sandbox): refuse to rm the workspace root

### DIFF
--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -960,6 +960,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
             normalized = await self._check_rm_with_exec(path, recursive=recursive, user=user)
         else:
             normalized = self.normalize_path(path, for_write=True)
+        self._raise_if_workspace_root_removal(normalized)
         try:
             if normalized.is_dir() and not normalized.is_symlink():
                 if recursive:

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -949,6 +949,17 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         except OSError as e:
             raise WorkspaceArchiveWriteError(path=normalized, cause=e) from e
 
+    def _raise_if_workspace_root_removal(self, path: Path) -> None:
+        # The validated path is a host realpath here, so also compare against the resolved
+        # root (Manifest.root may be a symlink, and /tmp is one on macOS).
+        root = Path(self.state.manifest.root)
+        if path == root.resolve(strict=False):
+            raise WorkspaceArchiveWriteError(
+                path=path,
+                context={"reason": "workspace_root_removal_refused"},
+            )
+        super()._raise_if_workspace_root_removal(path)
+
     async def rm(
         self,
         path: Path | str,

--- a/src/agents/sandbox/session/base_sandbox_session.py
+++ b/src/agents/sandbox/session/base_sandbox_session.py
@@ -839,12 +839,12 @@ class BaseSandboxSession(abc.ABC):
         wants from a file operation; clearing the workspace is `rm` of its entries.
         """
 
-        root = Path(self.state.manifest.root)
-        candidates = {sandbox_path_str(root), sandbox_path_str(self._workspace_root_path())}
-        try:
-            candidates.add(sandbox_path_str(root.resolve(strict=False)))
-        except OSError:
-            pass
+        # Compare POSIX spellings only: the manifest root names a path inside the sandbox,
+        # and resolving it on the SDK host would compare against the wrong filesystem.
+        candidates = {
+            sandbox_path_str(self.state.manifest.root),
+            sandbox_path_str(self._workspace_root_path()),
+        }
         if sandbox_path_str(path) in candidates:
             raise WorkspaceArchiveWriteError(
                 path=path,

--- a/src/agents/sandbox/session/base_sandbox_session.py
+++ b/src/agents/sandbox/session/base_sandbox_session.py
@@ -830,6 +830,27 @@ class BaseSandboxSession(abc.ABC):
     async def _validate_path_access(self, path: Path | str, *, for_write: bool = False) -> Path:
         return self.normalize_path(path, for_write=for_write)
 
+    def _raise_if_workspace_root_removal(self, path: Path) -> None:
+        """Refuse ``rm`` of the workspace root itself.
+
+        `rm(".")`, `rm("")` or `rm("<root>")` passed path validation and then deleted the
+        whole workspace directory, after which every exec, read and write in the session
+        failed with WorkspaceRootNotFoundError. Removing the root is never what a caller
+        wants from a file operation; clearing the workspace is `rm` of its entries.
+        """
+
+        root = Path(self.state.manifest.root)
+        candidates = {sandbox_path_str(root), sandbox_path_str(self._workspace_root_path())}
+        try:
+            candidates.add(sandbox_path_str(root.resolve(strict=False)))
+        except OSError:
+            pass
+        if sandbox_path_str(path) in candidates:
+            raise WorkspaceArchiveWriteError(
+                path=path,
+                context={"reason": "workspace_root_removal_refused"},
+            )
+
     async def _validate_remote_path_access(
         self,
         path: Path | str,
@@ -1136,6 +1157,7 @@ class BaseSandboxSession(abc.ABC):
         :param user: Optional sandbox user to remove as.
         """
         path = await self._validate_path_access(path, for_write=True)
+        self._raise_if_workspace_root_removal(path)
 
         cmd: list[str] = ["rm"]
         if recursive:

--- a/tests/sandbox/test_session_utils.py
+++ b/tests/sandbox/test_session_utils.py
@@ -15,6 +15,7 @@ from agents.sandbox.entries import GCSMount, InContainerMountStrategy, Mountpoin
 from agents.sandbox.errors import (
     MountConfigError,
     WorkspaceArchiveReadError,
+    WorkspaceArchiveWriteError,
     WorkspaceReadNotFoundError,
 )
 from agents.sandbox.files import EntryKind, FileEntry
@@ -235,6 +236,27 @@ async def test_check_mkdir_with_exec_runs_non_destructive_probe_as_user() -> Non
     assert session.last_command[:4] == ("sudo", "-u", "sandbox-user", "--")
     assert session.last_command[4:6] == ("sh", "-lc")
     assert session.last_command[-2:] == ("/workspace/nested/dir", "1")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("root_spelling", [".", "", "/workspace", "/workspace/", "sub/.."])
+async def test_rm_refuses_to_remove_the_workspace_root(root_spelling: str) -> None:
+    session = _CaptureExecSession()
+
+    with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+        await session.rm(root_spelling, recursive=True)
+
+    assert excinfo.value.context.get("reason") == "workspace_root_removal_refused"
+    assert session.last_command is None
+
+
+@pytest.mark.asyncio
+async def test_rm_of_a_workspace_entry_still_runs() -> None:
+    session = _CaptureExecSession()
+
+    await session.rm("sub", recursive=True)
+
+    assert session.last_command == ("rm", "-rf", "--", "/workspace/sub")
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -13,7 +13,7 @@ from typing import cast
 import pytest
 
 from agents.sandbox import SandboxPathGrant
-from agents.sandbox.errors import PtySessionNotFoundError
+from agents.sandbox.errors import PtySessionNotFoundError, WorkspaceArchiveWriteError
 from agents.sandbox.manifest import Environment, Manifest
 from agents.sandbox.sandboxes import unix_local as unix_local_module
 from agents.sandbox.sandboxes.unix_local import (
@@ -468,6 +468,38 @@ class TestUnixLocalUserScopedFilesystem:
         assert session.exec_commands[0][4:6] == ("sh", "-lc")
         assert session.exec_commands[0][-2:] == (str(target), "0")
         assert not any(part.startswith("rm ") for part in session.exec_commands[0])
+
+
+class TestUnixLocalRmWorkspaceRoot:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("root_spelling", [".", "", "{root}", "{root}/", "sub/.."])
+    async def test_rm_refuses_to_remove_the_workspace_root(
+        self,
+        tmp_path: Path,
+        root_spelling: str,
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "sub").mkdir(parents=True)
+        (workspace / "sub" / "keep.txt").write_text("keep", encoding="utf-8")
+        session = _RecordingUnixLocalSession(workspace)
+
+        with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+            await session.rm(root_spelling.format(root=workspace), recursive=True)
+
+        assert excinfo.value.context.get("reason") == "workspace_root_removal_refused"
+        assert (workspace / "sub" / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+    @pytest.mark.asyncio
+    async def test_rm_of_a_workspace_entry_still_removes_it(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "sub").mkdir(parents=True)
+        (workspace / "sub" / "old.txt").write_text("old", encoding="utf-8")
+        session = _RecordingUnixLocalSession(workspace)
+
+        await session.rm("sub", recursive=True)
+
+        assert workspace.is_dir()
+        assert not (workspace / "sub").exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request fixes `SandboxSession.rm()` so it refuses to remove the workspace root itself instead of deleting the whole workspace.

#### Bug

The workspace root is a valid workspace path, so `rm(".")`, `rm("")`, `rm("sub/..")` and `rm("<root>")` all pass `_validate_path_access()` / `normalize_path()` and then run:

- `BaseSandboxSession.rm()` (every exec-backed backend): `rm -rf -- /workspace` inside the sandbox;
- `UnixLocalSandboxSession.rm()`: `shutil.rmtree(<root>)` on the host.

After that the session is unusable. Reproduced on `main` with a real `UnixLocalSandboxClient` session: `await session.rm(".", recursive=True)` succeeds, the `/tmp/sandbox-local-*` directory is gone, and the next `session.exec("pwd")` raises `WorkspaceRootNotFoundError`. The same call is reachable from the model through `apply_patch` (`delete_file` with path `.`) and any tool that forwards a path to `rm`.

Removing the root is never what a caller means by a file operation; clearing a workspace is `rm` of its entries.

#### Fix

- `BaseSandboxSession._raise_if_workspace_root_removal(path)` compares the validated path with the manifest root, the policy's `sandbox_root()`, and the resolved root (for UnixLocal, whose validated paths are realpaths and whose `/tmp` may itself be a symlink), and raises `WorkspaceArchiveWriteError(context={"reason": "workspace_root_removal_refused"})`.
- `BaseSandboxSession.rm()` and `UnixLocalSandboxSession.rm()` call it after path validation and before any exec or filesystem mutation.
- `rm` of entries under the root is unchanged.

### Test plan

- `tests/sandbox/test_session_utils.py::test_rm_refuses_to_remove_the_workspace_root` (exec-backed base, five spellings of the root, asserts no `rm` command is executed) and `tests/sandbox/test_unix_local.py::TestUnixLocalRmWorkspaceRoot` (real filesystem, asserts the workspace and its contents survive). Ten parametrized cases fail on `main` and pass with this change; the companion tests assert `rm` of a child entry still works.
- `tests/sandbox/test_unix_local.py`, `tests/sandbox/test_session_utils.py`, `ruff`, `mypy`, and `pyright` on the changed files pass locally (Linux, Python 3.10).

Note: this touches the same `rm()` in `unix_local.py` as #4830 (leaf-symlink removal); the two changes are independent and either can be rebased trivially onto the other.

Verification stack: `make format`/`ruff check` clean, `mypy` and `pyright` clean on the changed files, focused suites plus `tests/sandbox` pass on Linux/Python 3.10. The repository-wide `mypy src` reports pre-existing errors on Python 3.10 (`archive_ops.py` SpooledTemporaryFile typing, `run_loop.py` BaseExceptionGroup export) that are unrelated to this PR, so the full-stack checkbox is left unchecked.

### Issue number

None (found while auditing the UnixLocal / Docker sandbox file operations).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run the verification steps from `.agents/skills/code-change-verification` individually (format, lint, typecheck on changed files, tests)
- [ ] I've confirmed all verification steps pass (see Test plan: pre-existing Python 3.10 `mypy` errors outside this change)
- [ ] If using Codex, I've run `/review` before submitting this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BN4v25msJgrjNgac97g1Az
