### PR TITLE
fix(extensions): raise on truncated empty Chat Completions responses

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -667,6 +667,22 @@ class AnyLLMModel(Model):
                 "output_tokens_details": usage.output_tokens_details.model_dump(),
             }
 
+            # A completion truncated before any visible token (finish_reason="length")
+            # is a token- or reasoning-budget exhaustion, not a policy refusal.
+            # Surface it as a model behavior error rather than returning an empty output.
+            if (
+                message is not None
+                and first_choice is not None
+                and first_choice.finish_reason == "length"
+                and not message.content
+                and not message.refusal
+                and not message.tool_calls
+            ):
+                raise ModelBehaviorError(
+                    "Chat Completions response terminated with finish_reason='length' "
+                    "but produced no assistant text, tool call, or refusal."
+                )
+
             provider_data: dict[str, Any] = {"model": self.model}
             if message is not None and hasattr(response, "id"):
                 provider_data["response_id"] = response.id

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -313,6 +313,24 @@ class LitellmModel(Model):
                 "output_tokens_details": usage.output_tokens_details.model_dump(),
             }
 
+            # A completion truncated before any visible token (finish_reason="length")
+            # is a token- or reasoning-budget exhaustion, not a policy refusal.
+            # Surface it as a model behavior error rather than returning an empty output.
+            provider_specific_fields = getattr(message, "provider_specific_fields", None) or {}
+            if (
+                message is not None
+                and first_choice is not None
+                and getattr(first_choice, "finish_reason", None) == "length"
+                and not message.content
+                and not getattr(message, "refusal", None)
+                and not provider_specific_fields.get("refusal")
+                and not getattr(message, "tool_calls", None)
+            ):
+                raise ModelBehaviorError(
+                    "Chat Completions response terminated with finish_reason='length' "
+                    "but produced no assistant text, tool call, or refusal."
+                )
+
             # Surface content-filter refusals explicitly. Some providers (e.g.
             # Anthropic on Amazon Bedrock) signal a safety block only via
             # ``finish_reason == "content_filter"`` with an empty message and no

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -24,6 +24,7 @@ from openai.types.completion_usage import (
 from openai.types.responses import (
     Response,
     ResponseCompletedEvent,
+    ResponseFunctionToolCall,
     ResponseOutputMessage,
     ResponseOutputRefusal,
 )
@@ -116,7 +117,7 @@ def _import_any_llm_module(
     return module, create_calls
 
 
-def _chat_completion(text: str) -> ChatCompletion:
+def _chat_completion(text: str | None) -> ChatCompletion:
     return ChatCompletion(
         id="chatcmpl_123",
         created=0,
@@ -593,6 +594,41 @@ def _content_filtered_chat_completion(content: str) -> ChatCompletion:
     return completion
 
 
+def _chat_completion_with_message(
+    message: ChatCompletionMessage, finish_reason: str
+) -> ChatCompletion:
+    completion = _chat_completion(message.content or "")
+    completion.choices[0].message = message
+    completion.choices[0].finish_reason = finish_reason
+    return completion
+
+
+def _chat_completion_with_finish_reason(content: str | None, finish_reason: str) -> ChatCompletion:
+    return _chat_completion_with_message(
+        ChatCompletionMessage(role="assistant", content=content), finish_reason
+    )
+
+
+async def _get_any_llm_chat_response(
+    monkeypatch: pytest.MonkeyPatch, chat_response: ChatCompletion
+) -> Any:
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=chat_response)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    return await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 async def test_any_llm_chat_path_surfaces_content_filter_refusal(monkeypatch) -> None:
@@ -661,6 +697,77 @@ async def test_any_llm_chat_path_content_filter_keeps_real_content(monkeypatch) 
     ]
     assert not refusals
     assert response.output[0].content[0].text == "here is the answer"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content", [None, ""], ids=["none", "empty-string"])
+async def test_any_llm_chat_path_raises_on_truncated_empty_turn(
+    monkeypatch, content: str | None
+) -> None:
+    """An empty length-truncated turn must not be returned as a successful empty response."""
+    provider = FakeAnyLLMProvider(
+        supports_responses=False,
+        chat_response=_chat_completion_with_finish_reason(content, "length"),
+    )
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    spans = _capture_spans(monkeypatch, module, "generation_span")
+
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.ENABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+
+    assert len(spans) == 1
+    assert spans[0].span_data.usage["requests"] == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_path_preserves_nonempty_truncated_output(monkeypatch) -> None:
+    response = await _get_any_llm_chat_response(
+        monkeypatch, _chat_completion_with_finish_reason("partial", "length")
+    )
+
+    assert response.output[0].content[0].text == "partial"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_path_preserves_truncated_refusal(monkeypatch) -> None:
+    response = await _get_any_llm_chat_response(
+        monkeypatch,
+        _chat_completion_with_message(
+            ChatCompletionMessage(role="assistant", content=None, refusal="provider refusal"),
+            "length",
+        ),
+    )
+
+    refusal = response.output[0].content[0]
+    assert isinstance(refusal, ResponseOutputRefusal)
+    assert refusal.refusal == "provider refusal"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_path_preserves_truncated_tool_call(monkeypatch) -> None:
+    chat_response = _chat_completion_with_tool_call(thought_signature="sig_123")
+    chat_response.choices[0].finish_reason = "length"
+    chat_response.choices[0].message.content = None
+
+    response = await _get_any_llm_chat_response(monkeypatch, chat_response)
+
+    assert any(isinstance(item, ResponseFunctionToolCall) for item in response.output)
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_litellm_content_filter.py
+++ b/tests/models/test_litellm_content_filter.py
@@ -1,19 +1,43 @@
 import litellm
 import pytest
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
-from openai.types.responses import ResponseOutputMessage, ResponseOutputRefusal
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputRefusal,
+)
 
