### PR TITLE
Fix non-bool approval policy results failing open

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -45,6 +45,7 @@ from ..logger import (
 from ..run_context import RunContextWrapper
 from ..tool import ToolErrorFunction
 from ..tool_guardrails import ToolInputGuardrail, ToolOutputGuardrail
+from ..util._approvals import evaluate_needs_approval_setting
 from ..util._types import MaybeAwaitable
 from . import _compat as mcp_compat
 from ._compat import (
@@ -843,10 +844,7 @@ class MCPServer(abc.ABC):
             async def _needs_approval(
                 run_context: RunContextWrapper[Any], _args: dict[str, Any], _call_id: str
             ) -> bool:
-                result = policy(run_context, agent, tool)
-                if inspect.isawaitable(result):
-                    result = await result
-                return bool(result)
+                return await evaluate_needs_approval_setting(policy, run_context, agent, tool)
 
             return _needs_approval
 

--- a/src/agents/util/_approvals.py
+++ b/src/agents/util/_approvals.py
@@ -42,7 +42,7 @@ async def evaluate_needs_approval_setting(
         maybe_result = needs_approval_setting(*args)
         if inspect.isawaitable(maybe_result):
             maybe_result = await maybe_result
-        return bool(maybe_result)
+        return maybe_result if isinstance(maybe_result, bool) else True
     if strict:
         raise UserError(
             f"Invalid needs_approval value: expected a bool or callable, "

--- a/tests/mcp/test_mcp_approval.py
+++ b/tests/mcp/test_mcp_approval.py
@@ -309,3 +309,32 @@ async def test_mcp_require_approval_async_callable_uses_run_context():
         {"needs_approval": True},
         {"needs_approval": False},
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_policy", [False, True], ids=["sync", "async"])
+async def test_mcp_require_approval_callable_non_bool_fails_closed(async_policy: bool):
+    """Callable policies that do not return bool must still require approval."""
+
+    def require_approval(_run_context, _agent, _tool):
+        return None
+
+    async def async_require_approval(_run_context, _agent, _tool):
+        return None
+
+    policy = async_require_approval if async_policy else require_approval
+    server = FakeMCPServer(require_approval=policy)
+    server.add_tool("guarded", {"type": "object", "properties": {}})
+    model = ScriptedModel()
+    agent = Agent(name="TestAgent", model=model, mcp_servers=[server])
+
+    queue_function_call_and_text(
+        model,
+        get_function_tool_call("guarded", "{}"),
+        followup=[get_text_message("done")],
+    )
+
+    first = await Runner.run(agent, "call guarded")
+
+    assert first.interruptions, "non-bool MCP policy result must fail closed"
+    assert server.tool_calls == []

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -3254,6 +3254,33 @@ async def test_execute_tools_handles_tool_approval_items(
     assert_single_approval_interruption(result, tool_name=scenario.expected_tool_name)
 
 
+@pytest.mark.parametrize("policy_result", [None, "approve"], ids=["none", "truthy-non-bool"])
+@pytest.mark.asyncio
+async def test_callable_needs_approval_non_bool_result_fails_closed(policy_result: Any) -> None:
+    tool_calls: list[str] = []
+
+    async def async_needs_approval(
+        _context: RunContextWrapper[Any], _args: dict[str, Any], _call_id: str
+    ) -> Any:
+        return policy_result
+
+    @function_tool(name_override="sensitive_tool", needs_approval=async_needs_approval)
+    def sensitive_tool() -> str:
+        tool_calls.append("ran")
+        return "sensitive result"
+
+    agent = make_agent(tools=[sensitive_tool])
+    tool_call = make_function_tool_call("sensitive_tool", arguments="{}")
+    processed_response = make_processed_response(
+        functions=[ToolRunFunction(function_tool=sensitive_tool, tool_call=tool_call)]
+    )
+
+    result = await run_execute_with_processed_response(agent, processed_response)
+
+    assert_single_approval_interruption(result, tool_name="sensitive_tool")
+    assert tool_calls == []
+
+
 @pytest.mark.asyncio
 async def test_execute_tools_preserves_synthetic_namespace_for_deferred_top_level_approval() -> (
     None


### PR DESCRIPTION
### Summary

Callable `needs_approval` policies are declared to return `bool`, but a non-boolean result such as `None` was coerced with `bool()` and treated as approval not required. This pull request makes every non-boolean callable result fail closed by requiring approval, and routes MCP callable policies through the same evaluator so they cannot bypass the fix.

Fixes #4845

### Test plan

- Added ordinary Runner regression coverage for `None` and truthy non-boolean results from async approval predicates; both cases interrupt before the tool runs.
- Added MCP end-to-end coverage for sync and async policies returning `None`; both cases interrupt and record zero MCP calls.
- Focused tests: 5 passed in `tests/test_run_step_execution.py`, 4 passed in `tests/mcp/test_mcp_approval.py`, and 3 passed in `tests/mcp/test_mcp_util.py`.
- `make format` and `make lint` passed; targeted Ruff, format, mypy, and Pyright checks passed.
- The full repository checks were attempted. Full mypy reported 46 pre-existing errors in 8 files, and full Pyright reported 27 pre-existing errors in sandbox/optional-dependency files. The full non-serial test run reached 6616 passed and 98 skipped, with 38 failures and 40 collection errors caused by missing optional dependencies and existing Windows/sandbox/runloop environment issues. The serial test entry point passed.

### Issue number

Fixes #4845

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR

### AI disclosure

This pull request was prepared with AI assistance. The implementation, tests, and verification results were reviewed before submission.
