### PR TITLE
fix(tools): fail closed on non-bool approval results

### DIFF
--- a/src/agents/util/_approvals.py
+++ b/src/agents/util/_approvals.py
@@ -42,7 +42,9 @@ async def evaluate_needs_approval_setting(
         maybe_result = needs_approval_setting(*args)
         if inspect.isawaitable(maybe_result):
             maybe_result = await maybe_result
-        return bool(maybe_result)
+        if isinstance(maybe_result, bool):
+            return maybe_result
+        return True
     if strict:
         raise UserError(
             f"Invalid needs_approval value: expected a bool or callable, "

--- a/tests/test_approval_utils.py
+++ b/tests/test_approval_utils.py
@@ -1,0 +1,29 @@
+import pytest
+
+from agents.util._approvals import evaluate_needs_approval_setting
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", [None, 0, "", [], {}])
+async def test_callable_non_bool_falsy_results_fail_closed(result: object) -> None:
+    def policy() -> object:
+        return result
+
+    assert await evaluate_needs_approval_setting(policy) is True
+
+
+@pytest.mark.asyncio
+async def test_async_callable_non_bool_result_fails_closed() -> None:
+    async def policy() -> None:
+        return None
+
+    assert await evaluate_needs_approval_setting(policy) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", [True, False])
+async def test_callable_bool_results_are_preserved(result: bool) -> None:
+    def policy() -> bool:
+        return result
+
+    assert await evaluate_needs_approval_setting(policy) is result


### PR DESCRIPTION
## Summary

Fixes #4845.

Callable `needs_approval` policies are declared to return `bool`, but the approval helper currently coerces any result with `bool()`. A predicate that accidentally returns `None` or another falsy non-bool value therefore becomes `False` and can let a guarded tool run without approval.

This change preserves explicit `True` and `False` results and treats any non-bool callable result as requiring approval. Truthy non-bool results keep their existing effective behaviour, while falsy non-bool results now fail closed.

## Tests

Adds regression coverage for synchronous and asynchronous non-bool results and verifies explicit boolean results are unchanged.