### PR TITLE
tests(sandbox): skip workspace path tests when symlinks are unavailable

### DIFF
--- a/tests/sandbox/test_workspace_paths.py
+++ b/tests/sandbox/test_workspace_paths.py
@@ -33,16 +33,23 @@ class WorkspacePathCase:
 
 
 def _symlink_or_skip(*args: Any, **kwargs: Any) -> None:
-    """Create a symlink, or skip the test where the platform forbids one.
+    """Create a symlink, or skip the test where Windows forbids one.
 
     Windows refuses symlink creation unless the process is elevated or Developer
     Mode is enabled, so these tests cannot run for an ordinary Windows contributor.
     CI runners hold the privilege, which is why this only shows up locally.
+
+    Only that specific failure is skipped. Any other OSError -- a missing parent,
+    an existing target, a full disk -- is re-raised, so a broken fixture cannot
+    quietly turn these path-policy and escape-rejection tests into passes. Mirrors
+    the helper of the same name in test_entries.py.
     """
     try:
         os.symlink(*args, **kwargs)
     except OSError as exc:
-        pytest.skip(f"Can't create symlinks: {exc}")
+        if os.name == "nt" and getattr(exc, "winerror", None) == 1314:
+            pytest.skip("symlink creation requires elevated privileges on Windows")
+        raise
 
 
 def _policy(root: Path | str = "/workspace") -> WorkspacePathPolicy:

--- a/tests/sandbox/test_workspace_paths.py
+++ b/tests/sandbox/test_workspace_paths.py
@@ -32,6 +32,19 @@ class WorkspacePathCase:
     error_context: dict[str, str] | None = None
 
 
+def _symlink_or_skip(*args: Any, **kwargs: Any) -> None:
+    """Create a symlink, or skip the test where the platform forbids one.
+
+    Windows refuses symlink creation unless the process is elevated or Developer
+    Mode is enabled, so these tests cannot run for an ordinary Windows contributor.
+    CI runners hold the privilege, which is why this only shows up locally.
+    """
+    try:
+        os.symlink(*args, **kwargs)
+    except OSError as exc:
+        pytest.skip(f"Can't create symlinks: {exc}")
+
+
 def _policy(root: Path | str = "/workspace") -> WorkspacePathPolicy:
     return WorkspacePathPolicy(root=root)
 
@@ -320,11 +333,11 @@ def test_normalize_path_with_symlink_resolution(tmp_path: Path) -> None:
 
     target = workspace / "target.txt"
     target.write_text("hello", encoding="utf-8")
-    os.symlink(target, workspace / "link.txt")
-    os.symlink(outside, workspace / "outside-link", target_is_directory=True)
+    _symlink_or_skip(target, workspace / "link.txt")
+    _symlink_or_skip(outside, workspace / "outside-link", target_is_directory=True)
 
     alias = tmp_path / "workspace-alias"
-    os.symlink(workspace, alias, target_is_directory=True)
+    _symlink_or_skip(workspace, alias, target_is_directory=True)
 
     test_cases = [
         WorkspacePathCase(
@@ -690,7 +703,7 @@ def test_host_io_rejects_write_under_resolved_read_only_extra_path_grant(
     grant_alias = tmp_path / "allowed-alias"
     workspace.mkdir()
     allowed.mkdir()
-    os.symlink(allowed, grant_alias, target_is_directory=True)
+    _symlink_or_skip(allowed, grant_alias, target_is_directory=True)
     target = allowed / "cache.db"
     grant = SandboxPathGrant(path=str(grant_alias), read_only=True)
     policy = WorkspacePathPolicy(
@@ -767,7 +780,7 @@ def test_host_io_rejects_extra_path_grant_symlink_to_root(tmp_path: Path) -> Non
     workspace = tmp_path / "workspace"
     root_alias = tmp_path / "root-alias"
     workspace.mkdir()
-    os.symlink(Path("/"), root_alias, target_is_directory=True)
+    _symlink_or_skip(Path("/"), root_alias, target_is_directory=True)
     policy = WorkspacePathPolicy(
         root=workspace,
         extra_path_grants=(SandboxPathGrant(path=str(root_alias)),),
@@ -781,7 +794,7 @@ def test_host_io_rejects_extra_path_grant_symlink_to_root(tmp_path: Path) -> Non
 
 def test_host_path_grant_rejects_symlink_to_root(tmp_path: Path) -> None:
     root_alias = tmp_path / "root-alias"
-    os.symlink(Path("/"), root_alias, target_is_directory=True)
+    _symlink_or_skip(Path("/"), root_alias, target_is_directory=True)
     grant = SandboxPathGrant(path="/mnt/shared-data", host_path=str(root_alias))
 
     with pytest.raises(
@@ -795,11 +808,11 @@ def test_host_path_grant_returns_validated_resolved_source(tmp_path: Path) -> No
     source = tmp_path / "source"
     source.mkdir()
     source_alias = tmp_path / "source-alias"
-    os.symlink(source, source_alias, target_is_directory=True)
+    _symlink_or_skip(source, source_alias, target_is_directory=True)
     grant = SandboxPathGrant(path="/mnt/shared-data", host_path=str(source_alias))
 
     resolved_source = sandbox_path_grant_host_path(grant)
     source_alias.unlink()
-    os.symlink(Path("/"), source_alias, target_is_directory=True)
+    _symlink_or_skip(Path("/"), source_alias, target_is_directory=True)
 
     assert resolved_source == source.resolve()


### PR DESCRIPTION
Five tests in test_workspace_paths.py create symlinks in their setup with no guard, so they fail on Windows for any user who is not elevated and does not have Developer Mode enabled:

    OSError: [WinError 1314] A required privilege is not held by the client

CI does not catch this: tests-windows runs the full suite on windows-latest and its runner holds the privilege, so these pass there and fail only locally.

Route the module's os.symlink calls through a small helper that skips with a clear reason when the platform refuses. Where symlinks work the helper is a passthrough, so behaviour on CI and on POSIX is unchanged.

test_workspace_paths.py on Windows: 5 failed / 65 passed -> 0 failed / 65 passed.

Note: this covers only the test-side half of the problem. The seven failures in test_tar_utils.py come from safe_extract_tarfile itself calling os.symlink unguarded, which needs a decision about symlink semantics on Windows and is left for maintainers.