### PR TITLE
fix(core): validate tool guardrail behaviors

### DIFF
--- a/src/agents/tool_guardrails.py
+++ b/src/agents/tool_guardrails.py
@@ -117,6 +117,22 @@ class ToolGuardrailFunctionOutput:
         return cls(output_info=output_info, behavior=RaiseExceptionBehavior(type="raise_exception"))
 
 
+def _validate_guardrail_behavior(
+    output: ToolGuardrailFunctionOutput, guardrail_name: str
+) -> ToolGuardrailFunctionOutput:
+    behavior = output.behavior
+    if not isinstance(behavior, dict):
+        raise UserError(f"Tool guardrail {guardrail_name} returned an invalid behavior")
+
+    behavior_type = behavior.get("type")
+    if behavior_type in {"allow", "raise_exception"}:
+        return output
+    if behavior_type == "reject_content" and isinstance(behavior.get("message"), str):
+        return output
+
+    raise UserError(f"Tool guardrail {guardrail_name} returned an invalid behavior")
+
+
 @dataclass
 class ToolInputGuardrailData:
     """Input data passed to a tool input guardrail function."""
@@ -173,8 +189,8 @@ class ToolInputGuardrail(Generic[TContext_co]):
 
         result = self.guardrail_function(data)
         if inspect.isawaitable(result):
-            return await result
-        return result
+            result = await result
+        return _validate_guardrail_behavior(result, self.get_name())
 
 
 @dataclass
@@ -202,8 +218,8 @@ class ToolOutputGuardrail(Generic[TContext_co]):
 
         result = self.guardrail_function(data)
         if inspect.isawaitable(result):
-            return await result
-        return result
+            result = await result
+        return _validate_guardrail_behavior(result, self.get_name())
 
 
 # Decorators

--- a/tests/test_tool_guardrails.py
+++ b/tests/test_tool_guardrails.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -239,6 +239,57 @@ async def test_invalid_tool_output_guardrail_raises_user_error():
             output="test output",
         )
         await guardrail.run(data)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("guardrail_kind", ["input", "output"])
+async def test_tool_guardrail_rejects_unknown_behavior(guardrail_kind: str) -> None:
+    invalid_output = ToolGuardrailFunctionOutput(
+        output_info=None,
+        behavior=cast(Any, {"type": "unknown"}),
+    )
+
+    if guardrail_kind == "input":
+        guardrail: ToolInputGuardrail[Any] | ToolOutputGuardrail[Any] = ToolInputGuardrail(
+            guardrail_function=lambda _data: invalid_output,
+            name="policy",
+        )
+        data: ToolInputGuardrailData | ToolOutputGuardrailData = ToolInputGuardrailData(
+            context=get_mock_tool_context(),
+            agent=Agent(name="test"),
+        )
+    else:
+        guardrail = ToolOutputGuardrail(
+            guardrail_function=lambda _data: invalid_output,
+            name="policy",
+        )
+        data = ToolOutputGuardrailData(
+            context=get_mock_tool_context(),
+            agent=Agent(name="test"),
+            output="sensitive output",
+        )
+
+    with pytest.raises(UserError, match="Tool guardrail policy returned an invalid behavior"):
+        await guardrail.run(data)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_tool_guardrail_rejects_reject_content_without_message() -> None:
+    guardrail: ToolInputGuardrail[Any] = ToolInputGuardrail(
+        guardrail_function=lambda _data: ToolGuardrailFunctionOutput(
+            output_info=None,
+            behavior=cast(Any, {"type": "reject_content"}),
+        ),
+        name="policy",
+    )
+
+    with pytest.raises(UserError, match="Tool guardrail policy returned an invalid behavior"):
+        await guardrail.run(
+            ToolInputGuardrailData(
+                context=get_mock_tool_context(),
+                agent=Agent(name="test"),
+            )
+        )
 
 
 # Test decorators


### PR DESCRIPTION
### Summary

Validate tool guardrail behavior values at the shared `ToolInputGuardrail.run()` / `ToolOutputGuardrail.run()` boundary.

Previously, an unchecked callback could return an unknown behavior type and the runner would fall through as if the guardrail allowed execution. The shared boundary now accepts only the documented `allow`, `reject_content`, and `raise_exception` variants, and requires a string message for `reject_content`.

The existing default `ToolGuardrailFunctionOutput(output_info=...)` behavior remains `allow`.

### Test plan

- `uv run pytest -q tests/test_tool_guardrails.py` — 25 passed
- `uv run ruff check src/agents/tool_guardrails.py tests/test_tool_guardrails.py` — passed
- `uv run ruff format --check src/agents/tool_guardrails.py tests/test_tool_guardrails.py` — passed
- targeted mypy — passed
- targeted Pyright — 0 errors, 0 warnings
- `git diff --check` — passed
- repository verification wrapper was also run: lint passed and the test job reached 7,515 passed / 69 skipped before unrelated existing optional-dependency, voice, sandbox and release-contract environment failures; global typechecking likewise depends on optional packages not installed in this environment

Fixes #4856.