### PR TITLE
fix(core): actionable error when **kwargs or dict[str, Any] tool parameters meet strict mode

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -533,7 +533,7 @@ def function_schema(
             raise UserError(
                 f"Function {func_name} cannot use a strict JSON schema: {exc} A parameter typed as"
                 " a free-form mapping such as dict[str, Any] has this effect; use a TypedDict or a"
-                " BaseModel, or set strict_json_schema=False."
+                " BaseModel, or use @function_tool(strict_mode=False) / strict_json_schema=False."
             ) from exc
 
     # 5. Return as a FuncSchema dataclass

--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -516,7 +516,25 @@ def function_schema(
     # 4. Build JSON schema from that model
     json_schema = dynamic_model.model_json_schema()
     if strict_json_schema:
-        json_schema = ensure_strict_json_schema(json_schema)
+        var_keyword = next(
+            (name for name, param in filtered_params if param.kind == param.VAR_KEYWORD), None
+        )
+        if var_keyword is not None:
+            # A strict schema cannot describe **kwargs (it needs additionalProperties), so say
+            # so up front instead of surfacing the generic strict-schema error from deep inside.
+            raise UserError(
+                f"Function {func_name} accepts `**{var_keyword}`, which a strict JSON schema"
+                " cannot describe. Use @function_tool(strict_mode=False) or"
+                f" strict_json_schema=False, or replace `**{var_keyword}` with explicit parameters."
+            )
+        try:
+            json_schema = ensure_strict_json_schema(json_schema)
+        except UserError as exc:
+            raise UserError(
+                f"Function {func_name} cannot use a strict JSON schema: {exc} A parameter typed as"
+                " a free-form mapping such as dict[str, Any] has this effect; use a TypedDict or a"
+                " BaseModel, or set strict_json_schema=False."
+            ) from exc
 
     # 5. Return as a FuncSchema dataclass
     return FuncSchema(

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1350,3 +1350,29 @@ def test_to_call_args_allows_kwargs_key_matching_var_positional_param() -> None:
     args, kwargs_dict = fs.to_call_args(parsed)
 
     assert _kwargs_var_positional_name(*args, **kwargs_dict) == ((1,), {"rest": 5})
+
+
+def test_var_keyword_under_strict_schema_names_the_parameter_and_the_fix():
+    def extra(**options: int) -> dict[str, int]:
+        return options
+
+    with pytest.raises(UserError, match=r"Function extra accepts `\*\*options`") as excinfo:
+        function_schema(extra)
+    assert "strict_mode=False" in str(excinfo.value)
+
+    relaxed = function_schema(extra, strict_json_schema=False)
+    assert relaxed.params_json_schema["properties"]["options"]["additionalProperties"] == {
+        "type": "integer"
+    }
+
+
+def test_free_form_mapping_under_strict_schema_names_the_function():
+    def tag(meta: dict[str, Any]) -> dict[str, Any]:
+        return meta
+
+    with pytest.raises(UserError, match="Function tag cannot use a strict JSON schema") as excinfo:
+        function_schema(tag)
+    assert "dict[str, Any]" in str(excinfo.value)
+
+    relaxed = function_schema(tag, strict_json_schema=False)
+    assert relaxed.params_json_schema["properties"]["meta"]["type"] == "object"

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1382,7 +1382,7 @@ def test_free_form_mapping_under_strict_schema_names_the_function():
 @pytest.mark.parametrize(
     ("declare", "expected"),
     [
-        (lambda: function_tool(_kwargs_tool), "accepts `**options`"),
+        (lambda: function_tool(_kwargs_tool), r"accepts `\*\*options`"),
         (lambda: function_tool(_mapping_tool), "Function _mapping_tool cannot use a strict"),
     ],
 )

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1373,6 +1373,33 @@ def test_free_form_mapping_under_strict_schema_names_the_function():
     with pytest.raises(UserError, match="Function tag cannot use a strict JSON schema") as excinfo:
         function_schema(tag)
     assert "dict[str, Any]" in str(excinfo.value)
+    assert "strict_mode=False" in str(excinfo.value)
 
     relaxed = function_schema(tag, strict_json_schema=False)
     assert relaxed.params_json_schema["properties"]["meta"]["type"] == "object"
+
+
+@pytest.mark.parametrize(
+    ("declare", "expected"),
+    [
+        (lambda: function_tool(_kwargs_tool), "accepts `**options`"),
+        (lambda: function_tool(_mapping_tool), "Function _mapping_tool cannot use a strict"),
+    ],
+)
+def test_function_tool_decorator_reports_the_strict_mode_fix(declare, expected):
+    """The supported entry point is the decorator, whose option is strict_mode, not
+    strict_json_schema; both messages must point at the option the caller can actually set."""
+    with pytest.raises(UserError, match=expected) as excinfo:
+        declare()
+    assert "strict_mode=False" in str(excinfo.value)
+
+    assert function_tool(_kwargs_tool, strict_mode=False).strict_json_schema is False
+    assert function_tool(_mapping_tool, strict_mode=False).strict_json_schema is False
+
+
+def _kwargs_tool(**options: int) -> dict[str, int]:
+    return options
+
+
+def _mapping_tool(meta: dict[str, Any]) -> dict[str, Any]:
+    return meta


### PR DESCRIPTION
### Summary

Declaring a tool with `**kwargs`, or with a parameter typed as a free-form mapping such as `dict[str, Any]`, under the default strict JSON schema fails with the generic strict-schema error:

```
UserError: additionalProperties should not be set for object types. This could be because you're
using an older version of Pydantic, or because you configured additional properties to be allowed.
If you really need this, update the function or output tool to not use a strict schema.
```

Neither suggested cause applies; the schema simply cannot be strict because `**kwargs` / `dict[str, Any]` need `additionalProperties`. Users who reach this from `@function_tool def f(**kwargs: int)` get no pointer to the parameter or to `strict_mode=False`.

This PR keeps the behavior (strict mode still rejects these) and makes the error actionable in `function_schema()`:

- `**kwargs` is detected before strict conversion and reported as `Function f accepts \`**kwargs\`, which a strict JSON schema cannot describe. Use @function_tool(strict_mode=False) or strict_json_schema=False, or replace \`**kwargs\` with explicit parameters.`
- Any other strict-conversion failure is re-raised as `Function f cannot use a strict JSON schema: <original message> A parameter typed as a free-form mapping such as dict[str, Any] has this effect; use a TypedDict or a BaseModel, or use @function_tool(strict_mode=False) / strict_json_schema=False.` (chained from the original `UserError`).

`strict_json_schema=False` behavior is unchanged, and `ensure_strict_json_schema()` itself is untouched.

### Test plan

- New tests in `tests/test_function_schema.py`: `test_var_keyword_under_strict_schema_names_the_parameter_and_the_fix` and `test_free_form_mapping_under_strict_schema_names_the_function`; both fail on `main` (generic message) and pass here, and both assert the non-strict schema is still produced; `test_function_tool_decorator_reports_the_strict_mode_fix` covers the `@function_tool` entry point and checks both messages name `strict_mode=False`.
- `tests/test_function_schema.py`, `tests/test_function_tool.py`, `tests/test_function_tool_decorator.py`, `tests/test_strict_schema.py`: 247 passed. `ruff format`/`ruff check` clean, `mypy` and `pyright` clean on the changed files (Linux, Python 3.10). The repository-wide `mypy src` reports pre-existing Python 3.10 errors in `archive_ops.py` / `run_loop.py` unrelated to this change, so the full-stack checkbox is left unchecked.

### Issue number

None (found while probing `function_schema()` with `**kwargs` and mapping parameters under the default strict mode).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run the verification steps from `.agents/skills/code-change-verification` individually (format, lint, typecheck on changed files, tests)
- [ ] I've confirmed all verification steps pass (see Test plan)
- [ ] If using Codex, I've run `/review` before submitting this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFSMrLZZ3oq1dKmJFAofz6

