### PR TITLE
fix(core): support PEP 692 kwargs unpack

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -4,9 +4,12 @@ import contextlib
 import inspect
 import logging
 import re
+import typing
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal, get_args, get_origin, get_type_hints
+
+import typing_extensions
 
 # griffelib exposes the `griffe` package at runtime but currently does not ship typing markers.
 from griffe import Docstring, DocstringSectionKind  # type: ignore[import-untyped]
@@ -462,12 +465,20 @@ def function_schema(
             )
 
         elif param.kind == param.VAR_KEYWORD:
-            # **kwargs handling: a ``**kwargs: X`` annotation applies to each keyword *value*
-            # (PEP 484), so the collected container is always ``dict[str, X]``. Preserve the full
-            # annotation as the value type -- mirroring the variadic-positional handling above,
-            # where ``*args: X`` becomes ``list[X]`` (see #4655). A bare ``**kwargs`` has ``ann``
-            # set to ``Any`` above, yielding ``dict[str, Any]``.
-            ann = dict[str, ann]  # type: ignore
+            # ``**kwargs: X`` normally annotates each keyword value (PEP 484), so the collected
+            # container is ``dict[str, X]``. PEP 692 is the exception: ``Unpack[TypedDict]``
+            # describes the collected keyword mapping itself, including its named/required keys.
+            unpack_origins = {typing_extensions.Unpack, getattr(typing, "Unpack", None)}
+            if get_origin(ann) in unpack_origins:
+                unpack_args = get_args(ann)
+                if len(unpack_args) != 1 or not typing_extensions.is_typeddict(unpack_args[0]):
+                    raise UserError(
+                        f"Variadic parameter `**{name}` in function {func.__name__} is annotated"
+                        f" with unsupported `{ann}`. `Unpack` on **kwargs must contain a TypedDict."
+                    )
+                ann = unpack_args[0]
+            else:
+                ann = dict[str, ann]  # type: ignore
 
             fields[name] = (
                 ann,

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, Literal
 import pytest
 from pydantic import BaseModel, Field, ValidationError
 from pydantic.json_schema import PydanticJsonSchemaWarning
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, Unpack
 
 from agents import RunContextWrapper, function_tool
 from agents.exceptions import ModelBehaviorError, UserError
@@ -536,6 +536,40 @@ def test_var_keyword_dict_annotation():
     # A flat mapping of ints no longer matches the declared value type.
     with pytest.raises(ValidationError):
         fs.params_pydantic_model.model_validate({"kwargs": {"a": 1, "b": 2}})
+
+
+class _PEP692Options(TypedDict):
+    count: int
+    label: str
+
+
+def test_var_keyword_unpack_typeddict_annotation():
+    def func(**kwargs: Unpack[_PEP692Options]):
+        return kwargs
+
+    fs = function_schema(func, use_docstring_info=False)
+
+    kwargs_schema = fs.params_json_schema["properties"]["kwargs"]
+    options_schema = fs.params_json_schema["$defs"]["_PEP692Options"]
+    assert kwargs_schema == {"$ref": "#/$defs/_PEP692Options"}
+    assert options_schema["required"] == ["count", "label"]
+    assert options_schema["properties"]["count"]["type"] == "integer"
+    assert options_schema["properties"]["label"]["type"] == "string"
+
+    parsed = fs.params_pydantic_model.model_validate({"kwargs": {"count": 2, "label": "ready"}})
+    args, kwargs = fs.to_call_args(parsed)
+    assert func(*args, **kwargs) == {"count": 2, "label": "ready"}
+
+    with pytest.raises(ValidationError):
+        fs.params_pydantic_model.model_validate({"kwargs": {"count": 2}})
+
+
+def test_var_keyword_unpack_requires_typeddict():
+    def func(**kwargs: Unpack[tuple[int, ...]]):  # type: ignore[misc]
+        return kwargs
+
+    with pytest.raises(UserError, match="Unpack.*TypedDict"):
+        function_schema(func, use_docstring_info=False)
 
 
 def test_var_keyword_scalar_annotation():


### PR DESCRIPTION
### Summary

Support PEP 692 `**kwargs: Unpack[TypedDict]` annotations in function-tool schema generation.

The ordinary `**kwargs: X` path correctly treats `X` as the type of each keyword value. PEP 692 is different: `Unpack[TypedDict]` describes the collected keyword mapping itself. The schema builder now recognizes that standard form, uses the TypedDict as the `kwargs` field schema, and lets the existing `to_call_args()` path expand the validated mapping back into keyword arguments.

Unsupported `Unpack[...]` shapes now raise a focused `UserError` instead of leaking Pydantic's schema-generation error. Ordinary `**kwargs: T` behavior is unchanged.

### Test plan

- `uv run pytest -q tests/test_function_schema.py` — 54 passed
- `uv run ruff check src/agents/function_schema.py tests/test_function_schema.py` — passed
- `uv run ruff format --check src/agents/function_schema.py tests/test_function_schema.py` — passed
- targeted mypy — passed
- targeted Pyright — 0 errors, 0 warnings
- `git diff --check` — passed
- repository verification wrapper was attempted; lint passed and the global typecheck stopped on existing missing optional dependencies and unrelated sandbox typing baseline errors in untouched files

Fixes #4859.