### PR TITLE
fix(sandbox): preserve empty Mountpoint prefixes

### DIFF
--- a/src/agents/sandbox/entries/mounts/providers/gcs.py
+++ b/src/agents/sandbox/entries/mounts/providers/gcs.py
@@ -142,7 +142,7 @@ class GCSMount(_ConfiguredMount):
                 access_key_id=self.access_id,
                 secret_access_key=self.secret_access_key,
                 session_token=None,
-                prefix=self.prefix or options.prefix,
+                prefix=self.prefix if self.prefix is not None else options.prefix,
                 region=self.region or options.region,
                 endpoint_url=(
                     self.endpoint_url or options.endpoint_url or "https://storage.googleapis.com"

--- a/src/agents/sandbox/entries/mounts/providers/s3.py
+++ b/src/agents/sandbox/entries/mounts/providers/s3.py
@@ -101,7 +101,7 @@ class S3Mount(_ConfiguredMount):
                 access_key_id=self.access_key_id,
                 secret_access_key=self.secret_access_key,
                 session_token=self.session_token,
-                prefix=self.prefix or options.prefix,
+                prefix=self.prefix if self.prefix is not None else options.prefix,
                 region=self.region or options.region,
                 endpoint_url=self.endpoint_url or options.endpoint_url,
                 mount_type=self.type,

--- a/tests/sandbox/test_mounts.py
+++ b/tests/sandbox/test_mounts.py
@@ -889,6 +889,36 @@ async def test_s3_mount_direct_mountpoint_fields_override_pattern_options() -> N
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("mount_cls", [S3Mount, GCSMount])
+@pytest.mark.parametrize(
+    ("entry_prefix", "expected_prefix"),
+    [("", None), (None, "pattern-prefix/")],
+)
+async def test_mountpoint_prefix_uses_none_as_inheritance_sentinel(
+    mount_cls: type[S3Mount] | type[GCSMount],
+    entry_prefix: str | None,
+    expected_prefix: str | None,
+) -> None:
+    pattern = MountpointMountPattern(
+        options=MountpointMountPattern.MountpointOptions(prefix="pattern-prefix/")
+    )
+    mount = mount_cls(
+        bucket="bucket",
+        prefix=entry_prefix,
+        mount_strategy=InContainerMountStrategy(pattern=pattern),
+    )
+    session = _MountpointApplySession()
+
+    await mount.apply(session, Path("/workspace/remote"), Path("/workspace"))
+
+    mount_command = session.exec_calls[-1][2]
+    if expected_prefix is None:
+        assert "--prefix" not in mount_command
+    else:
+        assert f"--prefix {expected_prefix}" in mount_command
+
+
+@pytest.mark.asyncio
 async def test_s3_mount_builds_prefixed_rclone_remote_path() -> None:
     session_id = uuid.uuid4()
     pattern = RcloneMountPattern()


### PR DESCRIPTION
### Summary

This pull request fixes explicit empty prefixes being replaced by a `MountpointMountPattern` default for S3 and GCS mounts.

Both provider adapters used a truthiness fallback, so `prefix=""` behaved like `None` and unexpectedly mounted the configured default subtree instead of the bucket root. The adapters now use `None` as the sole inheritance sentinel, preserving explicit empty prefixes while keeping nonempty overrides and existing `None` behavior unchanged.

The regression test exercises the public `Mount.apply` path for both providers and verifies the final command omits `--prefix` for an explicit empty value while still forwarding the pattern default for `None`.

### Test plan

- `uv run --locked pytest tests/sandbox/test_mounts.py::test_mountpoint_prefix_uses_none_as_inheritance_sentinel tests/sandbox/test_mounts.py::test_s3_mount_direct_mountpoint_fields_override_pattern_options -q`
- `/usr/bin/env -u OPENAI_API_KEY OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1 UV_DEFAULT_INDEX=https://pypi.org/simple PYTEST_XDIST_AUTO_NUM_WORKERS=4 bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
