### PR TITLE
refactor: share provider generation-span population

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -36,7 +36,7 @@ from ...models._response_terminal import (
     response_terminal_failure_error,
 )
 from ...models._retry_runtime import should_disable_provider_managed_retries
-from ...models._trace import model_config_for_trace
+from ...models._trace import model_config_for_trace, populate_generation_span
 from ...models.chatcmpl_converter import Converter
 from ...models.chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
 from ...models.chatcmpl_stream_handler import ChatCmplStreamHandler
@@ -798,30 +798,7 @@ class AnyLLMModel(Model):
         final_response: Response,
         tracing: ModelTracing,
     ) -> None:
-        if tracing.include_data():
-            span_generation.span_data.output = [final_response.model_dump()]
-
-        if final_response.usage is not None:
-            span_generation.span_data.usage = {
-                "requests": 1,
-                "input_tokens": final_response.usage.input_tokens,
-                "output_tokens": final_response.usage.output_tokens,
-                "total_tokens": final_response.usage.total_tokens,
-                "input_tokens_details": (
-                    final_response.usage.input_tokens_details.model_dump()
-                    if final_response.usage.input_tokens_details is not None
-                    else {"cached_tokens": 0, "cache_write_tokens": 0}
-                ),
-                "output_tokens_details": (
-                    final_response.usage.output_tokens_details.model_dump()
-                    if final_response.usage.output_tokens_details is not None
-                    else {"reasoning_tokens": 0}
-                ),
-            }
-        elif _requests_for_response_without_usage(final_response):
-            # Keep streamed tracing aligned with the non-streaming path, which records the
-            # request even when the provider reports no usage.
-            span_generation.span_data.usage = model_usage_to_span_usage(Usage(requests=1))
+        populate_generation_span(span_generation, final_response, tracing)
 
     @overload
     async def _fetch_chat_response(

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -45,7 +45,7 @@ from ...logger import log_model_action_debug, logger
 from ...model_settings import ModelSettings
 from ...models._openai_retry import get_openai_retry_advice
 from ...models._retry_runtime import should_disable_provider_managed_retries
-from ...models._trace import model_config_for_trace
+from ...models._trace import model_config_for_trace, populate_generation_span
 from ...models.chatcmpl_converter import Converter
 from ...models.chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
 from ...models.chatcmpl_stream_handler import ChatCmplStreamHandler
@@ -62,8 +62,6 @@ from ...usage import (
     Usage,
     _cache_write_tokens,
     _make_input_tokens_details,
-    _requests_for_response_without_usage,
-    model_usage_to_span_usage,
 )
 from ...util._error_tracing import model_span_errors
 from ...util._json import _to_dump_compatible
@@ -465,30 +463,7 @@ class LitellmModel(Model):
         final_response: Response,
         tracing: ModelTracing,
     ) -> None:
