### PR TITLE
chore: run repository skill tests in dedicated CI

### DIFF
--- a/.agents/skills/implementation-final-review/scripts/test_review_state.py
+++ b/.agents/skills/implementation-final-review/scripts/test_review_state.py
@@ -332,7 +332,8 @@ class ReviewStateTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "HEAD does not match.*vendor/dependency"):
             review_state(self.repo, self.base, ("vendor/dependency",))
 
-        self._git("add", "vendor/dependency")
+        # Stage the new gitlink even though the fixture intentionally ignores this submodule.
+        self._git("add", "--force", "vendor/dependency")
         clean_state = review_state(self.repo, self.base, ("vendor/dependency",))
 
         self.assertEqual(

--- a/.github/scripts/repo-skill-tests.md
+++ b/.github/scripts/repo-skill-tests.md
@@ -1,0 +1,19 @@
+# Repository skill tests
+
+Run `make tests-repo-skills` from the repository root. This command uses `uv run --no-project --python 3.11` and needs Git and make for disposable repository fixtures. It installs no SDK dependencies and does not collect `tests/` or pytest configuration. With an existing Python 3.11+ interpreter, use `python .github/scripts/run_repo_skill_tests.py` directly.
+
+Use `uv run --no-project --python 3.11 python .github/scripts/run_repo_skill_tests.py --list` to print the discovered inventory without executing tests. The runner discovers `.agents/skills/*/scripts/test_*.py` and its own `.github/scripts/test_run_repo_skill_tests.py` regression suite. Add skill helper tests under that pattern using standard-library `unittest` and sibling imports.
+
+The current skill inventory contains 159 tests across five modules:
+
+| Skill | Module | Tests |
+| --- | --- | --- |
+| implementation-final-review | test_review_protocol.py | 77 |
+| implementation-final-review | test_review_state.py | 43 |
+| implementation-kickoff | test_validate_handoff.py | 12 |
+| release-candidate-prep | test_prepare.py | 17 |
+| sensitive-logging-audit | test_inventory.py | 10 |
+
+Each module runs in a separate interpreter from its own scripts directory so sibling imports cannot collide across suites. Child processes receive only process essentials and fixed test settings; inherited API keys, tokens, Python import overrides, and user Git configuration are excluded. Git transport is limited to local files. Tests must use disposable local Git repositories and local bare origins, with no live service calls.
+
+The runner executes every discovered module and reports all failed modules before returning a nonzero exit code. An empty skill inventory also fails. The dedicated `repo-skills.yml` workflow runs the same Make target when skills or the command's owning files change. Existing review tiers, budgets, and validator behavior are unchanged.

--- a/.github/scripts/run_repo_skill_tests.py
+++ b/.github/scripts/run_repo_skill_tests.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Run repository skill unittest modules without collecting the SDK suite."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_environment() -> dict[str, str]:
+    """Keep process essentials, excluding credentials and user Git configuration."""
+    env = {
+        name: os.environ[name]
+        for name in ("PATH", "SYSTEMROOT", "WINDIR", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL")
+        if name in os.environ
+    }
+    # Release fixtures invoke python through make, so use this interpreter's directory first.
+    env["PATH"] = os.pathsep.join((str(Path(sys.executable).parent), env.get("PATH", os.defpath)))
+    env.update(
+        GIT_CONFIG_GLOBAL=os.devnull,
+        GIT_CONFIG_NOSYSTEM="1",
+        GIT_ALLOW_PROTOCOL="file",
+        GIT_TERMINAL_PROMPT="0",
+        UV_DEFAULT_INDEX="https://pypi.org/simple",
+    )
+    return env
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list", action="store_true", help="List discovered modules without running."
+    )
+    args = parser.parse_args()
+    repo = Path(__file__).resolve().parents[2]
+    skill_tests = sorted(repo.glob(".agents/skills/*/scripts/test_*.py"))
+    if not skill_tests:
+        parser.error("No repository skill test modules found.")
+    tests = sorted([*skill_tests, *repo.glob(".github/scripts/test_run_repo_skill_tests.py")])
+    print(f"Discovered {len(tests)} repository skill test modules:", flush=True)
+    for path in tests:
+        print(f"  {path.relative_to(repo).as_posix()}", flush=True)
+    if args.list:
+        return 0
+
+    env = test_environment()
+    failed = []
+    for path in tests:
+        print(f"\nRunning {path.relative_to(repo).as_posix()}", flush=True)
+        result = subprocess.run(
+            [sys.executable, "-m", "unittest", "discover", "-s", ".", "-p", path.name, "-v"],
+            cwd=path.parent,
+            env=env,
+            check=False,
+        )
+        if result.returncode:
+            failed.append(path.relative_to(repo).as_posix())
+
+    print(f"\nCompleted {len(tests)} modules; {len(failed)} failed.", flush=True)
+    for path in failed:
+        print(f"  FAILED: {path}", flush=True)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_run_repo_skill_tests.py
+++ b/.github/scripts/test_run_repo_skill_tests.py
@@ -1,0 +1,142 @@
+"""Exercise the runner CLI in disposable repositories without loading the SDK."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from run_repo_skill_tests import test_environment
+
+
+class RepoSkillRunnerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.repo = Path(directory.name)
+        self.runner = self.repo / ".github/scripts/run_repo_skill_tests.py"
+        self.runner.parent.mkdir(parents=True)
+        shutil.copyfile(Path(__file__).with_name(self.runner.name), self.runner)
+
+    def write_suite(self, skill: str, source: str) -> Path:
+        path = self.repo / ".agents/skills" / skill / "scripts/test_fixture.py"
+        path.parent.mkdir(parents=True)
+        path.write_text(source, encoding="utf-8")
+        return path
+
+    def run_cli(
+        self, *args: str, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(self.runner), *args],
+            cwd=self.repo.parent,
+            env=test_environment() if env is None else env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+    def test_inventory_is_sorted_and_listing_does_not_execute_tests(self) -> None:
+        for name in ("z-last", "a-first"):
+            self.write_suite(name, "raise RuntimeError('must not execute during listing')\n")
+        result = self.run_cli("--list")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [
+                "Discovered 2 repository skill test modules:",
+                "  .agents/skills/a-first/scripts/test_fixture.py",
+                "  .agents/skills/z-last/scripts/test_fixture.py",
+            ],
+        )
+
+    def test_isolated_modules_keep_sibling_imports_and_exclude_sdk_tests(self) -> None:
+        for name in ("first", "second"):
+            suite = self.write_suite(
+                name,
+                "import unittest\nfrom helper import VALUE\n"
+                "class Fixture(unittest.TestCase):\n"
+                f"    def test_value(self): self.assertEqual(VALUE, {name!r})\n",
+            )
+            suite.with_name("helper.py").write_text(f"VALUE = {name!r}\n", encoding="utf-8")
+        sdk_suite = self.repo / "tests/test_sdk.py"
+        sdk_suite.parent.mkdir()
+        sdk_suite.write_text("raise RuntimeError('SDK suite must not be collected')\n")
+        result = self.run_cli()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Completed 2 modules; 0 failed.", result.stdout)
+        self.assertEqual(result.stderr.count("Ran 1 test"), 2)
+
+    def test_failure_propagates_and_later_modules_still_execute(self) -> None:
+        self.write_suite(
+            "a-failing",
+            "import unittest\nclass Fixture(unittest.TestCase):\n"
+            "    def test_failure(self): self.fail('deliberate fixture failure')\n",
+        )
+        self.write_suite(
+            "z-passing",
+            "import unittest\nfrom pathlib import Path\nclass Fixture(unittest.TestCase):\n"
+            "    def test_later(self): Path('executed.txt').write_text('ran')\n",
+        )
+        result = self.run_cli()
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("deliberate fixture failure", result.stderr)
+        self.assertIn("Completed 2 modules; 1 failed.", result.stdout)
+        self.assertTrue((self.repo / ".agents/skills/z-passing/scripts/executed.txt").is_file())
+
+    def test_import_failure_propagates(self) -> None:
+        self.write_suite("broken", "raise ImportError('broken helper import')\n")
+        result = self.run_cli()
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("broken helper import", result.stderr)
+
+    def test_empty_skill_inventory_fails(self) -> None:
+        result = self.run_cli()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("No repository skill test modules found", result.stderr)
+
+    def test_children_drop_credentials_and_git_only_allows_local_remotes(self) -> None:
+        self.write_suite(
+            "environment",
+            """import os
+import subprocess
+import sys
+import unittest
+
+class Fixture(unittest.TestCase):
+    def test_environment(self):
+        for name in ('OPENAI_API_KEY', 'OPENAI_API_KEY_SOURCE', 'GH_TOKEN', 'GITHUB_TOKEN',
+                     'AZURE_OPENAI_API_KEY', 'AWS_SECRET_ACCESS_KEY', 'PYTHONPATH'):
+            self.assertNotIn(name, os.environ)
+        subprocess.run([sys.executable, '-c',
+                        "import os; assert 'OPENAI_API_KEY' not in os.environ"], check=True)
+        subprocess.run(['git', 'init', '--bare', 'origin.git'], check=True, capture_output=True)
+        local = subprocess.run(['git', 'ls-remote', 'origin.git'], capture_output=True)
+        self.assertEqual(local.returncode, 0, local.stderr)
+        remote = subprocess.run(['git', 'ls-remote', 'https://example.invalid/repo.git'],
+                                capture_output=True, text=True)
+        self.assertNotEqual(remote.returncode, 0)
+        self.assertIn("transport 'https' not allowed", remote.stderr)
+""",
+        )
+        env = test_environment()
+        # Only synthetic values enter this fixture; inherited credentials are never forwarded.
+        env.update(
+            OPENAI_API_KEY="fixture-only",
+            OPENAI_API_KEY_SOURCE="fixture-only",
+            GH_TOKEN="fixture-only",
+            GITHUB_TOKEN="fixture-only",
+            AZURE_OPENAI_API_KEY="fixture-only",
+            AWS_SECRET_ACCESS_KEY="fixture-only",
+            PYTHONPATH=str(self.repo / "unused"),
+        )
+        result = self.run_cli(env=env)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/repo-skills.yml
+++ b/.github/workflows/repo-skills.yml
@@ -1,0 +1,41 @@
+name: Repository skills
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .agents/**
+      - .github/scripts/*repo_skill_tests.py
+      - .github/scripts/repo-skill-tests.md
+      - .github/workflows/repo-skills.yml
+      - Makefile
+  pull_request:
+    paths:
+      - .agents/**
+      - .github/scripts/*repo_skill_tests.py
+      - .github/scripts/repo-skill-tests.md
+      - .github/workflows/repo-skills.yml
+      - Makefile
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repo-skills:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # setup-uv v9.0.0; uv 0.11.14
+        with:
+          version: "0.11.14"
+          python-version: "3.11"
+          enable-cache: false
+      - name: Run repository skill tests
+        run: make tests-repo-skills

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ tests-review: tests-parallel-review
 tests-asyncio-stability:
 	bash .github/scripts/run-asyncio-teardown-stability.sh
 
+.PHONY: tests-repo-skills
+tests-repo-skills:
+	env -u OPENAI_API_KEY uv run --no-project --python 3.11 python .github/scripts/run_repo_skill_tests.py
+
 .PHONY: tests-parallel
 tests-parallel:
 	uv run pytest -n "$${PYTEST_XDIST_AUTO_NUM_WORKERS:-auto}" $(if $(PYTEST_XDIST_AUTO_NUM_WORKERS),,--maxprocesses=9) --dist worksteal -m "not serial"


### PR DESCRIPTION
This pull request adds `make tests-repo-skills` and a dedicated CI workflow for the 159 existing skill helper tests excluded from ordinary SDK test collection.

The runner lists discovered modules, executes each in a separate interpreter without installing SDK dependencies, and reports failures after running every suite. Child processes exclude inherited credentials and restrict Git transport to local files. Six regression tests cover discovery, import isolation, failure propagation, and environment handling.