+from agents.exceptions import ModelBehaviorError
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
+from agents.tracing import trace
+from tests.testing_processor import fetch_ordered_spans
 
 
-async def _get_response(monkeypatch, *, finish_reason, content):
+async def _get_response(
+    monkeypatch,
+    *,
+    finish_reason,
+    content,
+    provider_specific_fields=None,
+    tool_calls=None,
+    tracing=ModelTracing.DISABLED,
+):
     """Drive get_response against a mocked litellm completion and return the items."""
 
     async def fake_acompletion(model, messages=None, **kwargs):
-        msg = Message(role="assistant", content=content)
-        choice = Choices(index=0, finish_reason=finish_reason, message=msg)
+        msg = Message(
+            role="assistant",
+            content=content,
+            provider_specific_fields=provider_specific_fields,
+            tool_calls=tool_calls,
+        )
+        if finish_reason is None:
+            choice = Choices(index=0, message=msg)
+            del choice.finish_reason
+        else:
+            choice = Choices(index=0, finish_reason=finish_reason, message=msg)
         return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
 
     monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
@@ -25,7 +49,7 @@ async def _get_response(monkeypatch, *, finish_reason, content):
         tools=[],
         output_schema=None,
         handoffs=[],
-        tracing=ModelTracing.DISABLED,
+        tracing=tracing,
         previous_response_id=None,
     )
 
@@ -71,6 +95,94 @@ async def test_content_filter_does_not_clobber_real_content(monkeypatch):
         if isinstance(content, ResponseOutputRefusal)
     ]
     assert not refusals, "should not synthesize a refusal when content is present"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content", [None, ""], ids=["none", "empty-string"])
+async def test_length_finish_reason_with_empty_message_raises_model_behavior_error(
+    monkeypatch, content
+):
+    """An empty length-truncated turn must not be returned as a successful empty response."""
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await _get_response(monkeypatch, finish_reason="length", content=content)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_length_finish_reason_records_usage_before_raising(monkeypatch):
+    with trace(workflow_name="litellm-truncated-empty"):
+        with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+            await _get_response(
+                monkeypatch,
+                finish_reason="length",
+                content=None,
+                tracing=ModelTracing.ENABLED,
+            )
+
+    generation_spans = [
+        span for span in fetch_ordered_spans() if span.span_data.type == "generation"
+    ]
+    assert len(generation_spans) == 1
+    assert generation_spans[0].span_data.usage is not None
+    assert generation_spans[0].span_data.usage["requests"] == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_length_finish_reason_with_nonempty_content_is_preserved(monkeypatch):
+    resp = await _get_response(monkeypatch, finish_reason="length", content="partial")
+
+    assert resp.output
+    assert resp.output[0].content
+    assert resp.output[0].content[0].text == "partial"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_length_finish_reason_with_refusal_is_preserved(monkeypatch):
+    resp = await _get_response(
+        monkeypatch,
+        finish_reason="length",
+        content=None,
+        provider_specific_fields={"refusal": "provider refusal"},
+    )
+
+    assert resp.output
+    assert resp.output[0].content
+    refusal = resp.output[0].content[0]
+    assert isinstance(refusal, ResponseOutputRefusal)
+    assert refusal.refusal == "provider refusal"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_length_finish_reason_with_tool_call_is_preserved(monkeypatch):
+    resp = await _get_response(
+        monkeypatch,
+        finish_reason="length",
+        content=None,
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "do_thing", "arguments": "{}"},
+            }
+        ],
+    )
+
+    assert any(isinstance(item, ResponseFunctionToolCall) for item in resp.output)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_missing_finish_reason_does_not_break_normal_response(monkeypatch):
+    """LiteLLM responses may omit finish_reason on a normal assistant message."""
+    resp = await _get_response(monkeypatch, finish_reason=None, content="all good")
+
+    assert resp.output
+    assert resp.output[0].content
+    assert resp.output[0].content[0].text == "all good"
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

This pull request fixes AnyLLM and LiteLLM non-streaming Chat Completions adapters returning successful empty responses when a completion terminates with `finish_reason="length"` before emitting assistant text, refusal, or tool calls.

Both adapters now raise `ModelBehaviorError` after usage and tracing data are recorded, matching the built-in OpenAI Chat Completions adapter. Responses containing partial text, refusals, or tool calls remain supported.

### Test plan

- Added regression tests for empty `content=None` and `content=""`.
- Added coverage for partial text, refusals, tool calls, and missing LiteLLM `finish_reason`.
- Added tracing coverage to verify usage is recorded before `ModelBehaviorError` is raised.
- Focused adapter tests: 101 passed.
- Full parallel test suite: 9360 passed, 29 skipped.
- Serial test suite: 77 passed, 4 skipped.
- Formatting, lint, mypy, Pyright, and the final code-change verification script passed.

Live verification:

- Model: `gpt-5.6-luna`
- `temperature=0`
- `max_tokens=256`

The raw Chat Completions response returned `finish_reason="length"` with `content=null`. The built-in adapter raised `ModelBehaviorError`, while AnyLLM and LiteLLM previously returned successful empty outputs.

### Issue number

Closes #4885

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR