### PR TITLE
fix: route verification changes and require confirmed docs-only pushes

### DIFF
--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -10,6 +10,21 @@ if [ -z "${GITHUB_OUTPUT:-}" ]; then
   exit 1
 fi
 
+# Unknown changes require checks, but cannot authorize deployment.
+unknown_changes() {
+  echo "Unable to determine changed files." >&2
+  if [ "$mode" = "docs-only" ]; then
+    echo "run=false" >> "$GITHUB_OUTPUT"
+  else
+    echo "run=true" >> "$GITHUB_OUTPUT"
+  fi
+  exit 0
+}
+
+if [ "$mode" = "docs-only" ] && { [ -z "$base_sha" ] || [ -z "$head_sha" ]; }; then
+  unknown_changes
+fi
+
 if [ -z "$head_sha" ]; then
   head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
 fi
@@ -24,40 +39,49 @@ if [ -z "$base_sha" ]; then
 fi
 
 if [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
-  echo "run=true" >> "$GITHUB_OUTPUT"
-  exit 0
+  unknown_changes
 fi
 
 if [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
-  echo "run=true" >> "$GITHUB_OUTPUT"
-  exit 0
+  unknown_changes
 fi
 
-if ! git cat-file -e "$base_sha" 2>/dev/null; then
-  git fetch --no-tags --depth=1 origin "$base_sha" || true
+for sha in "$base_sha" "$head_sha"; do
+  if ! git cat-file -e "$sha^{commit}" 2>/dev/null; then
+    git fetch --no-tags --depth=1 origin "$sha" || true
+  fi
+  if ! git cat-file -e "$sha^{commit}" 2>/dev/null; then
+    unknown_changes
+  fi
+done
+
+changed_files=$(mktemp)
+trap 'rm -f "$changed_files"' EXIT
+# Include both sides of renames and preserve complete Git path names.
+if ! git diff --name-only --no-renames -z "$base_sha" "$head_sha" -- > "$changed_files"; then
+  unknown_changes
 fi
 
-if ! git cat-file -e "$base_sha" 2>/dev/null; then
-  echo "run=true" >> "$GITHUB_OUTPUT"
-  exit 0
-fi
-
-changed_files=$(git diff --name-only "$base_sha" "$head_sha" || true)
-
+docs_pattern='^(docs/|mkdocs\.yml$)'
 case "$mode" in
   code)
-    pattern='^(src/|tests/|integration_tests/|examples/|\.agents/skills/(code-change-verification|examples-auto-run|examples-run-analysis|integration-tests)/|\.github/scripts/(detect-changes\.sh|run_examples\.sh|run_integration_tests\.py|update_released_api_contract\.py)$|\.github/workflows/tests\.yml$|pyproject.toml$|uv.lock$|Makefile$)'
+    pattern='^(src/|tests/|integration_tests/|examples/|docs/scripts/|\.agents/skills/(code-change-verification|examples-auto-run|examples-run-analysis|integration-tests)/|\.github/scripts/|\.github/workflows/(tests|docs|publish)\.yml$|pyproject\.toml$|uv\.lock$|Makefile$|pyrightconfig\.json$)'
     ;;
-  docs)
-    pattern='^(docs/|mkdocs.yml$)'
+  docs|docs-only)
+    pattern="$docs_pattern"
     ;;
   *)
     pattern="$mode"
     ;;
 esac
 
-if echo "$changed_files" | grep -Eq "$pattern"; then
-  echo "run=true" >> "$GITHUB_OUTPUT"
-else
-  echo "run=false" >> "$GITHUB_OUTPUT"
-fi
+run=false
+while IFS= read -r -d '' path; do
+  if [[ "$path" =~ $pattern ]]; then
+    run=true
+  elif [ "$mode" = "docs-only" ]; then
+    run=false
+    break
+  fi
+done < "$changed_files"
+echo "run=$run" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -65,7 +65,7 @@ fi
 docs_pattern='^(docs/|mkdocs\.yml$)'
 case "$mode" in
   code)
-    pattern='^(src/|tests/|integration_tests/|examples/|docs/scripts/|\.agents/skills/(code-change-verification|examples-auto-run|examples-run-analysis|integration-tests)/|\.github/scripts/|\.github/workflows/(tests|docs|publish)\.yml$|pyproject\.toml$|uv\.lock$|Makefile$|pyrightconfig\.json$)'
+    pattern='^(src/|tests/|integration_tests/|examples/|docs/scripts/|\.agents/skills/(code-change-verification|examples-auto-run|examples-run-analysis|integration-tests)/|\.github/scripts/|\.github/workflows/(tests|docs|publish|repo-skills)\.yml$|pyproject\.toml$|uv\.lock$|Makefile$|pyrightconfig\.json$)'
     ;;
   docs|docs-only)
     pattern="$docs_pattern"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,23 +19,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Determine docs-only push
         id: docs-only