-        if tracing.include_data():
-            span_generation.span_data.output = [final_response.model_dump()]
-
-        if final_response.usage is not None:
-            span_generation.span_data.usage = {
-                "requests": 1,
-                "input_tokens": final_response.usage.input_tokens,
-                "output_tokens": final_response.usage.output_tokens,
-                "total_tokens": final_response.usage.total_tokens,
-                "input_tokens_details": (
-                    final_response.usage.input_tokens_details.model_dump()
-                    if final_response.usage.input_tokens_details is not None
-                    else {"cached_tokens": 0, "cache_write_tokens": 0}
-                ),
-                "output_tokens_details": (
-                    final_response.usage.output_tokens_details.model_dump()
-                    if final_response.usage.output_tokens_details is not None
-                    else {"reasoning_tokens": 0}
-                ),
-            }
-        elif _requests_for_response_without_usage(final_response):
-            # Keep streamed tracing aligned with the non-streaming path, which records the
-            # request even when the provider reports no usage.
-            span_generation.span_data.usage = model_usage_to_span_usage(Usage(requests=1))
+        populate_generation_span(span_generation, final_response, tracing)
 
     @overload
     async def _fetch_response(

--- a/src/agents/models/_trace.py
+++ b/src/agents/models/_trace.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from ..model_settings import ModelSettings
+from ..usage import Usage, _requests_for_response_without_usage, model_usage_to_span_usage
+
+if TYPE_CHECKING:
+    from openai.types.responses import Response
+
+    from ..tracing.span_data import GenerationSpanData
+    from ..tracing.spans import Span
+    from .interface import ModelTracing
 
 
 def sanitize_url_for_trace(url: object) -> str:
@@ -29,3 +37,35 @@ def model_config_for_trace(
     if extra_config:
         config.update(extra_config)
     return config
+
+
+def populate_generation_span(
+    span_generation: Span[GenerationSpanData],
+    final_response: Response,
+    tracing: ModelTracing,
+) -> None:
+    """Populate generation trace data from a Chat Completions adapter response."""
+    if tracing.include_data():
+        span_generation.span_data.output = [final_response.model_dump()]
+
+    if final_response.usage is not None:
+        span_generation.span_data.usage = {
+            "requests": 1,
+            "input_tokens": final_response.usage.input_tokens,
+            "output_tokens": final_response.usage.output_tokens,
+            "total_tokens": final_response.usage.total_tokens,
+            "input_tokens_details": (
+                final_response.usage.input_tokens_details.model_dump()
+                if final_response.usage.input_tokens_details is not None
+                else {"cached_tokens": 0, "cache_write_tokens": 0}
+            ),
+            "output_tokens_details": (
+                final_response.usage.output_tokens_details.model_dump()
+                if final_response.usage.output_tokens_details is not None
+                else {"reasoning_tokens": 0}
+            ),
+        }
+    elif _requests_for_response_without_usage(final_response):
+        # Keep streamed tracing aligned with the non-streaming path, which records the
+        # request even when the provider reports no usage.
+        span_generation.span_data.usage = model_usage_to_span_usage(Usage(requests=1))

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -34,14 +34,12 @@ from ..tracing.spans import Span
 from ..usage import (
     Usage,
     _raw_usage_snapshot,
-    _requests_for_response_without_usage,
-    model_usage_to_span_usage,
 )
 from ..util._error_tracing import model_span_errors
 from ..util._json import _to_dump_compatible
 from ._openai_retry import get_openai_retry_advice
 from ._retry_runtime import should_disable_provider_managed_retries
-from ._trace import model_config_for_trace
+from ._trace import model_config_for_trace, populate_generation_span
 from .chatcmpl_converter import Converter
 from .chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
 from .chatcmpl_stream_handler import ChatCmplStreamHandler
@@ -535,30 +533,7 @@ class OpenAIChatCompletionsModel(Model):
         final_response: Response,
         tracing: ModelTracing,
     ) -> None:
-        if tracing.include_data():
-            span_generation.span_data.output = [final_response.model_dump()]
-
-        if final_response.usage is not None:
-            span_generation.span_data.usage = {
-                "requests": 1,
-                "input_tokens": final_response.usage.input_tokens,
-                "output_tokens": final_response.usage.output_tokens,
-                "total_tokens": final_response.usage.total_tokens,
-                "input_tokens_details": (
-                    final_response.usage.input_tokens_details.model_dump()
-                    if final_response.usage.input_tokens_details is not None
-                    else {"cached_tokens": 0, "cache_write_tokens": 0}
-                ),
-                "output_tokens_details": (
-                    final_response.usage.output_tokens_details.model_dump()
-                    if final_response.usage.output_tokens_details is not None
-                    else {"reasoning_tokens": 0}
-                ),
-            }
-        elif _requests_for_response_without_usage(final_response):
-            # Keep streamed tracing aligned with the non-streaming path, which records the
-            # request even when the provider reports no usage.
-            span_generation.span_data.usage = model_usage_to_span_usage(Usage(requests=1))
+        populate_generation_span(span_generation, final_response, tracing)
 
     def _handle_unsupported_server_managed_conversation_state(
         self,

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -16,7 +16,11 @@ from openai.types.chat import (
 )
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, ChoiceDelta
-from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
+from openai.types.completion_usage import (
+    CompletionTokensDetails,
+    CompletionUsage,
+    PromptTokensDetails,
+)
 from openai.types.responses import (
     Response,
     ResponseCompletedEvent,
@@ -2075,6 +2079,59 @@ class _CloseSignalingStream(_ClosableStream):
         self._close_started.set()
         await self._release.wait()
         self.aclose_completed += 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_usage", [False, True], ids=["no-usage", "detailed-usage"])
+@pytest.mark.parametrize("tracing", [ModelTracing.ENABLED, ModelTracing.ENABLED_WITHOUT_DATA])
+async def test_any_llm_chat_stream_preserves_trace_data_at_completed(
+    monkeypatch, with_usage: bool, tracing: ModelTracing
+) -> None:
+    """Exercise real chat stream conversion while the adapter is suspended at its terminal yield."""
+    chunk = _chat_chunk("Hello")
+    if with_usage:
+        chunk.usage = CompletionUsage(
+            completion_tokens=5,
+            prompt_tokens=7,
+            total_tokens=12,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=2),
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=3),
+        )
+    stream = _ClosableStream([chunk])
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=stream)
+    module, _ = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    spans = _capture_spans(monkeypatch, module, "generation_span")
+
+    with trace(workflow_name="any-llm-chat-terminal-span"):
+        stream_agen = _stream_events(model, tracing)
+        try:
+            async for event in stream_agen:
+                if event.type == "response.completed":
+                    [span] = spans
+                    assert span.span_data.usage == {
+                        "requests": 1,
+                        "input_tokens": 7 if with_usage else 0,
+                        "output_tokens": 5 if with_usage else 0,
+                        "total_tokens": 12 if with_usage else 0,
+                        "input_tokens_details": {
+                            "cached_tokens": 2 if with_usage else 0,
+                            "cache_write_tokens": 0,
+                        },
+                        "output_tokens_details": {"reasoning_tokens": 3 if with_usage else 0},
+                    }
+                    assert span.span_data.output == (
+                        [event.response.model_dump()] if tracing == ModelTracing.ENABLED else None
+                    )
+                    assert (event.response.usage is not None) == with_usage
+                    break
+            else:
+                pytest.fail("The stream did not yield a completed response.")
+        finally:
+            await stream_agen.aclose()
+
+    assert stream.aclose_calls == 1
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -32,6 +32,7 @@ from agents.extensions.models.litellm_provider import LitellmProvider
 from agents.items import TResponseStreamEvent
 from agents.model_settings import ModelSettings
 from agents.models.interface import Model, ModelTracing
