### PR TITLE
test(sandbox): skip unavailable Windows symlinks

### DIFF
--- a/tests/sandbox/test_workspace_paths.py
+++ b/tests/sandbox/test_workspace_paths.py
@@ -36,6 +36,20 @@ def _policy(root: Path | str = "/workspace") -> WorkspacePathPolicy:
     return WorkspacePathPolicy(root=root)
 
 
+def _symlink_or_skip(
+    target: Path,
+    link: Path,
+    *,
+    target_is_directory: bool = False,
+) -> None:
+    try:
+        os.symlink(target, link, target_is_directory=target_is_directory)
+    except OSError as exc:
+        if os.name == "nt" and getattr(exc, "winerror", None) == 1314:
+            pytest.skip("symlink creation requires elevated privileges on Windows")
+        raise
+
+
 def test_sandbox_workspace_scope_anchors_relative_paths() -> None:
     scope = SandboxWorkspaceScope.from_cwd("tasks/a")
 
@@ -320,11 +334,11 @@ def test_normalize_path_with_symlink_resolution(tmp_path: Path) -> None:
 
     target = workspace / "target.txt"
     target.write_text("hello", encoding="utf-8")
-    os.symlink(target, workspace / "link.txt")
-    os.symlink(outside, workspace / "outside-link", target_is_directory=True)
+    _symlink_or_skip(target, workspace / "link.txt")
+    _symlink_or_skip(outside, workspace / "outside-link", target_is_directory=True)
 
     alias = tmp_path / "workspace-alias"
-    os.symlink(workspace, alias, target_is_directory=True)
+    _symlink_or_skip(workspace, alias, target_is_directory=True)
 
     test_cases = [
         WorkspacePathCase(
@@ -690,7 +704,7 @@ def test_host_io_rejects_write_under_resolved_read_only_extra_path_grant(
     grant_alias = tmp_path / "allowed-alias"
     workspace.mkdir()
     allowed.mkdir()
-    os.symlink(allowed, grant_alias, target_is_directory=True)
+    _symlink_or_skip(allowed, grant_alias, target_is_directory=True)
     target = allowed / "cache.db"
     grant = SandboxPathGrant(path=str(grant_alias), read_only=True)
     policy = WorkspacePathPolicy(
@@ -767,7 +781,7 @@ def test_host_io_rejects_extra_path_grant_symlink_to_root(tmp_path: Path) -> Non
     workspace = tmp_path / "workspace"
     root_alias = tmp_path / "root-alias"
     workspace.mkdir()
-    os.symlink(Path("/"), root_alias, target_is_directory=True)
+    _symlink_or_skip(Path("/"), root_alias, target_is_directory=True)
     policy = WorkspacePathPolicy(
         root=workspace,
         extra_path_grants=(SandboxPathGrant(path=str(root_alias)),),
@@ -781,7 +795,7 @@ def test_host_io_rejects_extra_path_grant_symlink_to_root(tmp_path: Path) -> Non
 
 def test_host_path_grant_rejects_symlink_to_root(tmp_path: Path) -> None:
     root_alias = tmp_path / "root-alias"
-    os.symlink(Path("/"), root_alias, target_is_directory=True)
+    _symlink_or_skip(Path("/"), root_alias, target_is_directory=True)
     grant = SandboxPathGrant(path="/mnt/shared-data", host_path=str(root_alias))
 
     with pytest.raises(
@@ -795,11 +809,11 @@ def test_host_path_grant_returns_validated_resolved_source(tmp_path: Path) -> No
     source = tmp_path / "source"
     source.mkdir()
     source_alias = tmp_path / "source-alias"
-    os.symlink(source, source_alias, target_is_directory=True)
+    _symlink_or_skip(source, source_alias, target_is_directory=True)
     grant = SandboxPathGrant(path="/mnt/shared-data", host_path=str(source_alias))
 
     resolved_source = sandbox_path_grant_host_path(grant)
     source_alias.unlink()
-    os.symlink(Path("/"), source_alias, target_is_directory=True)
+    _symlink_or_skip(Path("/"), source_alias, target_is_directory=True)
 
     assert resolved_source == source.resolve()


### PR DESCRIPTION
### Summary

Make the workspace-path symlink tests skip cleanly when Windows refuses symlink creation with `WinError 1314`.

The test file now routes symlink setup through a small helper. On POSIX systems and Windows environments with symlink privileges, behavior is unchanged. On non-elevated Windows environments without Developer Mode, the affected tests skip instead of failing during fixture setup.

This intentionally addresses only the test-harness portion of #4852. It does not change `safe_extract_tarfile()` or choose a runtime policy for archives containing symlinks.

### Test plan

- `uv run pytest -q tests/sandbox/test_workspace_paths.py` — passed (69 passed, 2 skipped)
- `uv run ruff check tests/sandbox/test_workspace_paths.py` — passed
- `uv run ruff format --check tests/sandbox/test_workspace_paths.py` — passed
- `git diff --check` — passed

### Issue number

Addresses #4852