### PR TITLE
docs: Add Parallel Search to the remote MCP example

### DIFF
--- a/examples/mcp/streamable_http_remote_example/README.md
+++ b/examples/mcp/streamable_http_remote_example/README.md
@@ -11,3 +11,40 @@ uv run python examples/mcp/streamable_http_remote_example/main.py
 Prerequisites:
 
 - `OPENAI_API_KEY` set for the model calls.
+
+## Public web search with Parallel
+
+For public web search and page extraction, connect to [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) using the same Streamable HTTP client. The anonymous endpoint needs no Parallel account, API key, or authorization header. Free access is rate limited; `OPENAI_API_KEY` is still required for the agent's model calls.
+
+Save the following as `parallel_search.py` and run `uv run python parallel_search.py` from your SDK environment:
+
+```python
+import asyncio
+
+from agents import Agent, Runner
+from agents.mcp import MCPServerStreamableHttp
+
+
+async def main():
+    async with MCPServerStreamableHttp(
+        name="Parallel Search",
+        params={"url": "https://search.parallel.ai/mcp", "timeout": 30},
+        client_session_timeout_seconds=60,
+    ) as server:
+        agent = Agent(
+            name="Web research assistant",
+            instructions="Use web_search to find sources and web_fetch to read pages. Cite URLs.",
+            mcp_servers=[server],
+        )
+        result = await Runner.run(
+            agent,
+            "Find the official Python asyncio documentation and explain TaskGroup.",
+        )
+        print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Adding the connected server to `mcp_servers` makes `web_search` and `web_fetch` available to the agent. The agent can call them while answering a request without a separate confirmation for each call. Queries, requested URLs, and any supplied objectives or context are sent to Parallel; tool results enter the agent's model context. Remove the server from `mcp_servers` to stop exposing these tools to the agent.


### PR DESCRIPTION
### Summary

This pull request adds a Parallel Search setup snippet to the existing remote Streamable HTTP example README so users can give an agent public web search and page extraction without a Parallel account or API key.

It reuses `MCPServerStreamableHttp` and leaves the DeepWiki example unchanged. The README explains rate limits, the separate OpenAI API key requirement, and that enabled tools send queries, requested URLs, and supplied context to Parallel.

The SDK has no automatically enabled search provider: [`Agent` starts with empty tool and MCP-server lists](https://github.com/openai/openai-agents-python/blob/89c02c828ee8510fe9a84ee6675608193aa13b02/src/agents/agent.py#L194-L202). The existing remote examples use DeepWiki, and the research examples explicitly enable OpenAI’s hosted web search. Neither has a result on Artificial Analysis’s Search API leaderboard, so I’m not claiming a measured win over either.

The relevant overlap is Exa: the [E2B client accepts and forwards opt-in MCP configuration](https://github.com/openai/openai-agents-python/blob/89c02c828ee8510fe9a84ee6675608193aa13b02/src/agents/extensions/sandbox/e2b/sandbox.py#L1727-L1739), with [Exa covered by its passthrough test](https://github.com/openai/openai-agents-python/blob/89c02c828ee8510fe9a84ee6675608193aa13b02/tests/extensions/sandbox/test_e2b.py#L1213-L1279). That’s a supported configuration path, not a shipped Exa preset or an SDK default.

[Artificial Analysis’s August 31, 2026 data](https://artificialanalysis.ai/agents/search-api) gives a useful reason to try Parallel here. Parallel Fast scores **80.2 on DeepSearchQA**, compared with Exa Auto’s 77.8, Fast’s 75.7 and Instant’s 73.0. Its Search API spend is **$8.41 per 1,000 benchmark tasks**, versus $65.57, $78.11 and $72.23 for those Exa options, respectively. That’s **87% to 89% less search spend**. Average task time is 19.2s, versus 33.1s, 28.5s and 20.0s.

These are [Search API results in AA’s shared agent harness](https://artificialanalysis.ai/methodology/search-api), not scores for this MCP example. Task time includes measured search time and estimated model time; search spend excludes model cost. The [anonymous Parallel MCP endpoint uses Fast mode](https://docs.parallel.ai/integrations/mcp/search-mcp), which is why I’m using that result. Exa Auto is slightly ahead on the overall index (73.7 vs. 73.1); the case here is stronger research-task results at lower search cost, with no default replacement proposed.

I work at Parallel, which operates this service.

### Test plan

- Extracted the exact Python snippet and checked syntax, Ruff lint, and Ruff formatting.
- Executed the snippet against this checkout's SDK source with prebuilt dependencies, substituting the SDK's `ScriptedModel` for paid model calls. Verified native discovery of `web_search` and `web_fetch`, a real anonymous search with 10 results, a real fetch of the Python documentation page, and session cleanup.
- `git diff --check` passes.
- No repository build, full verification stack, or paid model calls were run, as requested. Two independent reviews of the unchanged diff found no actionable issues.

### Issue number

None.

### Checks

- [ ] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
