### PR TITLE
fix(memory): skip usage for empty sessions

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -635,6 +635,11 @@ class AdvancedSQLiteSession(SQLiteSession):
                 # unrelated removals (e.g. delete_branch on another branch) do
                 # not drop this write.
                 current_turn, branch_id, turn_anchor = self._capture_current_turn()
+                if turn_anchor is None:
+                    # There is no conversation turn to which this usage can belong.
+                    # In particular, do not create a phantom turn 0 row for an empty
+                    # session or a branch whose turns have all been removed.
+                    return
                 # Only update turn-level usage - session usage is aggregated on demand
                 await self._update_turn_usage_internal(
                     current_turn,

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -2103,6 +2103,35 @@ async def test_usage_tracking_storage(agent: Agent, usage_data: Usage):
     session.close()
 
 
+async def test_usage_tracking_skips_empty_session(usage_data: Usage) -> None:
+    """Usage must not create a turn-zero row when the current branch is empty."""
+    session = AdvancedSQLiteSession(session_id="empty_usage_test", create_tables=True)
+
+    await session.store_run_usage(create_mock_run_result(usage_data))
+
+    assert await session.get_items() == []
+    assert await session.get_session_usage() is None
+    assert await session.get_turn_usage() == []
+
+    session.close()
+
+
+async def test_usage_tracking_skips_branch_with_all_turns_popped(usage_data: Usage) -> None:
+    """Usage must not create a row after all turns on the branch are popped."""
+    session = AdvancedSQLiteSession(session_id="popped_usage_test", create_tables=True)
+
+    await session.add_items([{"role": "user", "content": "Removed turn"}])
+    assert await session.pop_item() == {"role": "user", "content": "Removed turn"}
+
+    await session.store_run_usage(create_mock_run_result(usage_data))
+
+    assert await session.get_items() == []
+    assert await session.get_session_usage() is None
+    assert await session.get_turn_usage() == []
+
+    session.close()
+
+
 async def test_failed_usage_write_rolls_back_cached_connection(usage_data: Usage):
     """A swallowed usage-write failure must not strand a transaction or SQLite lock."""
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -2405,6 +2434,7 @@ async def test_usage_tracking_failure_identity_follows_model_data_policy(
     )
     secret = "SECRET_USAGE_FAILURE"
     run_result = create_mock_run_result(usage_data)
+    await session.add_items([{"role": "user", "content": "Usage turn"}])
 
     original_record_factory = logging.getLogRecordFactory()
 


### PR DESCRIPTION
Fixes #4821

## Bug

`AdvancedSQLiteSession.store_run_usage()` could insert a `turn_usage` row for user turn 0 when the current branch had no conversation turn. This made an empty session report usage and `total_turns: 1` even though it contained no items. The same could happen after all turns on a branch were popped.

## Root cause

`_capture_current_turn()` correctly returned `turn_anchor=None` when no `message_structure` row existed, but `store_run_usage()` still passed `current_turn=0` to the write path. The write path only guarded anchored stale writes, so it inserted the phantom row.

## Fix

Return without writing when the captured turn has no anchor. This preserves the existing stale-write protection and prevents usage from being attributed to a nonexistent turn.

## Validation

- `PYTHONPATH=src .../python -m pytest -q tests/extensions/memory/test_advanced_sqlite_session.py` (130 passed)
- `ruff check src/agents/extensions/memory/advanced_sqlite_session.py tests/extensions/memory/test_advanced_sqlite_session.py`
- `ruff format --check src/agents/extensions/memory/advanced_sqlite_session.py tests/extensions/memory/test_advanced_sqlite_session.py`
- `PYTHONPATH=src .../python -m mypy src/agents/extensions/memory/advanced_sqlite_session.py`

The regression tests cover both an initially empty session and a branch whose only turn has been popped.