### PR TITLE
fix(tracing): record the tool output on approval-gated function spans

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1971,7 +1971,13 @@ class _FunctionToolBatchExecutor:
         )
         span_fn.set_error(
             SpanError(
-                message=rejection_message,
+                # The rejection message is app-supplied text, so it reaches the exported span
+                # under the same sensitive-data gate as the tool output above.
+                message=_error_tracing.get_trace_error(
+                    trace_include_sensitive_data=self.config.trace_include_sensitive_data,
+                    error_message=rejection_message,
+                    redacted_message="Tool execution rejected",
+                ),
                 data={
                     "tool_name": func_tool.name,
                     "error": (

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1852,7 +1852,12 @@ class _FunctionToolBatchExecutor:
                 raise UserError(f"Error running tool {func_tool.name}: {e}") from e
 
             if self.config.trace_include_sensitive_data:
-                span_fn.span_data.output = result
+                # Approval short-circuits return the FunctionToolResult wrapper rather than the
+                # tool's own output, so read the output off it the way every other consumer of
+                # this value does (see `_build_function_tool_results`).
+                span_fn.span_data.output = (
+                    result.output if isinstance(result, FunctionToolResult) else result
+                )
             return result
 
     async def _maybe_execute_tool_approval(
@@ -1975,7 +1980,6 @@ class _FunctionToolBatchExecutor:
                 },
             )
         )
-        span_fn.span_data.output = rejection_message
         return FunctionToolResult(
             tool=func_tool,
             output=rejection_message,

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -723,6 +723,70 @@ async def test_default_function_tool_error_trace_respects_sensitive_data_setting
     assert "secret-token-123" not in str(error)
 
 
+def _make_approval_function_tool() -> FunctionTool:
+    async def _approval_tool() -> str:
+        return "ok"
+
+    return function_tool(_approval_tool, name_override="approval_tool", needs_approval=True)
+
+
+@pytest.mark.asyncio
+async def test_pending_approval_function_span_output_excludes_internal_result_object():
+    agent = Agent(
+        name="test",
+        instructions="system-prompt-abc",
+        tools=[_make_approval_function_tool()],
+    )
+    response = ModelResponse(
+        output=[get_function_tool_call("approval_tool", "{}", call_id="1")],
+        usage=Usage(),
+        response_id=None,
+    )
+
+    with trace("test"):
+        await get_execute_result(
+            agent,
+            response,
+            run_config=RunConfig(trace_include_sensitive_data=True),
+        )
+
+    function_spans = _function_spans()
+
+    assert len(function_spans) == 1
+    output = function_spans[0]["span_data"]["output"]
+    assert output is None
+    assert "system-prompt-abc" not in str(function_spans[0])
+
+
+@pytest.mark.asyncio
+async def test_rejected_tool_function_span_output_respects_sensitive_data_setting():
+    agent = Agent(name="test", tools=[_make_approval_function_tool()])
+    tool_call = get_function_tool_call("approval_tool", "{}", call_id="1")
+    response = ModelResponse(output=[tool_call], usage=Usage(), response_id=None)
+
+    context_wrapper: RunContextWrapper[Any] = RunContextWrapper(None)
+    reject_tool_call(
+        context_wrapper,
+        agent,
+        tool_call,
+        tool_name="approval_tool",
+        rejection_message="secret-denial-456",
+    )
+
+    with trace("test"):
+        await get_execute_result(
+            agent,
+            response,
+            context_wrapper=context_wrapper,
+            run_config=RunConfig(trace_include_sensitive_data=False),
+        )
+
+    function_spans = _function_spans()
+
+    assert len(function_spans) == 1
+    assert function_spans[0]["span_data"]["output"] is None
+
+
 @pytest.mark.asyncio
 async def test_multiple_tool_calls_still_raise_when_sibling_cancelled():
     async def _ok_tool() -> str:

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -784,7 +784,44 @@ async def test_rejected_tool_function_span_output_respects_sensitive_data_settin
     function_spans = _function_spans()
 
     assert len(function_spans) == 1
-    assert function_spans[0]["span_data"]["output"] is None
+    exported = function_spans[0]
+    assert exported["span_data"]["output"] is None
+    error = exported["error"]
+    assert error["message"] == "Tool execution rejected"
+    assert error["data"]["tool_name"] == "approval_tool"
+    assert error["data"]["error"] == "Tool execution for 1 was manually rejected by user."
+    assert "secret-denial-456" not in json.dumps(exported, default=str)
+
+
+@pytest.mark.asyncio
+async def test_rejected_tool_function_span_keeps_rejection_message_when_sensitive_data_included():
+    agent = Agent(name="test", tools=[_make_approval_function_tool()])
+    tool_call = get_function_tool_call("approval_tool", "{}", call_id="1")
+    response = ModelResponse(output=[tool_call], usage=Usage(), response_id=None)
+
+    context_wrapper: RunContextWrapper[Any] = RunContextWrapper(None)
+    reject_tool_call(
+        context_wrapper,
+        agent,
+        tool_call,
+        tool_name="approval_tool",
+        rejection_message="denied-by-policy",
+    )
+
+    with trace("test"):
+        await get_execute_result(
+            agent,
+            response,
+            context_wrapper=context_wrapper,
+            run_config=RunConfig(trace_include_sensitive_data=True),
+        )
+
+    function_spans = _function_spans()
+
+    assert len(function_spans) == 1
+    exported = function_spans[0]
+    assert exported["span_data"]["output"] == "denied-by-policy"
+    assert exported["error"]["message"] == "denied-by-policy"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

When a function tool is gated by `needs_approval`, the function span exports the internal `FunctionToolResult` wrapper into `span_data.output` instead of the tool's output.

`_run_single_tool` returns either a raw tool output or a `FunctionToolResult`, because the approval path short-circuits. Every other consumer discriminates the two with `isinstance`, including `_build_function_tool_results` in the same file; the span write does not. `FunctionSpanData.export()` then calls `str()` on the wrapper, so the trace carries a repr of the whole `Agent` object in the field documented to hold the tool output, including `agent.instructions`, the tool inventory with JSON schemas, the model settings and the raw arguments. On the repo's own test agent that is 2506 characters, under the default `trace_include_sensitive_data=True`.

The rejection message leaked by two separate routes: it was written to `span_data.output` from outside the sensitive-data gate, and it went onto `SpanError.message`, which `Span.export()` sends through unchanged. Both reached the backend with the flag off.

The fix reads the output off the wrapper the way the rest of the file already does, drops the ungated write, and routes the error message through `_error_tracing.get_trace_error` under the same flag.

### Test plan

- Three tests in `tests/test_run_step_execution.py`, all failing on `main`: the `FunctionToolResult(...)` repr where `None` is expected, `assert error["message"] == "Tool execution rejected"` against a leaked `secret-denial-456`, and the include-sensitive-data path keeping the message intact.
- The redaction test asserts against the whole exported span rather than `span_data.output` alone, so a leak through any other field fails it too.
- Suite 7656 -> 7659 passed, with the same 25 pre-existing environment failures as an unpatched run. `ruff check`, `ruff format --check` and `mypy` on the changed module are clean.

The behaviour change worth a second look: with `trace_include_sensitive_data=False` the exported rejection output goes from the message text to `None`, and the span error message to a fixed string. That is what the flag asks for and it matches the error paths, but it is visible to anyone reading rejection reasons out of a redacted trace.

`redacted_message` is passed inline at the call site, where `_tool_errors.py` hoists its equivalent to a module constant. Say the word and I will match that shape.

### Issue number

None.