### PR TITLE
fix(voice): decode provider PCM16 as little-endian

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -104,7 +104,9 @@ class StreamedAudioResult:
             # np.int16 needs 2-byte alignment; pad odd-length chunks safely.
             combined_buffer += b"\x00"
 
-        np_array = np.frombuffer(combined_buffer, dtype=np.int16)
+        # Provider PCM16 is little-endian regardless of host byte order. Decode it
+        # explicitly, then normalize to native int16 before exposing it to callers.
+        np_array = np.frombuffer(combined_buffer, dtype=np.dtype("<i2")).astype(np.int16, copy=False)
 
         if output_dtype == np.int16:
             return np_array

--- a/tests/voice/test_pcm16_endianness.py
+++ b/tests/voice/test_pcm16_endianness.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from agents.voice.result import StreamedAudioResult
+
+
+def test_transform_audio_buffer_decodes_pcm16_as_little_endian() -> None:
+    result = StreamedAudioResult.__new__(StreamedAudioResult)
+
+    raw = b"\x01\x02\x03\x04"
+    transformed = result._transform_audio_buffer([raw], np.int16)
+
+    assert transformed.dtype == np.dtype(np.int16)
+    assert transformed.tolist() == [0x0201, 0x0403]
+
+
+def test_transform_audio_buffer_float32_uses_little_endian_samples() -> None:
+    result = StreamedAudioResult.__new__(StreamedAudioResult)
+
+    raw = b"\x01\x02\x03\x04"
+    transformed = result._transform_audio_buffer([raw], np.float32)
+
+    assert transformed.dtype == np.dtype(np.float32)
+    assert transformed.shape == (2, 1)
+    np.testing.assert_allclose(
+        transformed[:, 0],
+        np.asarray([0x0201, 0x0403], dtype=np.float32) / 32767.0,
+    )


### PR DESCRIPTION
## Summary

Decode provider PCM16 bytes with an explicit little-endian dtype instead of the host-native `np.int16` interpretation, then normalize to native `int16` before returning audio to callers.

This fixes the big-endian-host corruption described in #4816 while preserving the existing `np.int16` / `np.float32` output shapes and odd-byte padding behavior.

## Tests

Adds focused coverage using `b"\x01\x02\x03\x04"`, which must decode to samples `[513, 1027]` for both integer and float output paths.

Closes #4816

AI assistance disclosure: AI assistance was used to inspect the issue, prepare the focused implementation and regression tests, and review the resulting diff.