### PR TITLE
fix(sandbox): let UnixLocal ls list a regular file like the other backends

### DIFF
--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -915,13 +915,19 @@ class UnixLocalSandboxSession(BaseSandboxSession):
     def _requested_leaf_path(self, path: Path | str, normalized: Path) -> Path:
         """Return the validated entry without following a leaf symlink.
 
-        `normalized` has already validated `path` (resolving every symlink); keep the leaf
-        name so a symlink is reported as itself, the way `ls -la <link>` prints it.
+        `normalized` has already validated `path` through its resolved target, so this only
+        rebuilds where the entry itself lives (parents resolved, leaf kept) for `lstat()` and
+        for the reported path; it must not demand authority over the parent, which an
+        exact-file grant does not confer.
         """
         raw_path = Path(path)
         if raw_path.name in ("", ".", ".."):
             return normalized
-        return self.normalize_path(raw_path.parent) / raw_path.name
+        absolute = raw_path if raw_path.is_absolute() else Path(self.state.manifest.root) / raw_path
+        return absolute.parent.resolve(strict=False) / absolute.name
+
+    async def _validate_listing_path(self, path: Path | str) -> Path:
+        return self._requested_leaf_path(path, self.normalize_path(path))
 
     async def ls(
         self,

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -35,7 +35,6 @@ from ..errors import (
     ExecNonZeroError,
     ExecTimeoutError,
     ExecTransportError,
-    InvalidManifestPathError,
     WorkspaceArchiveReadError,
     WorkspaceArchiveWriteError,
     WorkspaceReadNotFoundError,
@@ -70,7 +69,7 @@ from ..util.tar_utils import (
     safe_extract_tarfile,
     should_skip_tar_member,
 )
-from ..workspace_paths import _raise_if_filesystem_root
+from ..workspace_paths import _raise_if_filesystem_root, coerce_posix_path
 
 _DEFAULT_WORKSPACE_PREFIX = "sandbox-local-"
 _DEFAULT_MANIFEST_ROOT = cast(str, Manifest.model_fields["root"].default)
@@ -913,27 +912,23 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         policy = self._workspace_path_policy()
         return policy.normalize_path(path, for_write=for_write, resolve_symlinks=True)
 
-    def _requested_leaf_path(self, path: Path | str, normalized: Path) -> Path:
-        """Return the validated entry without following a leaf symlink.
+    def _requested_leaf_path(self, path: Path | str) -> Path:
+        """Validate `path` and return the entry itself without following a leaf symlink.
 
-        `normalized` has already validated `path` through its resolved target. Rebuild where
-        the entry itself lives from the policy's canonical lexical path (so `link/../x` names
-        `x` under the workspace, as validation saw it, and never re-follows `link`), resolving
-        only the parents and keeping the leaf for `lstat()` and the reported path. This does
-        not demand authority over the parent, which an exact-file grant does not confer.
+        One POSIX identity of the input serves both checks: the fully resolved target must be
+        confined (an escaping link is rejected as before), and then the leaf's own location,
+        with only its parents resolved, must be under the workspace root or an extra grant.
+        The leaf is reported as itself, the way `ls -la <link>` prints it, so a symlink keeps
+        its kind and path, including under a symlinked Manifest.root.
         """
-        try:
-            canonical = self._workspace_path_policy().normalize_path(path)
-        except InvalidManifestPathError:
-            # The lexical form is not under the configured root (e.g. a path already resolved
-            # through a symlinked Manifest.root); the resolved path is the best we have.
-            return normalized
-        if not canonical.name:
-            return normalized
-        return canonical.parent.resolve(strict=False) / canonical.name
+        canonical = coerce_posix_path(path)
+        self.normalize_path(canonical.as_posix())
+        return self._workspace_path_policy().normalize_path(
+            canonical, resolve_symlinks=True, follow_leaf_symlink=False
+        )
 
     async def _validate_listing_path(self, path: Path | str) -> Path:
-        return self._requested_leaf_path(path, self.normalize_path(path))
+        return self._requested_leaf_path(path)
 
     async def ls(
         self,
@@ -944,7 +939,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         if user is not None:
             return await super().ls(path, user=user)
 
-        requested = self._requested_leaf_path(path, self.normalize_path(path))
+        requested = self._requested_leaf_path(path)
         command = ("ls", "-la", "--", str(requested))
         try:
             # Match `ls -la <path>`: a directory lists its entries; anything else, including a

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -35,6 +35,7 @@ from ..errors import (
     ExecNonZeroError,
     ExecTimeoutError,
     ExecTransportError,
+    InvalidManifestPathError,
     WorkspaceArchiveReadError,
     WorkspaceArchiveWriteError,
     WorkspaceReadNotFoundError,
@@ -915,16 +916,21 @@ class UnixLocalSandboxSession(BaseSandboxSession):
     def _requested_leaf_path(self, path: Path | str, normalized: Path) -> Path:
         """Return the validated entry without following a leaf symlink.
 
-        `normalized` has already validated `path` through its resolved target, so this only
-        rebuilds where the entry itself lives (parents resolved, leaf kept) for `lstat()` and
-        for the reported path; it must not demand authority over the parent, which an
-        exact-file grant does not confer.
+        `normalized` has already validated `path` through its resolved target. Rebuild where
+        the entry itself lives from the policy's canonical lexical path (so `link/../x` names
+        `x` under the workspace, as validation saw it, and never re-follows `link`), resolving
+        only the parents and keeping the leaf for `lstat()` and the reported path. This does
+        not demand authority over the parent, which an exact-file grant does not confer.
         """
-        raw_path = Path(path)
-        if raw_path.name in ("", ".", ".."):
+        try:
+            canonical = self._workspace_path_policy().normalize_path(path)
+        except InvalidManifestPathError:
+            # The lexical form is not under the configured root (e.g. a path already resolved
+            # through a symlinked Manifest.root); the resolved path is the best we have.
             return normalized
-        absolute = raw_path if raw_path.is_absolute() else Path(self.state.manifest.root) / raw_path
-        return absolute.parent.resolve(strict=False) / absolute.name
+        if not canonical.name:
+            return normalized
+        return canonical.parent.resolve(strict=False) / canonical.name
 
     async def _validate_listing_path(self, path: Path | str) -> Path:
         return self._requested_leaf_path(path, self.normalize_path(path))
@@ -938,16 +944,16 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         if user is not None:
             return await super().ls(path, user=user)
 
-        normalized = self.normalize_path(path)
-        command = ("ls", "-la", "--", str(normalized))
+        requested = self._requested_leaf_path(path, self.normalize_path(path))
+        command = ("ls", "-la", "--", str(requested))
         try:
-            if not normalized.is_dir():
-                # `ls -la <file>` lists the entry itself, and for a symlink that is the link,
-                # not its target; the exec-backed sessions return that single entry, so do
-                # the same instead of failing with ENOTDIR.
-                requested = self._requested_leaf_path(path, normalized)
-                return [_unix_file_entry(str(requested), requested.lstat())]
-            with os.scandir(normalized) as entries:
+            # Match `ls -la <path>`: a directory lists its entries; anything else, including a
+            # symlink (even one to a directory), is reported as the single entry itself. The
+            # exec-backed sessions return the same shape.
+            stat_result = requested.lstat()
+            if not stat.S_ISDIR(stat_result.st_mode):
+                return [_unix_file_entry(str(requested), stat_result)]
+            with os.scandir(requested) as entries:
                 return [
                     _unix_file_entry(entry.path, entry.stat(follow_symlinks=False))
                     for entry in entries

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -912,6 +912,17 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         policy = self._workspace_path_policy()
         return policy.normalize_path(path, for_write=for_write, resolve_symlinks=True)
 
+    def _requested_leaf_path(self, path: Path | str, normalized: Path) -> Path:
+        """Return the validated entry without following a leaf symlink.
+
+        `normalized` has already validated `path` (resolving every symlink); keep the leaf
+        name so a symlink is reported as itself, the way `ls -la <link>` prints it.
+        """
+        raw_path = Path(path)
+        if raw_path.name in ("", ".", ".."):
+            return normalized
+        return self.normalize_path(raw_path.parent) / raw_path.name
+
     async def ls(
         self,
         path: Path | str,
@@ -925,9 +936,11 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         command = ("ls", "-la", "--", str(normalized))
         try:
             if not normalized.is_dir():
-                # `ls -la <file>` lists the file itself; the exec-backed sessions return that
-                # single entry, so do the same instead of failing with ENOTDIR.
-                return [_unix_file_entry(str(normalized), normalized.lstat())]
+                # `ls -la <file>` lists the entry itself, and for a symlink that is the link,
+                # not its target; the exec-backed sessions return that single entry, so do
+                # the same instead of failing with ENOTDIR.
+                requested = self._requested_leaf_path(path, normalized)
+                return [_unix_file_entry(str(requested), requested.lstat())]
             with os.scandir(normalized) as entries:
                 return [
                     _unix_file_entry(entry.path, entry.stat(follow_symlinks=False))

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -15,6 +15,7 @@ import os
 import shlex
 import shutil
 import signal
+import stat
 import tarfile
 import tempfile
 import termios
@@ -110,6 +111,26 @@ def _mount_path_diagnostic_extra(mount_path: Path) -> dict[str, object]:
 def _close_fd_quietly(fd: int) -> None:
     with suppress(OSError):
         os.close(fd)
+
+
+def _unix_file_entry(path: str, stat_result: os.stat_result) -> FileEntry:
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        kind = EntryKind.SYMLINK
+    elif stat.S_ISDIR(mode):
+        kind = EntryKind.DIRECTORY
+    elif stat.S_ISREG(mode):
+        kind = EntryKind.FILE
+    else:
+        kind = EntryKind.OTHER
+    return FileEntry(
+        path=path,
+        permissions=Permissions.from_mode(mode),
+        owner=str(stat_result.st_uid),
+        group=str(stat_result.st_gid),
+        size=stat_result.st_size,
+        kind=kind,
+    )
 
 
 def _restore_pty_child_signal_defaults() -> None:
@@ -903,29 +924,15 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         normalized = self.normalize_path(path)
         command = ("ls", "-la", "--", str(normalized))
         try:
+            if not normalized.is_dir():
+                # `ls -la <file>` lists the file itself; the exec-backed sessions return that
+                # single entry, so do the same instead of failing with ENOTDIR.
+                return [_unix_file_entry(str(normalized), normalized.lstat())]
             with os.scandir(normalized) as entries:
-                listed: list[FileEntry] = []
-                for entry in entries:
-                    stat_result = entry.stat(follow_symlinks=False)
-                    if entry.is_symlink():
-                        kind = EntryKind.SYMLINK
-                    elif entry.is_dir(follow_symlinks=False):
-                        kind = EntryKind.DIRECTORY
-                    elif entry.is_file(follow_symlinks=False):
-                        kind = EntryKind.FILE
-                    else:
-                        kind = EntryKind.OTHER
-                    listed.append(
-                        FileEntry(
-                            path=entry.path,
-                            permissions=Permissions.from_mode(stat_result.st_mode),
-                            owner=str(stat_result.st_uid),
-                            group=str(stat_result.st_gid),
-                            size=stat_result.st_size,
-                            kind=kind,
-                        )
-                    )
-                return listed
+                return [
+                    _unix_file_entry(entry.path, entry.stat(follow_symlinks=False))
+                    for entry in entries
+                ]
         except OSError as e:
             raise ExecNonZeroError(
                 ExecResult(stdout=b"", stderr=str(e).encode("utf-8"), exit_code=1),

--- a/src/agents/sandbox/session/base_sandbox_session.py
+++ b/src/agents/sandbox/session/base_sandbox_session.py
@@ -830,6 +830,10 @@ class BaseSandboxSession(abc.ABC):
     async def _validate_path_access(self, path: Path | str, *, for_write: bool = False) -> Path:
         return self.normalize_path(path, for_write=for_write)
 
+    async def _validate_listing_path(self, path: Path | str) -> Path:
+        """Validate the path ``ls`` lists; backends that resolve symlinks keep the leaf."""
+        return await self._validate_path_access(path)
+
     async def _validate_remote_path_access(
         self,
         path: Path | str,
@@ -1112,7 +1116,7 @@ class BaseSandboxSession(abc.ABC):
         :param user: Optional sandbox user to list as.
         :returns: A list of `FileEntry` objects.
         """
