### PR TITLE
fix(memory): allow base session settings overrides for subclasses

### DIFF
--- a/src/agents/memory/session_settings.py
+++ b/src/agents/memory/session_settings.py
@@ -77,7 +77,12 @@ def _coerce_session_settings(
     settings_type: type[SessionSettings],
 ) -> SessionSettings:
     if isinstance(value, SessionSettings):
-        return value
+        if type(value) is SessionSettings or isinstance(value, settings_type):
+            return value
+        raise TypeError(
+            f"Session settings override must be SessionSettings or an instance of "
+            f"{settings_type.__name__}; got {type(value).__name__}"
+        )
     return coerce_dataclass_config(value, settings_type, parameter_name="session")
 
 

--- a/src/agents/memory/session_settings.py
+++ b/src/agents/memory/session_settings.py
@@ -51,10 +51,10 @@ class SessionSettings:
         override = _coerce_session_settings(override, settings_type=type(self))
 
         changes = {
-            field.name: getattr(override, field.name)
+            field.name: getattr(override, field.name, None)
             for field in fields(self)
             if (override_fields is None or field.name in override_fields)
-            and getattr(override, field.name) is not None
+            and getattr(override, field.name, None) is not None
         }
 
         return replace(self, **changes)
@@ -76,6 +76,8 @@ def _coerce_session_settings(
     *,
     settings_type: type[SessionSettings],
 ) -> SessionSettings:
+    if isinstance(value, SessionSettings):
+        return value
     return coerce_dataclass_config(value, settings_type, parameter_name="session")
 
 

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -962,6 +962,25 @@ async def test_session_settings_resolve():
     assert final_none.limit == 100
 
 
+def test_session_settings_resolve_accepts_base_override_for_subclass() -> None:
+    """A subclass can resolve settings produced by the base RunConfig type."""
+    from pydantic.dataclasses import dataclass
+
+    @dataclass
+    class TenantSessionSettings(SessionSettings):
+        tenant: str = "default"
+
+    base = TenantSessionSettings(limit=100, tenant="acme")
+    run_config = RunConfig(session_settings={"limit": 50})
+
+    final = base.resolve(run_config.session_settings)
+
+    assert isinstance(final, TenantSessionSettings)
+    assert final.limit == 50
+    assert final.tenant == "acme"
+    assert base.limit == 100
+
+
 @pytest.mark.asyncio
 async def test_runner_with_session_settings_override():
     """Test that RunConfig can override session's default settings."""

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -981,6 +981,25 @@ def test_session_settings_resolve_accepts_base_override_for_subclass() -> None:
     assert base.limit == 100
 
 
+def test_session_settings_resolve_rejects_incompatible_subclass_override() -> None:
+    """A subclass must not silently discard fields from a sibling subclass."""
+    from pydantic.dataclasses import dataclass
+
+    @dataclass
+    class TenantSessionSettings(SessionSettings):
+        tenant: str = "default"
+
+    @dataclass
+    class RegionSessionSettings(SessionSettings):
+        region: str = "default"
+
+    base = TenantSessionSettings(limit=100, tenant="acme")
+    override = RegionSessionSettings(limit=50, region="us-east-1")
+
+    with pytest.raises(TypeError, match="TenantSessionSettings"):
+        base.resolve(override)
+
+
 @pytest.mark.asyncio
 async def test_runner_with_session_settings_override():
     """Test that RunConfig can override session's default settings."""


### PR DESCRIPTION
Fixes #4819

### Bug
A session configured with a `SessionSettings` subclass cannot be used with a `RunConfig` session-settings override. The run fails with a `TypeError` when `RunConfig` provides a base `SessionSettings` instance (including the dict form, which `RunConfig` normalizes to the base type).

### Root cause
`SessionSettings.resolve()` coerced every non-dict override to `type(self)`, rejecting a valid base `SessionSettings` instance. It also read subclass-only fields without a default, so a base override could not be overlaid onto a subclass.

### Fix
- Accept any existing `SessionSettings` instance when resolving an override, matching the existing `ModelSettings` behavior.
- Read fields with a `None` default so base settings can be applied while preserving subclass-specific values.
- Add a regression test covering a subclass receiving a `RunConfig`-normalized base override.

### Validation
- `pytest -q tests/memory` (204 passed)
- `pytest -q tests/memory/test_session.py tests/test_run_config.py tests/memory/test_session_limit.py tests/memory/test_openai_conversations_session.py` (154 passed)
- Ruff check and format check passed.
- Mypy passed for the changed code paths.
- Manual end-to-end `Runner.run` reproduction completed successfully with the subclass settings preserved.