### PR TITLE
fix(sessions): reset compaction state on pop

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -431,6 +431,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         async with self._mutation_lock:
             popped = await self.underlying_session.pop_item()
             if popped:
+                self._response_id = None
+                self._deferred_response_id = None
+                self._last_unstored_response_id = None
                 self._compaction_candidate_items = None
                 self._session_items = None
             return popped

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -166,6 +166,53 @@ class TestOpenAIResponsesCompactionSession:
         mock_session.get_items.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_pop_item_invalidates_response_chain_state(self) -> None:
+        item = cast(
+            TResponseInputItem,
+            {"type": "message", "role": "assistant", "content": "old"},
+        )
+        underlying = SimpleListSession(history=[item])
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(
+            return_value=SimpleNamespace(output=[], usage=None)
+        )
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=underlying,
+            client=mock_client,
+            compaction_mode="previous_response_id",
+        )
+
+        await session.run_compaction({"response_id": "resp-old"})
+        await session.pop_item()
+
+        with pytest.raises(ValueError, match="previous_response_id compaction"):
+            await session.run_compaction({"force": True})
+        mock_client.responses.compact.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pop_item_noop_preserves_response_chain_state(self) -> None:
+        underlying = SimpleListSession(history=[])
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(
+            return_value=SimpleNamespace(output=[], usage=None)
+        )
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=underlying,
+            client=mock_client,
+            compaction_mode="previous_response_id",
+        )
+
+        await session.run_compaction({"response_id": "resp-old"})
+        assert await session.pop_item() is None
+        await session.run_compaction({"force": True})
+
+        mock_client.responses.compact.assert_awaited_once_with(
+            model="gpt-4.1", previous_response_id="resp-old"
+        )
+
+    @pytest.mark.asyncio
     async def test_run_compaction_requires_response_id(self) -> None:
         mock_session = self.create_mock_session()
         session = OpenAIResponsesCompactionSession(


### PR DESCRIPTION
### Summary

Reset retained Responses response-chain state after `OpenAIResponsesCompactionSession.pop_item()` actually removes an item from local session history.

Previously, a successful pop invalidated the cached session/compaction items but retained `_response_id`, `_deferred_response_id`, and `_last_unstored_response_id`. A later `previous_response_id` compaction could therefore reuse server-side history that still contained the item the caller had removed locally.

The response-chain fields now reset at the same successful-mutation boundary as the local caches. A no-op pop preserves the existing chain, and an underlying pop failure still leaves state untouched.

### Test plan

- `uv run pytest -q tests/memory/test_openai_responses_compaction_session.py` — 57 passed
- Ruff check/format on changed files — passed
- targeted mypy — passed
- targeted Pyright — 0 errors, 0 warnings
- `git diff --check` — passed
- repository lint — passed
- full runtime test job reached 7,487 passed / 96 skipped; the remaining failures/errors are existing optional-integration/environment gaps involving packages such as httpx, Docker, voice/numpy, LiteLLM, SQLAlchemy and sandbox/release-contract fixtures
- repository-wide typecheck remains blocked by the same missing optional dependencies and unrelated sandbox/voice baseline errors in untouched files

Fixes #4867.