+from agents.tracing import get_current_span, trace
 
 
 @pytest.mark.allow_call_model_methods
@@ -827,7 +828,9 @@ def _patch_fetch_response(monkeypatch, provider_stream: _ClosableChatStream) -> 
     monkeypatch.setattr(LitellmModel, "_fetch_response", patched_fetch_response)
 
 
-def _stream_response(model: Model) -> AsyncIterator[TResponseStreamEvent]:
+def _stream_response(
+    model: Model, tracing: ModelTracing = ModelTracing.DISABLED
+) -> AsyncIterator[TResponseStreamEvent]:
     return model.stream_response(
         system_instructions=None,
         input="",
@@ -835,11 +838,63 @@ def _stream_response(model: Model) -> AsyncIterator[TResponseStreamEvent]:
         tools=[],
         output_schema=None,
         handoffs=[],
-        tracing=ModelTracing.DISABLED,
+        tracing=tracing,
         previous_response_id=None,
         conversation_id=None,
         prompt=None,
     )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_usage", [False, True], ids=["no-usage", "detailed-usage"])
+@pytest.mark.parametrize("tracing", [ModelTracing.ENABLED, ModelTracing.ENABLED_WITHOUT_DATA])
+async def test_stream_span_is_populated_before_yielding_completed(
+    monkeypatch, with_usage: bool, tracing: ModelTracing
+) -> None:
+    """Record exact trace data even when a consumer closes at the completed event."""
+    chunk = _text_chunk("Hello")
+    if with_usage:
+        chunk.usage = CompletionUsage(
+            completion_tokens=5,
+            prompt_tokens=7,
+            total_tokens=12,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=2),
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=3),
+        )
+    provider_stream = _ClosableChatStream([chunk])
+    _patch_fetch_response(monkeypatch, provider_stream)
+    model = LitellmProvider().get_model("gpt-4")
+
+    with trace(workflow_name="litellm-terminal-span"):
+        stream_agen = cast(Any, _stream_response(model, tracing))
+        try:
+            async for event in stream_agen:
+                if event.type == "response.completed":
+                    generation = get_current_span()
+                    assert generation is not None
+                    assert generation.span_data.usage == {
+                        "requests": 1,
+                        "input_tokens": 7 if with_usage else 0,
+                        "output_tokens": 5 if with_usage else 0,
+                        "total_tokens": 12 if with_usage else 0,
+                        "input_tokens_details": {
+                            "cached_tokens": 2 if with_usage else 0,
+                            "cache_write_tokens": 0,
+                        },
+                        "output_tokens_details": {"reasoning_tokens": 3 if with_usage else 0},
+                    }
+                    assert generation.span_data.output == (
+                        [event.response.model_dump()] if tracing == ModelTracing.ENABLED else None
+                    )
+                    assert (event.response.usage is not None) == with_usage
+                    break
+            else:
+                pytest.fail("The stream did not yield a completed response.")
+        finally:
+            await stream_agen.aclose()
+
+    assert provider_stream.aclose_calls == 1
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -50,6 +50,7 @@ from agents.models.chatcmpl_stream_handler import (
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
+from agents.tracing import get_current_span
 from tests.testing_processor import fetch_ordered_spans
 from tests.utils.simple_session import SimpleListSession
 
@@ -4326,16 +4327,29 @@ async def test_streamed_span_records_the_request_when_provider_omits_usage(monke
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+@pytest.mark.parametrize("with_usage", [False, True], ids=["no-usage", "detailed-usage"])
+@pytest.mark.parametrize("tracing", [ModelTracing.ENABLED, ModelTracing.ENABLED_WITHOUT_DATA])
 async def test_stream_span_is_recorded_for_a_consumer_that_stops_at_the_terminal_event(
-    monkeypatch,
+    monkeypatch, with_usage: bool, tracing: ModelTracing
 ) -> None:
     """A caller that stops at `response.completed` closes the generator.
 
     Anything recorded only after the yield loop never runs for such a consumer, so the span
     has to be populated before the terminal event is handed out.
     """
+    usage = (
+        CompletionUsage(
+            completion_tokens=5,
+            prompt_tokens=7,
+            total_tokens=12,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=2),
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=3),
+        )
+        if with_usage
+        else None
+    )
     monkeypatch.setattr(
-        OpenAIChatCompletionsModel, "_fetch_response", _usageless_stream_patch(usage=None)
+        OpenAIChatCompletionsModel, "_fetch_response", _usageless_stream_patch(usage=usage)
     )
     model = OpenAIProvider(use_responses=False).get_model("gpt-4")
 
