### PR TITLE
fix(core): validate guardrail tripwire results

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -68,6 +68,11 @@ class OutputGuardrailResult:
     """The output of the guardrail function."""
 
 
+def _validate_tripwire_triggered(output: GuardrailFunctionOutput, guardrail_name: str) -> None:
+    if not isinstance(output.tripwire_triggered, bool):
+        raise UserError(f"Guardrail {guardrail_name} must return a boolean for tripwire_triggered.")
+
+
 @dataclass
 class InputGuardrail(Generic[TContext]):
     """Input guardrails are checks that run either in parallel with the agent or before it starts.
@@ -119,15 +124,9 @@ class InputGuardrail(Generic[TContext]):
 
         output = self.guardrail_function(context, agent, input)
         if inspect.isawaitable(output):
-            return InputGuardrailResult(
-                guardrail=self,
-                output=await output,
-            )
-
-        return InputGuardrailResult(
-            guardrail=self,
-            output=output,
-        )
+            output = await output
+        _validate_tripwire_triggered(output, self.get_name())
+        return InputGuardrailResult(guardrail=self, output=output)
 
 
 @dataclass
@@ -170,13 +169,8 @@ class OutputGuardrail(Generic[TContext]):
 
         output = self.guardrail_function(context, agent, agent_output)
         if inspect.isawaitable(output):
-            return OutputGuardrailResult(
-                guardrail=self,
-                agent=agent,
-                agent_output=agent_output,
-                output=await output,
-            )
-
+            output = await output
+        _validate_tripwire_triggered(output, self.get_name())
         return OutputGuardrailResult(
             guardrail=self,
             agent=agent,

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -84,6 +84,66 @@ async def test_sync_input_guardrail():
     assert result.output.output_info == "test"
 
 
+@pytest.mark.asyncio
+async def test_input_guardrail_rejects_non_bool_tripwire() -> None:
+    guardrail = InputGuardrail(
+        guardrail_function=lambda ctx, agent, input: GuardrailFunctionOutput(
+            output_info=None,
+            tripwire_triggered=None,  # type: ignore[arg-type]
+        ),
+        name="policy",
+    )
+
+    with pytest.raises(
+        UserError, match="Guardrail policy must return a boolean for tripwire_triggered"
+    ):
+        await guardrail.run(
+            agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        )
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_rejects_non_bool_tripwire() -> None:
+    async def invalid_output_guardrail(
+        context: RunContextWrapper[Any], agent: Agent[Any], output: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(
+            output_info=None,
+            tripwire_triggered=None,  # type: ignore[arg-type]
+        )
+
+    guardrail = OutputGuardrail(guardrail_function=invalid_output_guardrail, name="policy")
+
+    with pytest.raises(
+        UserError, match="Guardrail policy must return a boolean for tripwire_triggered"
+    ):
+        await guardrail.run(
+            context=RunContextWrapper(context=None),
+            agent=Agent(name="test"),
+            agent_output="test",
+        )
+
+
+@pytest.mark.asyncio
+async def test_blocking_input_guardrail_non_bool_tripwire_stops_before_model() -> None:
+    @input_guardrail(run_in_parallel=False)
+    async def invalid_guardrail(
+        ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(
+            output_info=None,
+            tripwire_triggered=None,  # type: ignore[arg-type]
+        )
+
+    model = ScriptedModel([[get_text_message("model-ran")]])
+    agent = Agent(name="guardrail-repro", model=model, input_guardrails=[invalid_guardrail])
+
+    with pytest.raises(UserError, match="must return a boolean for tripwire_triggered"):
+        await Runner.run(agent, "test")
+
+    assert len(model.calls) == 0
+
+
 def get_async_input_guardrail(triggers: bool, output_info: Any | None = None):
     async def async_guardrail(
         context: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]


### PR DESCRIPTION
### Summary

Reject non-boolean `tripwire_triggered` values returned by input and output guardrails.

`GuardrailFunctionOutput.tripwire_triggered` is typed as `bool`, but unchecked runtime values were previously consumed by truthiness checks. A guardrail returning `None` could therefore be treated as passing and allow downstream execution.

Validation now happens at the shared `InputGuardrail.run()` / `OutputGuardrail.run()` boundary before the result reaches runner logic. Explicit `True` and `False` behavior is unchanged.

### Test plan

- `uv run pytest -q tests/test_guardrails.py` — 63 passed
- `uv run ruff check src/agents/guardrail.py tests/test_guardrails.py` — passed
- `uv run ruff format --check src/agents/guardrail.py tests/test_guardrails.py` — passed
- targeted mypy — passed
- targeted Pyright — 0 errors, 0 warnings
- `git diff --check` — passed
- repository verification wrapper was attempted; its global typecheck stopped on existing optional-dependency and unrelated sandbox typing errors in untouched files (`litellm`, `temporalio`, SQLAlchemy, Vercel/Runloop sandbox typing, and related baseline errors)

Fixes #4854.