### PR TITLE
fix(sessions): reset compaction state on clear

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -516,7 +516,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
                 raise
             self._compaction_candidate_items = []
             self._session_items = []
+            self._response_id = None
             self._deferred_response_id = None
+            self._last_unstored_response_id = None
             self._mutation_generation += 1
 
     async def _ensure_compaction_candidates(

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -508,7 +508,19 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         async with self._mutation_lock:
             try:
                 await self.underlying_session.clear_session()
-            except (Exception, asyncio.CancelledError):
+            except asyncio.CancelledError:
+                # Some session backends shield mutations so a cancellation can be
+                # observed only after the clear has committed. Treat cancellation as
+                # potentially destructive and forget the response chain as well as
+                # cached history, so cleared history cannot be reconstructed later.
+                self._compaction_candidate_items = None
+                self._session_items = None
+                self._response_id = None
+                self._deferred_response_id = None
+                self._last_unstored_response_id = None
+                self._mutation_generation += 1
+                raise
+            except Exception:
                 self._compaction_candidate_items = None
                 self._session_items = None
                 self._deferred_response_id = None

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -100,6 +100,25 @@ class TestSelectCompactionCandidateItems:
 
 
 class TestOpenAIResponsesCompactionSession:
+    @pytest.mark.asyncio
+    async def test_clear_session_forgets_response_chain_state(self) -> None:
+        mock_session = self.create_mock_session()
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock()
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=mock_session,
+            client=mock_client,
+            should_trigger_compaction=lambda _context: False,
+        )
+
+        await session.run_compaction({"response_id": "resp-old", "store": True})
+        await session.clear_session()
+
+        with pytest.raises(ValueError, match="requires a response_id"):
+            await session.run_compaction({"force": True, "compaction_mode": "previous_response_id"})
+        mock_client.responses.compact.assert_not_called()
+
     def test_client_preserves_falsy_default_client(self) -> None:
         mock_client = MagicMock()
         mock_client.__bool__.return_value = False

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -119,6 +119,32 @@ class TestOpenAIResponsesCompactionSession:
             await session.run_compaction({"force": True, "compaction_mode": "previous_response_id"})
         mock_client.responses.compact.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_cancelled_clear_forgets_response_chain_state(self) -> None:
+        class CancelAfterCommittedClearSession(SimpleListSession):
+            async def clear_session(self) -> None:
+                await super().clear_session()
+                raise asyncio.CancelledError()
+
+        underlying = CancelAfterCommittedClearSession()
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock()
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=underlying,
+            client=mock_client,
+            should_trigger_compaction=lambda _context: False,
+        )
+
+        await session.run_compaction({"response_id": "resp-old", "store": True})
+        with pytest.raises(asyncio.CancelledError):
+            await session.clear_session()
+
+        assert await underlying.get_items() == []
+        with pytest.raises(ValueError, match="requires a response_id"):
+            await session.run_compaction({"force": True, "compaction_mode": "previous_response_id"})
+        mock_client.responses.compact.assert_not_called()
+
     def test_client_preserves_falsy_default_client(self) -> None:
         mock_client = MagicMock()
         mock_client.__bool__.return_value = False


### PR DESCRIPTION
### Summary

Reset retained response-chain state after `OpenAIResponsesCompactionSession.clear_session()` successfully clears the underlying history.

The wrapper previously reset cached session items and `_deferred_response_id`, but retained `_response_id` and `_last_unstored_response_id`. A later `previous_response_id` compaction could therefore reuse a response chain belonging to history the caller explicitly erased.

A successful clear now resets all three response-chain fields alongside the history caches. The reset occurs only after the underlying clear succeeds, preserving existing state if the backend clear fails. Cancellation is treated separately because the backend mutation may already have committed before `CancelledError` is re-raised; a plain backend exception preserves the chain state because the clear may not have committed. This distinction is deliberate, even though the sibling `pop_item` path in #4934 currently resets on either failure class.

### Test plan

- Added a regression proving a pre-clear response ID cannot be reused by a later `previous_response_id` compaction.
- `uv run pytest -q tests/memory/test_openai_responses_compaction_session.py` — 56 passed.
- Ruff check/format — passed.
- Targeted mypy — passed.
- Targeted Pyright — 0 errors, 0 warnings.
- `git diff --check` — passed.
- Repository-wide verification was also attempted: lint passed and the test run reached 7,513 passed / 69 skipped before unrelated existing optional-integration, voice, sandbox, and release-contract environment failures.

Fixes #4864.