@@ -4347,16 +4361,37 @@ async def test_stream_span_is_recorded_for_a_consumer_that_stops_at_the_terminal
             tools=[],
             output_schema=None,
             handoffs=[],
-            tracing=ModelTracing.ENABLED,
+            tracing=tracing,
             previous_response_id=None,
             conversation_id=None,
             prompt=None,
         )
         stream_agen = cast(Any, stream)
-        async for event in stream_agen:
-            if event.type == "response.completed":
-                break  # stop consuming, as a caller watching for the terminal event would
-        await stream_agen.aclose()
+        try:
+            async for event in stream_agen:
+                if event.type == "response.completed":
+                    generation = get_current_span()
+                    assert generation is not None
+                    assert generation.span_data.usage == {
+                        "requests": 1,
+                        "input_tokens": 7 if with_usage else 0,
+                        "output_tokens": 5 if with_usage else 0,
+                        "total_tokens": 12 if with_usage else 0,
+                        "input_tokens_details": {
+                            "cached_tokens": 2 if with_usage else 0,
+                            "cache_write_tokens": 0,
+                        },
+                        "output_tokens_details": {"reasoning_tokens": 3 if with_usage else 0},
+                    }
+                    assert generation.span_data.output == (
+                        [event.response.model_dump()] if tracing == ModelTracing.ENABLED else None
+                    )
+                    assert (event.response.usage is not None) == with_usage
+                    break
+            else:
+                pytest.fail("The stream did not yield a completed response.")
+        finally:
+            await stream_agen.aclose()
 
     generation = next(s for s in fetch_ordered_spans() if s.span_data.type == "generation")
     assert generation.span_data.usage is not None


### PR DESCRIPTION
This pull request updates the OpenAI Chat Completions, LiteLLM, and AnyLLM adapters to share generation-span population through `models/_trace.py`, removing three copies of the same conversion logic.

Trace output, usage accounting, sensitive-data exclusion, and updates before terminal events remain unchanged, including when a consumer closes the stream immediately after receiving the terminal event.