### PR TITLE
fix(core): raise a clear UserError when a tool parameter is named model_config

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -511,6 +511,13 @@ def function_schema(
                 )
 
     # 3. Dynamically build a Pydantic model
+    if "model_config" in fields:
+        # Pydantic reads a ``model_config`` keyword as the model's configuration, not as a
+        # field, so create_model() fails deep inside Pydantic with an unhelpful TypeError.
+        raise UserError(
+            f"Parameter `model_config` in function {func_name} is reserved by Pydantic and cannot"
+            " be a tool argument. Rename the parameter."
+        )
     dynamic_model = create_model(f"{func_name}_args", __base__=BaseModel, **fields)
 
     # 4. Build JSON schema from that model

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1350,3 +1350,14 @@ def test_to_call_args_allows_kwargs_key_matching_var_positional_param() -> None:
     args, kwargs_dict = fs.to_call_args(parsed)
 
     assert _kwargs_var_positional_name(*args, **kwargs_dict) == ((1,), {"rest": 5})
+
+
+def test_model_config_parameter_raises_a_clear_user_error():
+    """Pydantic treats a ``model_config`` kwarg to create_model() as the configuration, which
+    surfaced as ``TypeError: 'FieldInfo' object is not iterable``. Name the real problem."""
+
+    def configure(model_config: int) -> int:
+        return model_config
+
+    with pytest.raises(UserError, match="`model_config` in function configure is reserved"):
+        function_schema(configure)


### PR DESCRIPTION
### Summary

A tool parameter named `model_config` made `function_schema()` fail with an unrelated-looking error from inside Pydantic:

```
TypeError: 'FieldInfo' object is not iterable
```

`function_schema()` builds the argument model with `create_model(f"{name}_args", __base__=BaseModel, **fields)`, and Pydantic interprets a `model_config` keyword to `create_model()` as the model's configuration dict rather than as a field, so it tries to iterate the `FieldInfo`. Other reserved names already produce readable Pydantic errors (`model_dump` / `model_validate` → "conflicts with member … of protected namespace", leading underscores → "Fields must not use names with leading underscores"); `model_config` was the one that failed opaquely.

This PR checks for that name before calling `create_model()` and raises a `UserError` that names the function and the parameter:

```
Parameter `model_config` in function configure is reserved by Pydantic and cannot be a tool argument. Rename the parameter.
```

No behavior changes for any other parameter name.

### Test plan

- `test_model_config_parameter_raises_a_clear_user_error` in `tests/test_function_schema.py`: on `main` it fails with the Pydantic `TypeError`; with this change it gets the `UserError`.
- `tests/test_function_schema.py`, `tests/test_function_tool.py`, `tests/test_function_tool_decorator.py`: 177 passed. `ruff format`/`ruff check` clean, `mypy` and `pyright` clean on the changed files (Linux, Python 3.10). The repository-wide `mypy src` reports pre-existing Python 3.10 errors in `archive_ops.py` / `run_loop.py` unrelated to this change, so the full-stack checkbox is left unchecked.

### Issue number

None (found while probing `function_schema()` with reserved parameter names).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run the verification steps from `.agents/skills/code-change-verification` individually (format, lint, typecheck on changed files, tests)
- [ ] I've confirmed all verification steps pass (see Test plan)
- [ ] If using Codex, I've run `/review` before submitting this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFSMrLZZ3oq1dKmJFAofz6
