### PR TITLE
fix(models): report Responses-only settings dropped by Chat Completions

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -75,7 +75,7 @@ class OpenAIChatCompletionsModel(Model):
         self._has_warned_unsupported_prompt = False
         self._has_warned_unsupported_conversation_state = False
         self._has_warned_unsupported_reasoning_settings = False
-        self._has_warned_unsupported_response_settings = False
+        self._warned_unsupported_response_settings: set[str] = set()
 
     def _non_null_or_omit(self, value: Any) -> Any:
         return value if value is not None else omit
@@ -139,21 +139,32 @@ class OpenAIChatCompletionsModel(Model):
         if not unsupported:
             return
 
-        unsupported_params = ", ".join(f"`{name}`" for name in unsupported)
-        message = (
+        if self._strict_feature_validation:
+            raise UserError(self._unsupported_response_settings_message(unsupported))
+
+        # Warn per setting name rather than once overall. A later call that adds a
+        # setting not warned about yet would otherwise be dropped in silence, which is
+        # the behavior this handler exists to report.
+        unwarned = [
+            name for name in unsupported if name not in self._warned_unsupported_response_settings
+        ]
+        if not unwarned:
+            return
+
+        logger.warning(
+            "%s Ignoring them; enable strict feature validation to raise an error instead.",
+            self._unsupported_response_settings_message(unwarned),
+        )
+        self._warned_unsupported_response_settings.update(unwarned)
+
+    @staticmethod
+    def _unsupported_response_settings_message(names: list[str]) -> str:
+        unsupported_params = ", ".join(f"`{name}`" for name in names)
+        return (
             f"OpenAIChatCompletionsModel does not support {unsupported_params}. "
             "These settings are only sent by the Responses API; use a Responses model "
             "instead."
         )
-        if self._strict_feature_validation:
-            raise UserError(message)
-
-        if not self._has_warned_unsupported_response_settings:
-            logger.warning(
-                "%s Ignoring them; enable strict feature validation to raise an error instead.",
-                message,
-            )
-            self._has_warned_unsupported_response_settings = True
 
     def get_retry_advice(self, request: ModelRetryAdviceRequest) -> ModelRetryAdvice | None:
         return get_openai_retry_advice(request)

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -75,6 +75,7 @@ class OpenAIChatCompletionsModel(Model):
         self._has_warned_unsupported_prompt = False
         self._has_warned_unsupported_conversation_state = False
         self._has_warned_unsupported_reasoning_settings = False
+        self._has_warned_unsupported_response_settings = False
 
     def _non_null_or_omit(self, value: Any) -> Any:
         return value if value is not None else omit
@@ -128,6 +129,31 @@ class OpenAIChatCompletionsModel(Model):
                 message,
             )
             self._has_warned_unsupported_reasoning_settings = True
+
+    def _handle_unsupported_response_settings(self, model_settings: ModelSettings) -> None:
+        unsupported = [
+            name
+            for name in ("truncation", "response_include", "context_management")
+            if getattr(model_settings, name, None) is not None
+        ]
+        if not unsupported:
+            return
+
+        unsupported_params = ", ".join(f"`{name}`" for name in unsupported)
+        message = (
+            f"OpenAIChatCompletionsModel does not support {unsupported_params}. "
+            "These settings are only sent by the Responses API; use a Responses model "
+            "instead."
+        )
+        if self._strict_feature_validation:
+            raise UserError(message)
+
+        if not self._has_warned_unsupported_response_settings:
+            logger.warning(
+                "%s Ignoring them; enable strict feature validation to raise an error instead.",
+                message,
+            )
+            self._has_warned_unsupported_response_settings = True
 
     def get_retry_advice(self, request: ModelRetryAdviceRequest) -> ModelRetryAdvice | None:
         return get_openai_retry_advice(request)
@@ -637,6 +663,7 @@ class OpenAIChatCompletionsModel(Model):
     ) -> ChatCompletion | tuple[Response, AsyncStream[ChatCompletionChunk]]:
         self._handle_unsupported_prompt(prompt)
         self._handle_unsupported_reasoning_settings(model_settings)