-        path = await self._validate_path_access(path)
+        path = await self._validate_listing_path(path)
 
         path_arg = sandbox_path_str(path)
         cmd = ("ls", "-la", "--", path_arg)

--- a/src/agents/sandbox/types.py
+++ b/src/agents/sandbox/types.py
@@ -51,7 +51,7 @@ class Permissions(BaseModel):
             owner=(mode >> 6) & 0b111,
             group=(mode >> 3) & 0b111,
             other=(mode >> 0) & 0b111,
-            directory=bool(mode & stat.S_IFDIR),
+            directory=stat.S_ISDIR(mode),
         )
 
     @classmethod

--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -368,11 +368,15 @@ class WorkspacePathPolicy:
         *,
         for_write: bool = False,
         resolve_symlinks: bool = False,
+        follow_leaf_symlink: bool = True,
     ) -> Path:
         """Return a validated absolute path under the workspace or an extra grant.
 
         `resolve_symlinks` follows symlinks on the host filesystem. Use it only when the sandbox
         workspace is a real local host directory, such as UnixLocalSandboxSession.
+        With `follow_leaf_symlink=False`, only the parent directories are resolved and the
+        final path component is kept as the entry itself, so an operation on a symlink (such as
+        listing or removing it) is validated at the link's own location rather than its target.
         """
 
         if resolve_symlinks:
@@ -382,7 +386,9 @@ class WorkspacePathPolicy:
                     raise self._invalid_path_error(windows_path)
             else:
                 original = Path(path)
-            result, grant = self._resolved_host_path_and_grant(original)
+            result, grant = self._resolved_host_path_and_grant(
+                original, follow_leaf_symlink=follow_leaf_symlink
+            )
         else:
             if (windows_path := windows_absolute_path(path)) is not None:
                 native_path = _native_path_from_windows_absolute(windows_path)
@@ -427,13 +433,19 @@ class WorkspacePathPolicy:
     def _resolved_host_path_and_grant(
         self,
         original: Path,
+        *,
+        follow_leaf_symlink: bool = True,
     ) -> tuple[Path, SandboxPathGrant | None]:
         workspace_root = self._root.resolve(strict=False)
         if original.is_absolute():
-            resolved = original.resolve(strict=False)
+            absolute_path = original
         else:
             absolute = self._absolute_workspace_posix_path(coerce_posix_path(original))
-            resolved = Path(str(absolute)).resolve(strict=False)
+            absolute_path = Path(str(absolute))
+        if follow_leaf_symlink or absolute_path.name in ("", ".", ".."):
+            resolved = absolute_path.resolve(strict=False)
+        else:
+            resolved = absolute_path.parent.resolve(strict=False) / absolute_path.name
 
         if self._is_under(resolved, workspace_root):
             return resolved, None

--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -447,7 +447,7 @@ class WorkspacePathPolicy:
         if (
             follow_leaf_symlink
             or absolute_path.name in ("", ".", "..")
-            or absolute_path == self._root
+            or absolute_path == Path(self._normalized_root().as_posix())
         ):
             resolved = absolute_path.resolve(strict=False)
         else:

--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -442,7 +442,13 @@ class WorkspacePathPolicy:
         else:
             absolute = self._absolute_workspace_posix_path(coerce_posix_path(original))
             absolute_path = Path(str(absolute))
-        if follow_leaf_symlink or absolute_path.name in ("", ".", ".."):
+        # The workspace root itself is always addressed through its resolved form, so a
+        # symlinked root alias stays authorized; only entries below it keep their leaf.
+        if (
+            follow_leaf_symlink
+            or absolute_path.name in ("", ".", "..")
+            or absolute_path == self._root
+        ):
             resolved = absolute_path.resolve(strict=False)
         else:
             resolved = absolute_path.parent.resolve(strict=False) / absolute_path.name

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -13,7 +13,8 @@ from typing import cast
 import pytest
 
 from agents.sandbox import SandboxPathGrant
-from agents.sandbox.errors import PtySessionNotFoundError
+from agents.sandbox.errors import ExecNonZeroError, PtySessionNotFoundError
+from agents.sandbox.files import EntryKind
 from agents.sandbox.manifest import Environment, Manifest
 from agents.sandbox.sandboxes import unix_local as unix_local_module
 from agents.sandbox.sandboxes.unix_local import (
@@ -468,6 +469,46 @@ class TestUnixLocalUserScopedFilesystem:
         assert session.exec_commands[0][4:6] == ("sh", "-lc")
         assert session.exec_commands[0][-2:] == (str(target), "0")
         assert not any(part.startswith("rm ") for part in session.exec_commands[0])
+
+
+class TestUnixLocalLs:
+    @pytest.mark.asyncio
+    async def test_ls_of_a_regular_file_returns_that_entry(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "plain.txt").write_text("hello", encoding="utf-8")
+        session = _RecordingUnixLocalSession(workspace)
+
+        entries = await session.ls("plain.txt")
+
+        assert [(entry.kind, entry.path, entry.size) for entry in entries] == [
+            (EntryKind.FILE, str(workspace / "plain.txt"), len("hello"))
+        ]
+
+    @pytest.mark.asyncio
+    async def test_ls_of_a_directory_lists_entries_with_kinds(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "sub").mkdir(parents=True)
+        (workspace / "plain.txt").write_text("hello", encoding="utf-8")
+        (workspace / "link").symlink_to("plain.txt")
+        session = _RecordingUnixLocalSession(workspace)
+
+        entries = await session.ls(".")
+
+        assert {Path(entry.path).name: entry.kind for entry in entries} == {
+            "sub": EntryKind.DIRECTORY,
+            "plain.txt": EntryKind.FILE,
+            "link": EntryKind.SYMLINK,
+        }
+
+    @pytest.mark.asyncio
+    async def test_ls_of_a_missing_path_still_fails(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        session = _RecordingUnixLocalSession(workspace)
+
+        with pytest.raises(ExecNonZeroError):
+            await session.ls("missing")
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -536,6 +536,40 @@ class TestUnixLocalLs:
         ]
 
     @pytest.mark.asyncio
+    async def test_ls_as_user_lists_the_link_itself(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "plain.txt").write_text("hello", encoding="utf-8")
+        (workspace / "link").symlink_to("plain.txt")
+        session = _RecordingUnixLocalSession(workspace)
+
+        await session.ls("link", user=User(name="sandbox-user"))
+
+        assert len(session.exec_commands) == 1
+        assert session.exec_commands[0][:4] == ("sudo", "-u", "sandbox-user", "--")
+        assert session.exec_commands[0][4:] == ("ls", "-la", "--", str(workspace / "link"))
+
+    @pytest.mark.asyncio
+    async def test_ls_of_a_file_covered_by_an_exact_grant(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        granted = tmp_path / "outside.txt"
+        granted.write_text("granted", encoding="utf-8")
+        session = UnixLocalSandboxSession(
+            state=UnixLocalSandboxSessionState(
+                manifest=Manifest(
+                    root=str(workspace),
+                    extra_path_grants=(SandboxPathGrant(path=str(granted), read_only=True),),
+                ),
+                snapshot=NoopSnapshot(id="noop"),
+            )
+        )
+
+        entries = await session.ls(str(granted))
+
+        assert [(entry.kind, entry.path) for entry in entries] == [(EntryKind.FILE, str(granted))]
+
+    @pytest.mark.asyncio
     async def test_ls_of_a_directory_lists_entries_with_kinds(self, tmp_path: Path) -> None:
         workspace = tmp_path / "workspace"
         (workspace / "sub").mkdir(parents=True)

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -15,7 +15,11 @@ from typing import cast
 import pytest
 
 from agents.sandbox import SandboxPathGrant
-from agents.sandbox.errors import ExecNonZeroError, PtySessionNotFoundError
+from agents.sandbox.errors import (
+    ExecNonZeroError,
+    InvalidManifestPathError,
+    PtySessionNotFoundError,
+)
 from agents.sandbox.files import EntryKind
 from agents.sandbox.manifest import Environment, Manifest
 from agents.sandbox.sandboxes import unix_local as unix_local_module
@@ -606,6 +610,61 @@ class TestUnixLocalLs:
         entries = await session.ls("link/../secret")
         assert [(entry.kind, entry.path) for entry in entries] == [
             (EntryKind.FILE, str(workspace / "secret"))
+        ]
+
+    @pytest.mark.asyncio
+    async def test_ls_rejects_a_leaf_that_lives_outside_the_workspace(self, tmp_path: Path) -> None:
+        """`jump/back` resolves back inside the workspace, but the entry itself lives in an
+        ungranted directory; its metadata must not be read."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "inside.txt").write_text("inside", encoding="utf-8")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "back").symlink_to(workspace / "inside.txt")
+        (workspace / "jump").symlink_to(outside)
+        session = _RecordingUnixLocalSession(workspace)
+
+        with pytest.raises(InvalidManifestPathError):
+            await session.ls("jump/back")
+
+    @pytest.mark.asyncio
+    async def test_ls_treats_backslashes_as_separators_for_both_checks(
+        self, tmp_path: Path
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "sub").mkdir(parents=True)
+        (workspace / "sub" / "file.txt").write_text("x", encoding="utf-8")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret").write_text("secret", encoding="utf-8")
+        (workspace / "link").symlink_to(outside)
+        session = _RecordingUnixLocalSession(workspace)
+
+        entries = await session.ls("sub\\file.txt")
+        assert [(entry.kind, entry.path) for entry in entries] == [
+            (EntryKind.FILE, str(workspace / "sub" / "file.txt"))
+        ]
+        with pytest.raises(InvalidManifestPathError):
+            await session.ls("link\\secret")
+
+    @pytest.mark.asyncio
+    async def test_ls_keeps_a_leaf_symlink_addressed_through_the_resolved_root(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        real_root = tmp_path / "ws"
+        real_root.mkdir()
+        root_link = tmp_path / "ws-link"
+        root_link.symlink_to(real_root)
+        (real_root / "plain.txt").write_text("x", encoding="utf-8")
+        (real_root / "link").symlink_to("plain.txt")
+        session = _RecordingUnixLocalSession(root_link)
+
+        entries = await session.ls(str(real_root / "link"))
+
+        assert [(entry.kind, entry.path) for entry in entries] == [
+            (EntryKind.SYMLINK, str(real_root / "link"))
         ]
 
     @pytest.mark.asyncio

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -570,6 +570,45 @@ class TestUnixLocalLs:
         assert [(entry.kind, entry.path) for entry in entries] == [(EntryKind.FILE, str(granted))]
 
     @pytest.mark.asyncio
+    async def test_ls_of_a_directory_symlink_returns_the_link_itself(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        (workspace / "realdir").mkdir(parents=True)
+        (workspace / "realdir" / "inner.txt").write_text("x", encoding="utf-8")
+        (workspace / "linkdir").symlink_to("realdir")
+        session = _RecordingUnixLocalSession(workspace)
+
+        entries = await session.ls("linkdir")
+
+        assert [(entry.kind, entry.path) for entry in entries] == [
+            (EntryKind.SYMLINK, str(workspace / "linkdir"))
+        ]
+        assert {Path(entry.path).name for entry in await session.ls("realdir")} == {"inner.txt"}
+
+    @pytest.mark.asyncio
+    async def test_ls_never_rebuilds_the_leaf_through_a_symlinked_parent(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`link/../secret` is validated as `<root>/secret`; the leaf must be rebuilt from that
+        canonical path rather than by following `link` and stepping out of the workspace."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret").write_text("secret", encoding="utf-8")
+        (workspace / "link").symlink_to(outside)
+        session = _RecordingUnixLocalSession(workspace)
+
+        with pytest.raises(ExecNonZeroError):
+            await session.ls("link/../secret")
+
+        (workspace / "secret").write_text("inside", encoding="utf-8")
+        entries = await session.ls("link/../secret")
+        assert [(entry.kind, entry.path) for entry in entries] == [
+            (EntryKind.FILE, str(workspace / "secret"))
+        ]
+
+    @pytest.mark.asyncio
     async def test_ls_of_a_directory_lists_entries_with_kinds(self, tmp_path: Path) -> None:
         workspace = tmp_path / "workspace"
         (workspace / "sub").mkdir(parents=True)

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import io
 import signal
+import socket
+import stat
 import tarfile
 import threading
 import time
@@ -24,7 +26,7 @@ from agents.sandbox.sandboxes.unix_local import (
     _UnixPtyProcessEntry,
 )
 from agents.sandbox.snapshot import NoopSnapshot
-from agents.sandbox.types import ExecResult, User
+from agents.sandbox.types import ExecResult, Permissions, User
 
 
 class _RecordingUnixLocalSession(UnixLocalSandboxSession):
@@ -471,6 +473,23 @@ class TestUnixLocalUserScopedFilesystem:
         assert not any(part.startswith("rm ") for part in session.exec_commands[0])
 
 
+@pytest.mark.parametrize(
+    ("mode", "directory"),
+    [
+        (stat.S_IFDIR | 0o755, True),
+        (stat.S_IFREG | 0o644, False),
+        (stat.S_IFLNK | 0o777, False),
+        (stat.S_IFSOCK | 0o755, False),  # S_IFSOCK shares the S_IFDIR bit
+        (stat.S_IFBLK | 0o660, False),  # so does S_IFBLK
+    ],
+)
+def test_permissions_from_mode_uses_the_file_type_not_a_bit_mask(
+    mode: int,
+    directory: bool,
+) -> None:
+    assert Permissions.from_mode(mode).directory is directory
+
+
 class TestUnixLocalLs:
     @pytest.mark.asyncio
     async def test_ls_of_a_regular_file_returns_that_entry(self, tmp_path: Path) -> None:
@@ -483,6 +502,37 @@ class TestUnixLocalLs:
 
         assert [(entry.kind, entry.path, entry.size) for entry in entries] == [
             (EntryKind.FILE, str(workspace / "plain.txt"), len("hello"))
+        ]
+
+    @pytest.mark.asyncio
+    async def test_ls_of_a_file_symlink_returns_the_link_itself(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "plain.txt").write_text("hello", encoding="utf-8")
+        (workspace / "link").symlink_to("plain.txt")
+        session = _RecordingUnixLocalSession(workspace)
+
+        entries = await session.ls("link")
+
+        assert [(entry.kind, entry.path) for entry in entries] == [
+            (EntryKind.SYMLINK, str(workspace / "link"))
+        ]
+
+    @pytest.mark.asyncio
+    async def test_ls_of_a_socket_is_not_reported_as_a_directory(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        sock = socket.socket(socket.AF_UNIX)
+        try:
+            sock.bind(str(workspace / "dev.sock"))
+        finally:
+            sock.close()
+        session = _RecordingUnixLocalSession(workspace)
+
+        entries = await session.ls("dev.sock")
+
+        assert [(entry.kind, entry.permissions.directory) for entry in entries] == [
+            (EntryKind.OTHER, False)
         ]
 
     @pytest.mark.asyncio

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -669,17 +669,22 @@ class TestUnixLocalLs:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("root_spelling", [".", "", "{alias}", "{alias}/"])
+    @pytest.mark.parametrize("configured_root", ["{alias}", "{dummy}/../ws-link"])
     async def test_ls_lists_a_symlinked_workspace_root(
         self,
         tmp_path: Path,
         root_spelling: str,
+        configured_root: str,
     ) -> None:
         real_root = tmp_path / "ws"
         real_root.mkdir()
         root_link = tmp_path / "ws-link"
         root_link.symlink_to(real_root)
+        (tmp_path / "dummy").mkdir()
         (real_root / "plain.txt").write_text("x", encoding="utf-8")
-        session = _RecordingUnixLocalSession(root_link)
+        session = _RecordingUnixLocalSession(
+            Path(configured_root.format(alias=root_link, dummy=tmp_path / "dummy"))
+        )
 
         entries = await session.ls(root_spelling.format(alias=root_link))
 

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -668,6 +668,24 @@ class TestUnixLocalLs:
         ]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("root_spelling", [".", "", "{alias}", "{alias}/"])
+    async def test_ls_lists_a_symlinked_workspace_root(
+        self,
+        tmp_path: Path,
+        root_spelling: str,
+    ) -> None:
+        real_root = tmp_path / "ws"
+        real_root.mkdir()
+        root_link = tmp_path / "ws-link"
+        root_link.symlink_to(real_root)
+        (real_root / "plain.txt").write_text("x", encoding="utf-8")
+        session = _RecordingUnixLocalSession(root_link)
+
+        entries = await session.ls(root_spelling.format(alias=root_link))
+
+        assert [Path(entry.path).name for entry in entries] == ["plain.txt"]
+
+    @pytest.mark.asyncio
     async def test_ls_of_a_directory_lists_entries_with_kinds(self, tmp_path: Path) -> None:
         workspace = tmp_path / "workspace"
         (workspace / "sub").mkdir(parents=True)


### PR DESCRIPTION
### Summary

This pull request fixes `UnixLocalSandboxSession.ls()` so that listing a regular file returns that file's entry, matching the exec-backed session implementation.

#### Bug

`BaseSandboxSession.ls()` (every exec-backed backend) runs `ls -la -- <path>` and parses the output, so `ls("plain.txt")` returns a single `FileEntry` for the file. `UnixLocalSandboxSession.ls()` called `os.scandir()` on the validated path unconditionally, so the same call failed:

```
ExecNonZeroError: [Errno 20] Not a directory: '/tmp/sandbox-local-…/plain.txt'
```

Reproduced on `main` with a real `UnixLocalSandboxClient` session; the same request against the base implementation (verified by feeding real `ls -la <file>` output through `parse_ls_la`) yields `[('file', '/…/plain.txt')]`.

#### Fix

- When the validated path is not a directory, return one entry built from its `lstat()` result instead of calling `os.scandir()`.
- Build `FileEntry` values from `stat_result` in a small helper (`_unix_file_entry`) used by both the single-entry and the directory branch, deriving the kind via `stat.S_ISLNK` / `S_ISDIR` / `S_ISREG`; directory listings are unchanged.
- Missing paths still raise `ExecNonZeroError` from the `OSError` path as before.

#### Behavior changes

- `ls("<regular file>")` returns that file's entry instead of raising `ExecNonZeroError` (the fix).
- `ls("<symlink>")` reports the symlink itself (`EntryKind.SYMLINK`, the link's own path), including a symlink to a directory, which previously listed the target directory's contents in the direct branch. This matches `ls -la <path>` on the exec-backed sessions and is now identical with and without `user=`.
- `Permissions.from_mode()` reports `directory=False` for sockets and block devices (it used `mode & S_IFDIR`, which those file types also set).

### Test plan

- `tests/sandbox/test_unix_local.py::TestUnixLocalLs` covers the regular-file case (fails on `main`), a directory listing with file / directory / symlink kinds, and a missing path.
- `tests/sandbox/test_unix_local.py`, `ruff`, `mypy`, and `pyright` on the changed files pass locally (Linux, Python 3.10).

Verification stack: `make format`/`ruff check` clean, `mypy` and `pyright` clean on the changed files, focused suites plus `tests/sandbox` pass on Linux/Python 3.10. The repository-wide `mypy src` reports pre-existing errors on Python 3.10 (`archive_ops.py` SpooledTemporaryFile typing, `run_loop.py` BaseExceptionGroup export) that are unrelated to this PR, so the full-stack checkbox is left unchecked.

### Issue number

None (found while auditing the UnixLocal / Docker sandbox file operations).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run the verification steps from `.agents/skills/code-change-verification` individually (format, lint, typecheck on changed files, tests)
- [ ] I've confirmed all verification steps pass (see Test plan: pre-existing Python 3.10 `mypy` errors outside this change)
- [ ] If using Codex, I've run `/review` before submitting this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BN4v25msJgrjNgac97g1Az

