### PR TITLE
fix(core): support homogeneous Unpack varargs

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -12,6 +12,7 @@ from typing import Annotated, Any, Literal, get_args, get_origin, get_type_hints
 from griffe import Docstring, DocstringSectionKind  # type: ignore[import-untyped]
 from pydantic import BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
+from typing_extensions import Unpack
 
 from .exceptions import ModelBehaviorError, UserError
 from .run_context import RunContextWrapper
@@ -436,7 +437,23 @@ def function_schema(
         # Handle different parameter kinds
         if param.kind == param.VAR_POSITIONAL:
             # e.g. *args: extend positional args
-            if get_origin(ann) is tuple:
+            if get_origin(ann) is Unpack:
+                # PEP 646 ``*args: Unpack[tuple[T, ...]]`` means each positional argument
+                # is ``T``. Unwrap it before handing the collected array to Pydantic; otherwise
+                # ``list[Unpack[...]]`` fails schema generation.
+                unpack_args = get_args(ann)
+                unpacked = unpack_args[0] if len(unpack_args) == 1 else None
+                unpacked_tuple_args = get_args(unpacked) if get_origin(unpacked) is tuple else ()
+                if len(unpacked_tuple_args) == 2 and unpacked_tuple_args[1] is Ellipsis:
+                    ann = list[unpacked_tuple_args[0]]  # type: ignore
+                else:
+                    raise UserError(
+                        f"Variadic parameter `*{name}` in function {func.__name__} uses the"
+                        f" unsupported `Unpack` annotation `{ann}`. Strict tool schemas support"
+                        " homogeneous variadic arguments, so use *args: T or"
+                        " Unpack[tuple[T, ...]] instead."
+                    )
+            elif get_origin(ann) is tuple:
                 # Preserve a homogeneous tuple as the type of each positional argument.
                 args_of_tuple = get_args(ann)
                 if len(args_of_tuple) == 2 and args_of_tuple[1] is Ellipsis:

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, Literal
 import pytest
 from pydantic import BaseModel, Field, ValidationError
 from pydantic.json_schema import PydanticJsonSchemaWarning
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, Unpack
 
 from agents import RunContextWrapper, function_tool
 from agents.exceptions import ModelBehaviorError, UserError
@@ -460,6 +460,29 @@ def test_var_positional_tuple_annotation():
 
     with pytest.raises(ValidationError):
         fs.params_pydantic_model.model_validate({"args": [1, 2, 3]})
+
+
+def test_var_positional_unpack_homogeneous_tuple_annotation():
+    def func(*args: Unpack[tuple[int, ...]]) -> int:
+        return sum(args)
+
+    fs = function_schema(func, use_docstring_info=False)
+
+    args_schema = fs.params_json_schema["properties"]["args"]
+    assert args_schema["type"] == "array"
+    assert args_schema["items"]["type"] == "integer"
+
+    parsed = fs.params_pydantic_model.model_validate({"args": [1, 2, 3]})
+    args, kwargs = fs.to_call_args(parsed)
+    assert func(*args, **kwargs) == 6
+
+
+def test_var_positional_unpack_fixed_tuple_annotation_is_rejected():
+    def func(*args: Unpack[tuple[int, str]]) -> int:
+        return len(args)
+
+    with pytest.raises(UserError, match=r"Unpack\[tuple\[T, \.\.\.\]\]"):
+        function_schema(func, use_docstring_info=False)
 
 
 def _var_positional_fixed_pair(*args: tuple[int, str]) -> int:


### PR DESCRIPTION
### Summary

Support PEP 646 homogeneous `Unpack` annotations on variadic tool parameters.

`*args: Unpack[tuple[T, ...]]` currently falls through to `list[Unpack[...]]`, which Pydantic cannot turn into a schema. The converter now unwraps that annotation to the ordinary `list[T]` representation used by tool schemas.

Unsupported fixed or otherwise non-homogeneous `Unpack` forms now raise a clear `UserError` instead of leaking `PydanticSchemaGenerationError`.

### Test plan

- `uv run --locked pytest -q tests/test_function_schema.py` — 54 passed
- `uv run --locked ruff format --check src/agents/function_schema.py tests/test_function_schema.py` — passed
- `uv run --locked ruff check src/agents/function_schema.py tests/test_function_schema.py` — passed
- `uv run --locked mypy src/agents/function_schema.py` — passed
- `.agents/skills/code-change-verification/scripts/run.sh` — attempted; repository-wide typecheck stops on existing missing optional dependencies and unrelated baseline errors outside the touched files
- `git diff --check` — passed

### Issue number

Closes #4850