+        self._handle_unsupported_response_settings(model_settings)
         self._validate_official_openai_input_content_types(input)
         converted_messages = Converter.items_to_messages(
             input,

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -1261,6 +1261,50 @@ def test_chat_completions_warns_once_for_responses_only_reasoning_settings(
     assert "reasoning.context" in caplog.text
 
 
+def test_chat_completions_warns_once_for_responses_only_response_settings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    model = OpenAIChatCompletionsModel(
+        model="gpt-5.6-sol",
+        openai_client=cast(Any, object()),
+    )
+    model_settings = ModelSettings(
+        truncation="auto",
+        response_include=cast(Any, ["reasoning.encrypted_content"]),
+        context_management=cast(Any, [{"type": "transcript_trimming"}]),
+    )
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    model._handle_unsupported_response_settings(model_settings)
+    model._handle_unsupported_response_settings(model_settings)
+
+    assert caplog.text.count("Ignoring them") == 1
+    assert "`truncation`" in caplog.text
+    assert "`response_include`" in caplog.text
+    assert "`context_management`" in caplog.text
+
+
+def test_chat_completions_rejects_responses_only_response_settings_in_strict_mode() -> None:
+    model = OpenAIChatCompletionsModel(
+        model="gpt-5.6-sol",
+        openai_client=cast(Any, object()),
+        strict_feature_validation=True,
+    )
+
+    with pytest.raises(UserError, match="`truncation`"):
+        model._handle_unsupported_response_settings(ModelSettings(truncation="auto"))
+
+
+def test_chat_completions_allows_settings_the_responses_api_owns_when_unset() -> None:
+    model = OpenAIChatCompletionsModel(
+        model="gpt-5.6-sol",
+        openai_client=cast(Any, object()),
+        strict_feature_validation=True,
+    )
+
+    model._handle_unsupported_response_settings(ModelSettings())
+
+
 def test_chat_completions_rejects_responses_only_reasoning_settings_in_strict_mode() -> None:
     model = OpenAIChatCompletionsModel(
         model="gpt-5.6-sol",

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -1284,6 +1284,41 @@ def test_chat_completions_warns_once_for_responses_only_response_settings(
     assert "`context_management`" in caplog.text
 
 
+def test_chat_completions_warns_for_a_response_setting_added_on_a_later_call(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A setting introduced after the first warning must still be reported.
+
+    Suppressing it would drop the setting in silence, which is what this handler
+    exists to prevent.
+    """
+    model = OpenAIChatCompletionsModel(
+        model="gpt-5.6-sol",
+        openai_client=cast(Any, object()),
+    )
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    model._handle_unsupported_response_settings(ModelSettings(truncation="auto"))
+    assert "`truncation`" in caplog.text
+    assert "`context_management`" not in caplog.text
+
+    caplog.clear()
+    model._handle_unsupported_response_settings(
+        ModelSettings(
+            truncation="auto",
+            context_management=cast(Any, [{"type": "transcript_trimming"}]),
+        )
+    )
+
+    # Only the newly introduced setting is named; truncation is not repeated.
+    assert "`context_management`" in caplog.text
+    assert "`truncation`" not in caplog.text
+
+    caplog.clear()
+    model._handle_unsupported_response_settings(ModelSettings(truncation="auto"))
+    assert caplog.text == ""
+
+
 def test_chat_completions_rejects_responses_only_response_settings_in_strict_mode() -> None:
     model = OpenAIChatCompletionsModel(
         model="gpt-5.6-sol",


### PR DESCRIPTION
Closes #4837

## Summary

`ModelSettings.truncation`, `response_include` and `context_management` are read only by `OpenAIResponsesModel`. `OpenAIChatCompletionsModel` never reads them, so setting one on a Chat Completions model did nothing and said nothing.

| Setting | `openai_responses.py` | `openai_chatcompletions.py` |
|---|---|---|
| `truncation` | `:1012` | none |
| `response_include` | `:958-959` | none |
| `context_management` | `:1026` | none |

The one `truncation` match in `openai_chatcompletions.py` is `raise_on_length_truncation` at `:494`, which is a different thing.

## Approach

The file already reports two other Responses-only features rather than dropping them, `_handle_unsupported_prompt` and `_handle_unsupported_reasoning_settings`. This adds a third handler in the same shape, called from the same place as the reasoning one:

- raise `UserError` when `strict_feature_validation` is on
- otherwise log once, guarded by `_has_warned_unsupported_response_settings`
- return immediately when none of the three are set, so a caller who does not use them is unaffected

No public API change, and nothing about request construction changes.

## Tests

`tests/models/test_openai_chatcompletions.py`, mirroring the existing reasoning-settings pair:

- warns once across two calls and names all three settings
- raises `UserError` under strict validation
- stays silent when the settings are unset

Confirmed load-bearing: with `openai_chatcompletions.py` reverted, the first two fail.

## Validation

```bash
uv run pytest tests/models/          # 863 passed
uv run mypy src/agents/models/openai_chatcompletions.py   # clean
uv run ruff check && uv run ruff format --check
```

`uv run mypy src` reports the same 46 pre-existing errors in `extensions/sandbox/` and `voice/` before and after this change; none are in the touched file.