-        run: |
-          if [ "${{ github.event_name }}" != "push" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          set -euo pipefail
-          before="${{ github.event.before }}"
-          sha="${{ github.sha }}"
-          changed_files=$(git diff --name-only "$before" "$sha" || true)
-          non_docs=$(echo "$changed_files" | grep -vE '^(docs/|mkdocs.yml$)' || true)
-          if [ -n "$non_docs" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: ./.github/scripts/detect-changes.sh docs-only
       - name: Setup uv
-        if: steps.docs-only.outputs.skip != 'true'
+        if: steps.docs-only.outputs.run == 'true'
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # setup-uv v9.0.0; uv 0.11.14
         with:
           version: "0.11.14"
@@ -43,8 +32,8 @@ jobs:
           prune-cache: true
           python-version: "3.14"
       - name: Install dependencies
-        if: steps.docs-only.outputs.skip != 'true'
+        if: steps.docs-only.outputs.run == 'true'
         run: make sync
       - name: Deploy docs
-        if: steps.docs-only.outputs.skip != 'true'
+        if: steps.docs-only.outputs.run == 'true'
         run: make deploy-docs

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -111,6 +111,7 @@ def _detect(
         (".github/workflows/tests.yml", True, False, False),
         (".github/workflows/docs.yml", True, False, False),
         (".github/workflows/publish.yml", True, False, False),
+        (".github/workflows/repo-skills.yml", True, False, False),
         ("pyproject.toml", True, False, False),
         ("uv.lock", True, False, False),
         ("Makefile", True, False, False),

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DETECTOR = ROOT / ".github/scripts/detect-changes.sh"
+ZERO_SHA = "0" * 40
+MISSING_SHA = "1" * 40
+
+
+def _environment() -> dict[str, str]:
+    env = os.environ.copy()
+    for key in ("OPENAI_API_KEY", "BASE_SHA", "HEAD_SHA", "GITHUB_OUTPUT"):
+        env.pop(key, None)
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_ALLOW_PROTOCOL"] = "file"
+    return env
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_environment(),
+        timeout=10,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, *paths: str) -> str:
+    for name in paths:
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("Changed content.\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "--allow-empty", "-m", "Record test changes")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def change_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "source"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.name", "Change detection test")
+    _git(repo, "config", "user.email", "change-test@example.invalid")
+    return repo, _commit(repo)
+
+
+def _detect(
+    repo: Path,
+    mode: str,
+    base: str,
+    head: str,
+    *,
+    extra_env: dict[str, str] | None = None,
+    command: list[str] | None = None,
+) -> bool:
+    output = repo.parent / "github-output"
+    output.write_text("", encoding="utf-8")
+    env = _environment()
+    env.update(extra_env or {})
+    env["GITHUB_OUTPUT"] = str(output)
+    result = subprocess.run(
+        command or ["bash", str(DETECTOR), mode, base, head],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    value = output.read_text(encoding="utf-8")
+    assert value in ("run=true\n", "run=false\n"), (value, result.stderr)
+    return value == "run=true\n"
+
+
+@pytest.mark.parametrize(
+    ("path", "code", "docs", "docs_only"),
+    [
+        ("src/agents/run.py", True, False, False),
+        ("tests/test_release_provenance.py", True, False, False),
+        ("integration_tests/test_contract.py", True, False, False),
+        ("examples/basic.py", True, False, False),
+        (".github/scripts/detect-changes.sh", True, False, False),
+        (".github/scripts/check_optional_truthiness.py", True, False, False),
+        (".github/scripts/run_serial_tests.py", True, False, False),
+        (".github/scripts/run-asyncio-teardown-stability.sh", True, False, False),
+        (".github/scripts/verify_release.py", True, False, False),
+        (".github/scripts/run_integration_tests.py", True, False, False),
+        (".github/scripts/run_examples.sh", True, False, False),
+        (".github/scripts/update_released_api_contract.py", True, False, False),
+        (".github/scripts/run_repo_skill_tests.py", True, False, False),
+        (".github/workflows/tests.yml", True, False, False),
+        (".github/workflows/docs.yml", True, False, False),
+        (".github/workflows/publish.yml", True, False, False),
+        ("pyproject.toml", True, False, False),
+        ("uv.lock", True, False, False),
+        ("Makefile", True, False, False),
+        ("pyrightconfig.json", True, False, False),
+        (".agents/skills/code-change-verification/SKILL.md", True, False, False),
+        (".agents/skills/examples-run-analysis/SKILL.md", True, False, False),
+        ("docs/scripts/generate_ref_files.py", True, True, True),
+        ("docs/index.md", False, True, True),
+        ("docs/日本語 guide.md", False, True, True),
+        pytest.param(
+            "docs/line\nbreak.md",
+            False,
+            True,
+            True,
+            marks=pytest.mark.skipif(os.name == "nt", reason="Windows forbids newlines in paths."),
+        ),
+        ("mkdocs.yml", False, True, True),
+        ("mkdocs-yml", False, False, False),
+        ("README.md", False, False, False),
+        ("AGENTS.md", False, False, False),
+        (".github/RELEASING.md", False, False, False),
+    ],
+)
+def test_changed_paths_select_owning_checks(
+    change_repo: tuple[Path, str], path: str, code: bool, docs: bool, docs_only: bool
+) -> None:
+    repo, base = change_repo
+    head = _commit(repo, path)
+
+    for mode, expected in (("code", code), ("docs", docs), ("docs-only", docs_only)):
+        assert _detect(repo, mode, base, head) is expected, mode
+
+
+def test_mixed_push_builds_docs_and_checks_code_without_deploying(
+    change_repo: tuple[Path, str],
+) -> None:
+    repo, base = change_repo
+    _commit(repo, "src/agents/run.py")
+    head = _commit(repo, "docs/index.md")
+
+    assert _detect(repo, "code", base, head)
+    assert _detect(repo, "docs", base, head)
+    assert not _detect(repo, "docs-only", base, head)
+
+
+@pytest.mark.parametrize(
+    ("missing", "docs_only"), [("base", False), ("base", True), ("head", True)]
+)
+def test_shallow_checkout_fetches_missing_event_commit(
+    change_repo: tuple[Path, str], tmp_path: Path, missing: str, docs_only: bool
+) -> None:
+    repo, base = change_repo
+    if not docs_only:
+        _commit(repo, "src/agents/run.py")
+    head = _commit(repo, "docs/index.md")
+    clone = tmp_path / "checkout"
+    _git(tmp_path, "clone", "--depth=1", repo.as_uri(), str(clone))
+    if missing == "head":
+        # A detached event commit can be fetched even when absent from the local checkout.
+        head = _commit(repo, "docs/next.md")
+        base = _git(clone, "rev-parse", "HEAD")
+    assert _git(clone, "rev-parse", "--is-shallow-repository") == "true"
+
+    assert _detect(clone, "docs-only", base, head) is docs_only
+    _git(clone, "cat-file", "-e", f"{base}^{{commit}}")
+    _git(clone, "cat-file", "-e", f"{head}^{{commit}}")
+
+
+def test_force_push_fetches_before_commit_outside_current_history(
+    change_repo: tuple[Path, str], tmp_path: Path
+) -> None:
+    repo, initial = change_repo
+    base = _commit(repo, "docs/old.md")
+    _git(repo, "reset", "--hard", initial)
+    head = _commit(repo, "docs/new.md")
+    clone = tmp_path / "checkout"
+    _git(tmp_path, "clone", "--depth=1", repo.as_uri(), str(clone))
+
+    assert _detect(clone, "docs-only", base, head)
+    _git(clone, "cat-file", "-e", f"{base}^{{commit}}")
+
+
+@pytest.mark.parametrize("base_kind", ["unavailable", "new-branch", "missing-input"])
+def test_unknown_base_requires_checks_and_denies_deployment(
+    change_repo: tuple[Path, str], base_kind: str
+) -> None:
+    repo, _ = change_repo
+    head = _commit(repo, "docs/index.md")
+    base = {"unavailable": MISSING_SHA, "new-branch": ZERO_SHA, "missing-input": ""}[base_kind]
+
+    assert _detect(repo, "code", base, head)
+    assert _detect(repo, "docs", base, head)
+    assert not _detect(repo, "docs-only", base, head)
+
+
+def test_unknown_head_requires_checks_and_denies_deployment(
+    change_repo: tuple[Path, str],
+) -> None:
+    repo, base = change_repo
+
+    assert _detect(repo, "code", base, MISSING_SHA)
+    assert _detect(repo, "docs", base, MISSING_SHA)
+    assert not _detect(repo, "docs-only", base, MISSING_SHA)
+    assert not _detect(repo, "docs-only", base, "")
+
+
+def test_failed_diff_cannot_skip_checks_or_authorize_deployment(
+    change_repo: tuple[Path, str], tmp_path: Path
+) -> None:
+    repo, base = change_repo
+    head = _commit(repo, "docs/index.md")
+    git = shutil.which("git")
+    assert git is not None
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    shim = bin_dir / "git"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = diff ]; then\n'
+        "  printf 'docs/index.md\\0'\n"
+        "  exit 128\n"
+        "fi\n"
+        f'exec {shlex.quote(Path(git).as_posix())} "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+
+    assert _detect(repo, "code", base, head, extra_env=env)
+    assert _detect(repo, "docs", base, head, extra_env=env)
+    assert not _detect(repo, "docs-only", base, head, extra_env=env)
+
+
+def test_empty_diff_does_not_run_checks_or_deploy(change_repo: tuple[Path, str]) -> None:
+    repo, base = change_repo
+
+    for mode in ("code", "docs", "docs-only"):
+        assert not _detect(repo, mode, base, base)
+
+
+def test_rename_into_docs_still_counts_removed_code(change_repo: tuple[Path, str]) -> None:
+    repo, _ = change_repo
+    base = _commit(repo, "src/old.py")
+    (repo / "docs").mkdir()
+    _git(repo, "mv", "src/old.py", "docs/new.md")
+    head = _commit(repo)
+
+    assert _detect(repo, "code", base, head)
+    assert _detect(repo, "docs", base, head)
+    assert not _detect(repo, "docs-only", base, head)
+
+
+def test_code_mode_retains_merge_base_and_head_fallback(change_repo: tuple[Path, str]) -> None:
+    repo, base = change_repo
+    _git(repo, "update-ref", "refs/remotes/origin/main", base)
+    _commit(repo, "src/agents/run.py")
+
+    assert _detect(repo, "code", "", "")
+
+
+def test_custom_pattern_mode_is_preserved(change_repo: tuple[Path, str]) -> None:
+    repo, base = change_repo
+    head = _commit(repo, "README.md")
+
+    assert _detect(repo, r"^README\.md$", base, head)
+    assert not _detect(repo, r"^other/", base, head)
+
+
+def test_docs_workflow_requires_positive_detector_evidence(change_repo: tuple[Path, str]) -> None:
+    workflow = yaml.load(
+        (ROOT / ".github/workflows/docs.yml").read_text(encoding="utf-8"), Loader=yaml.BaseLoader
+    )
+    assert workflow["on"] == {"push": {"branches": ["main"], "paths": ["docs/**", "mkdocs.yml"]}}
+    steps = workflow["jobs"]["deploy_docs"]["steps"]
+    detection = next(step for step in steps if step.get("id") == "docs-only")
+    assert detection["env"] == {
+        "BASE_SHA": "${{ github.event.before }}",
+        "HEAD_SHA": "${{ github.sha }}",
+    }
+    for step in steps[steps.index(detection) + 1 :]:
+        assert step["if"] == "steps.docs-only.outputs.run == 'true'"
+
+    repo, base = change_repo
+    script = repo / DETECTOR.relative_to(ROOT)
+    script.parent.mkdir(parents=True)
+    shutil.copy2(DETECTOR, script)
+    base = _commit(repo)
+    head = _commit(repo, "docs/index.md")
+    command = ["bash", "-euo", "pipefail", "-c", detection["run"]]
+    assert _detect(
+        repo, "", "", "", extra_env={"BASE_SHA": base, "HEAD_SHA": head}, command=command
+    )
+    head = _commit(repo, "src/agents/run.py")
+    assert not _detect(
+        repo, "", "", "", extra_env={"BASE_SHA": base, "HEAD_SHA": head}, command=command
+    )

--- a/tests/test_change_detection.py
+++ b/tests/test_change_detection.py
@@ -64,22 +64,29 @@ def _detect(
     head: str,
     *,
     extra_env: dict[str, str] | None = None,
-    command: list[str] | None = None,
+    bash_args: list[str] | None = None,
 ) -> bool:
+    if os.name == "nt":
+        # Resolve Git for Windows' Bash instead of the system WSL launcher.
+        git_exec_path = Path(_git(repo, "--exec-path"))
+        bash = str(git_exec_path.parents[2] / "bin/bash.exe")
+    else:
+        bash = shutil.which("bash")
+        assert bash is not None
     output = repo.parent / "github-output"
     output.write_text("", encoding="utf-8")
     env = _environment()
     env.update(extra_env or {})
-    env["GITHUB_OUTPUT"] = str(output)
+    env["GITHUB_OUTPUT"] = output.as_posix()
     result = subprocess.run(
-        command or ["bash", str(DETECTOR), mode, base, head],
+        [bash, *(bash_args or [DETECTOR.as_posix(), mode, base, head])],
         cwd=repo,
         env=env,
         capture_output=True,
         text=True,
         timeout=10,
     )
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, (result.stdout, result.stderr)
     value = output.read_text(encoding="utf-8")
     assert value in ("run=true\n", "run=false\n"), (value, result.stderr)
     return value == "run=true\n"
@@ -228,13 +235,19 @@ def test_failed_diff_cannot_skip_checks_or_authorize_deployment(
         "fi\n"
         f'exec {shlex.quote(Path(git).as_posix())} "$@"\n',
         encoding="utf-8",
+        newline="\n",
     )
     shim.chmod(0o755)
-    env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
-
-    assert _detect(repo, "code", base, head, extra_env=env)
-    assert _detect(repo, "docs", base, head, extra_env=env)
-    assert not _detect(repo, "docs-only", base, head, extra_env=env)
+    # Set the shim's precedence after Git Bash's wrapper initializes PATH.
+    bash_args = [
+        "-c",
+        'export PATH="$(cd "$1" && pwd):$PATH"; shift; exec "$@"',
+        "bash",
+        bin_dir.as_posix(),
+        DETECTOR.as_posix(),
+    ]
+    for mode, expected in (("code", True), ("docs", True), ("docs-only", False)):
+        assert _detect(repo, mode, base, head, bash_args=[*bash_args, mode, base, head]) is expected
 
 
 def test_empty_diff_does_not_run_checks_or_deploy(change_repo: tuple[Path, str]) -> None:
@@ -292,11 +305,11 @@ def test_docs_workflow_requires_positive_detector_evidence(change_repo: tuple[Pa
     shutil.copy2(DETECTOR, script)
     base = _commit(repo)
     head = _commit(repo, "docs/index.md")
-    command = ["bash", "-euo", "pipefail", "-c", detection["run"]]
+    bash_args = ["-euo", "pipefail", "-c", detection["run"]]
     assert _detect(
-        repo, "", "", "", extra_env={"BASE_SHA": base, "HEAD_SHA": head}, command=command
+        repo, "", "", "", extra_env={"BASE_SHA": base, "HEAD_SHA": head}, bash_args=bash_args
     )
     head = _commit(repo, "src/agents/run.py")
     assert not _detect(
-        repo, "", "", "", extra_env={"BASE_SHA": base, "HEAD_SHA": head}, command=command
+        repo, "", "", "", extra_env={"BASE_SHA": base, "HEAD_SHA": head}, bash_args=bash_args
     )

--- a/tests/test_integration_runner.py
+++ b/tests/test_integration_runner.py
@@ -11,7 +11,6 @@ from typing import Any, cast
 import pytest
 
 RUNNER = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "run_integration_tests.py"
-CHANGE_DETECTOR = RUNNER.with_name("detect-changes.sh")
 INTEGRATION_CONFTEST = RUNNER.parents[2] / "integration_tests" / "conftest.py"
 
 
@@ -573,18 +572,6 @@ def test_extra_collection_deselects_only_non_applicable_memory_backends(
 
     assert items == [requested, matching]
     assert deselected == [non_applicable]
-
-
-def test_code_change_detection_includes_packaged_contract_inputs() -> None:
-    detector = CHANGE_DETECTOR.read_text(encoding="utf-8")
-
-    assert "integration_tests/" in detector
-    assert "detect-changes\\.sh" in detector
-    assert "run_integration_tests\\.py" in detector
-    assert "run_examples\\.sh" in detector
-    assert "examples-run-analysis" in detector
-    assert "update_released_api_contract\\.py" in detector
-    assert "\\.github/workflows/tests\\.yml" in detector
 
 
 def test_packaging_profile_checks_dependency_present_contract_for_wheel_and_sdist(


### PR DESCRIPTION
This pull request fixes skipped CI checks when verification scripts, workflow controls, or typecheck configuration change. Documentation deployment now uses the shared change detector, fetches missing event commits, and requires a successful, nonempty docs-only diff. Mixed changes, failed comparisons, and code-to-docs renames cannot authorize deployment.