### PR TITLE
fix(core): fail closed on non-bool needs_approval predicate results

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -45,6 +45,7 @@ from ..logger import (
 from ..run_context import RunContextWrapper
 from ..tool import ToolErrorFunction
 from ..tool_guardrails import ToolInputGuardrail, ToolOutputGuardrail
+from ..util._approvals import evaluate_needs_approval_setting
 from ..util._types import MaybeAwaitable
 from . import _compat as mcp_compat
 from ._compat import (
@@ -843,10 +844,9 @@ class MCPServer(abc.ABC):
             async def _needs_approval(
                 run_context: RunContextWrapper[Any], _args: dict[str, Any], _call_id: str
             ) -> bool:
-                result = policy(run_context, agent, tool)
-                if inspect.isawaitable(result):
-                    result = await result
-                return bool(result)
+                return await evaluate_needs_approval_setting(
+                    lambda: policy(run_context, agent, tool)
+                )
 
             return _needs_approval
 

--- a/src/agents/util/_approvals.py
+++ b/src/agents/util/_approvals.py
@@ -42,7 +42,11 @@ async def evaluate_needs_approval_setting(
         maybe_result = needs_approval_setting(*args)
         if inspect.isawaitable(maybe_result):
             maybe_result = await maybe_result
-        return bool(maybe_result)
+        # The predicate contract is a bool, so a non-bool result has not answered the
+        # approval question and must fail closed like the other unanswerable cases.
+        if not isinstance(maybe_result, bool):
+            return True
+        return maybe_result
     if strict:
         raise UserError(
             f"Invalid needs_approval value: expected a bool or callable, "

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1605,6 +1605,86 @@ async def test_to_function_tool_async_callable_policy_is_awaited():
     assert needs_approval is True
 
 
+@pytest.mark.parametrize("async_policy", [False, True], ids=["sync", "async"])
+@pytest.mark.asyncio
+async def test_to_function_tool_non_bool_policy_result_requires_approval(async_policy: bool):
+    """A require_approval policy that does not return a bool must require approval."""
+
+    captured: dict[str, Any] = {}
+
+    def sync_policy(
+        run_context: RunContextWrapper[Any],
+        agent: Agent,
+        tool: MCPToolType,
+    ) -> Any:
+        captured["policy_ran"] = True
+        captured["tool"] = tool
+        return None
+
+    async def async_policy(
+        run_context: RunContextWrapper[Any],
+        agent: Agent,
+        tool: MCPToolType,
+    ) -> Any:
+        await asyncio.sleep(0)
+        captured["policy_ran"] = True
+        captured["tool"] = tool
+        return None
+
+    server = FakeMCPServer(require_approval=async_policy if async_policy else sync_policy)
+    tool = MCPTool(name="branch_gap_tool", inputSchema={})
+    agent = Agent(name="test-agent")
+
+    function_tool = MCPUtil.to_function_tool(
+        tool,
+        server,
+        convert_schemas_to_strict=False,
+        agent=agent,
+    )
+
+    assert callable(function_tool.needs_approval)
+
+    run_context = RunContextWrapper(context=None)
+    needs_approval = await function_tool.needs_approval(run_context, {}, "call_none_123")
+
+    assert needs_approval is True
+    assert captured["policy_ran"] is True
+    assert captured["tool"].name == "branch_gap_tool"
+
+
+@pytest.mark.asyncio
+async def test_to_function_tool_sync_bool_policy_result_is_honored():
+    """A sync callable policy returning False must keep the released run behavior."""
+
+    def require_approval(
+        _run_context: RunContextWrapper[Any],
+        _agent: Agent,
+        _tool: MCPToolType,
+    ) -> bool:
+        return False
+
+    server = FakeMCPServer(require_approval=require_approval)
+    tool = MCPTool(name="unguarded_tool", inputSchema={})
+    agent = Agent(name="test-agent")
+
+    function_tool = MCPUtil.to_function_tool(
+        tool,
+        server,
+        convert_schemas_to_strict=False,
+        agent=agent,
+    )
+
+    assert callable(function_tool.needs_approval)
+
+    needs_approval = await function_tool.needs_approval(
+        RunContextWrapper(context=None),
+        {},
+        "call_false_123",
+    )
+
+    assert needs_approval is False
+
+
 @pytest.mark.asyncio
 async def test_mcp_tool_failure_error_function_agent_default():
     """Agent-level failure_error_function should handle MCP tool failures."""

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1605,9 +1605,9 @@ async def test_to_function_tool_async_callable_policy_is_awaited():
     assert needs_approval is True
 
 
-@pytest.mark.parametrize("async_policy", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
 @pytest.mark.asyncio
-async def test_to_function_tool_non_bool_policy_result_requires_approval(async_policy: bool):
+async def test_to_function_tool_non_bool_policy_result_requires_approval(is_async: bool):
     """A require_approval policy that does not return a bool must require approval."""
 
     captured: dict[str, Any] = {}
@@ -1631,7 +1631,7 @@ async def test_to_function_tool_non_bool_policy_result_requires_approval(async_p
         captured["tool"] = tool
         return None
 
-    server = FakeMCPServer(require_approval=async_policy if async_policy else sync_policy)
+    server = FakeMCPServer(require_approval=async_policy if is_async else sync_policy)
     tool = MCPTool(name="branch_gap_tool", inputSchema={})
     agent = Agent(name="test-agent")
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -3210,6 +3210,41 @@ class TestToolCallExecution:
         assert tool_call_event.call_id not in session._pending_tool_calls
 
     @pytest.mark.asyncio
+    async def test_callable_function_approval_fails_closed_for_non_bool_result(
+        self, mock_model
+    ) -> None:
+        tool_inputs: list[str] = []
+
+        async def needs_approval(_ctx: Any, _params: dict[str, Any], _call_id: str) -> Any:
+            return None
+
+        async def invoke_tool(_ctx: ToolContext[Any], raw_arguments: str) -> str:
+            tool_inputs.append(raw_arguments)
+            return "sent"
+
+        tool = FunctionTool(
+            name="send_email",
+            description="Send an email.",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=invoke_tool,
+            needs_approval=needs_approval,
+        )
+        agent = RealtimeAgent(name="agent", tools=[tool])
+        session = RealtimeSession(mock_model, agent, None, run_config={"async_tool_calls": False})
+        tool_call_event = RealtimeModelToolCallEvent(
+            name=tool.name,
+            call_id="call-nonbool",
+            arguments='{"subject": "refund"}',
+        )
+
+        await session._handle_tool_call(tool_call_event)
+
+        assert tool_call_event.call_id in session._pending_tool_calls
+        assert tool_inputs == []
+        approval_event = await session._event_queue.get()
+        assert isinstance(approval_event, RealtimeToolApprovalRequired)
+
+    @pytest.mark.asyncio
     async def test_tool_input_guardrail_rejects_before_realtime_function_execution(
         self, mock_model
     ):

--- a/tests/test_hitl_error_scenarios.py
+++ b/tests/test_hitl_error_scenarios.py
@@ -1000,6 +1000,87 @@ async def test_callable_function_approval_receives_valid_object_arguments() -> N
     assert tool_inputs == [arguments]
 
 
+@pytest.mark.parametrize(
+    "predicate_result",
+    [
+        None,
+        "",
+        0,
+        "needs review",
+    ],
+)
+@pytest.mark.asyncio
+async def test_callable_function_approval_fails_closed_for_non_bool_result(
+    predicate_result: Any,
+) -> None:
+    """A predicate that does not return a bool has not answered and must require approval."""
+    tool_inputs: list[str] = []
+
+    async def needs_approval(_ctx: Any, _params: dict[str, Any], _call_id: str) -> Any:
+        return predicate_result
+
+    async def invoke_tool(_ctx: Any, raw_arguments: str) -> str:
+        tool_inputs.append(raw_arguments)
+        return "sent"
+
+    tool = FunctionTool(
+        name="send_email",
+        description="Send an email.",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=invoke_tool,
+        needs_approval=needs_approval,
+    )
+    model, agent = make_model_and_agent(tools=[tool])
+    model.enqueue(
+        [
+            make_function_tool_call(
+                tool.name, arguments='{"subject": "refund"}', call_id="call-nonbool"
+            )
+        ]
+    )
+
+    result = await Runner.run(agent, "send an email")
+
+    assert len(result.interruptions) == 1
+    assert result.interruptions[0].tool_name == tool.name
+    assert tool_inputs == []
+
+
+@pytest.mark.asyncio
+async def test_sync_callable_function_approval_fails_closed_for_none_result() -> None:
+    """The non-bool fail-closed rule applies to non-awaitable predicate results too."""
+    tool_inputs: list[str] = []
+
+    def needs_approval(_ctx: Any, _params: dict[str, Any], _call_id: str) -> Any:
+        return None
+
+    async def invoke_tool(_ctx: Any, raw_arguments: str) -> str:
+        tool_inputs.append(raw_arguments)
+        return "sent"
+
+    tool = FunctionTool(
+        name="send_email",
+        description="Send an email.",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=invoke_tool,
+        needs_approval=needs_approval,
+    )
+    model, agent = make_model_and_agent(tools=[tool])
+    model.enqueue(
+        [
+            make_function_tool_call(
+                tool.name, arguments='{"subject": "refund"}', call_id="call-nonbool"
+            )
+        ]
+    )
+
+    result = await Runner.run(agent, "send an email")
+
+    assert len(result.interruptions) == 1
+    assert result.interruptions[0].tool_name == tool.name
+    assert tool_inputs == []
+
+
 @pytest.mark.asyncio
 async def test_resume_invalid_needs_approval_raises() -> None:
     """Resume path should surface invalid needs_approval configuration errors."""


### PR DESCRIPTION
### Summary

This pull request fixes #4845 by making a callable `needs_approval` predicate fail closed when its resolved return value is not a `bool`.

A predicate that falls off the end of a branch returns `None`, and `evaluate_needs_approval_setting` coerced the result with `bool()`, so `bool(None)` became `False` and the guarded tool executed without any approval request. Every other unanswerable approval question in the feature already fails closed: a predicate that raises is caught in tool planning, and uninspectable arguments short-circuit to "requires approval" (the fix for #3863 in #3867). A non-bool result is the same kind of non-answer, so the shared helper now treats any resolved non-bool result (for example `None`, `""`, or `0`) as requiring approval.

The change is a 5-line rule in the single shared helper (`src/agents/util/_approvals.py`), so it applies uniformly to Runner function tools, shell tools, apply-patch tools, custom tools, and Realtime sessions. MCP callable `require_approval` policies are routed through the same helper in `src/agents/mcp/server.py`, so a policy returning a non-bool there also fails closed. Behavior for predicates that return actual booleans is unchanged, and truthy non-bool returns keep the released outcome of requesting approval; only falsy non-bool results flip from silent execution to an approval interruption. `strict` continues to govern only invalid setting types, so the `strict=False` Realtime path gets the same fail-closed rule.

A separately timed docs-only PR will extend the existing fail-closed sentence in `docs/human_in_the_loop.md` to cover non-bool results, since that wording describes behavior not yet in a published release.

### Test plan

- Added regression tests in `tests/test_hitl_error_scenarios.py`: parametrized async predicate returning `None`, `""`, `0`, and a truthy string (the truthy case pins the released compat behavior), plus a sync-predicate `None` case, all asserting an approval interruption with the tool not executed.
- Added a Realtime regression test in `tests/realtime/test_session.py` asserting a `None` predicate result produces `RealtimeToolApprovalRequired` and does not invoke the tool.
- Added MCP regression tests in `tests/mcp/test_mcp_util.py`: sync and async `require_approval` policies returning `None` require approval (the policy still runs and receives the tool), and a sync policy returning `False` keeps the released run behavior.
- Verified the issue reproducer: with the fix, the `returns None` row changes from `ran=YES -> no approval requested` to `asked for approval`, while all three control rows are unchanged.
- Focused approval suites pass on both Runner and Realtime paths (including all pre-existing bool-predicate tests).

### Issue number

Fixes #4845

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR