### PR TITLE
fix(sandbox): reject commas in S3 Files mount -o options

### DIFF
--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -109,6 +109,8 @@ _BLAXEL_S3FS_OPTION_FIELDS_BY_MOUNT_TYPE: dict[str, tuple[str, ...]] = {
     "r2_mount": ("custom_domain", "account_id"),
     "s3_mount": ("endpoint_url", "region"),
 }
+# S3 Files renders these fields (plus extra_options) into a single comma-joined `mount -o` string.
+_S3_FILES_JOINED_OPTION_FIELDS: tuple[str, ...] = ("mount_target_ip", "access_point", "region")
 # Every free-form value interpolated into an rclone configuration line must remain a single line.
 # Keep this table aligned with the built-in providers' ``_rclone_required_lines`` methods.
 _RCLONE_CONFIG_VALUE_FIELDS_BY_MOUNT_TYPE: dict[str, tuple[str, ...]] = {
@@ -889,6 +891,39 @@ def _configured_blaxel_s3fs_option_fields(
     )
 
 
+def _mapping_contains_s3fs_option_delimiter(options: object) -> bool:
+    if not isinstance(options, Mapping):
+        return False
+    return any(
+        _value_contains_s3fs_option_delimiter(key) or _value_contains_s3fs_option_delimiter(value)
+        for key, value in options.items()
+    )
+
+
+def _configured_s3_files_option_delimiter_fields(mount: Mount) -> tuple[str, ...]:
+    """S3 Files joins helper options into one `mount -o` list. Commas become extra options."""
+    mount_type = _canonical_mount_type(type(mount)) or mount.type
+    if mount_type != "s3_files_mount":
+        return ()
+
+    fields: list[str] = []
+    for name in _S3_FILES_JOINED_OPTION_FIELDS:
+        if _value_contains_s3fs_option_delimiter(getattr(mount, name, None)):
+            fields.append(name)
+    if _mapping_contains_s3fs_option_delimiter(getattr(mount, "extra_options", None)):
+        fields.append("extra_options")
+
+    pattern = getattr(getattr(mount, "mount_strategy", None), "pattern", None)
+    if isinstance(pattern, S3FilesMountPattern):
+        options = pattern.options
+        for name in _S3_FILES_JOINED_OPTION_FIELDS:
+            if _value_contains_s3fs_option_delimiter(getattr(options, name, None)):
+                fields.append(f"mount_strategy.pattern.options.{name}")
+        if _mapping_contains_s3fs_option_delimiter(options.extra_options):
+            fields.append("mount_strategy.pattern.options.extra_options")
+    return tuple(dict.fromkeys(fields))
+
+
 def _configured_unknown_strategy_fields(strategy: MountStrategyBase) -> tuple[str, ...]:
     if _strategy_classification(strategy)[0] != "unknown":
         return ()
@@ -1491,7 +1526,10 @@ def _mount_boundary_error(
                 "configuration_fields": invalid_rclone_fields,
             },
         )
-    invalid_s3fs_fields = _configured_blaxel_s3fs_option_fields(mount, mount_type)
+    invalid_s3fs_fields = (
+        _configured_blaxel_s3fs_option_fields(mount, mount_type)
+        + _configured_s3_files_option_delimiter_fields(mount)
+    )
     if invalid_s3fs_fields:
         return MountConfigError(
             message="cloud mount configuration values must not contain s3fs option delimiters",

--- a/tests/sandbox/test_mount_security.py
+++ b/tests/sandbox/test_mount_security.py
@@ -1459,6 +1459,62 @@ def test_s3_files_require_broad_acknowledgement_before_ambient_iam_can_be_used()
 
 
 @pytest.mark.parametrize(
+    ("mount", "field_name"),
+    [
+        (
+            S3FilesMount(
+                file_system_id="fs-123",
+                extra_options={"mounttargetip": "10.0.0.1,ro"},
+                mount_strategy=InContainerMountStrategy(pattern=S3FilesMountPattern()),
+            ),
+            "extra_options",
+        ),
+        (
+            S3FilesMount(
+                file_system_id="fs-123",
+                extra_options={"foo,ro": "1"},
+                mount_strategy=InContainerMountStrategy(pattern=S3FilesMountPattern()),
+            ),
+            "extra_options",
+        ),
+        (
+            S3FilesMount(
+                file_system_id="fs-123",
+                mount_target_ip="10.0.0.1,subdir=/",
+                mount_strategy=InContainerMountStrategy(pattern=S3FilesMountPattern()),
+            ),
+            "mount_target_ip",
+        ),
+        (
+            S3FilesMount(
+                file_system_id="fs-123",
+                mount_strategy=InContainerMountStrategy(
+                    pattern=S3FilesMountPattern(
+                        options=S3FilesMountPattern.S3FilesOptions(
+                            extra_options={"accesspoint": "ap-1,ro"}
+                        )
+                    )
+                ),
+            ),
+            "mount_strategy.pattern.options.extra_options",
+        ),
+    ],
+)
+def test_rejects_s3_files_mount_option_delimiter_injection(
+    mount: S3FilesMount,
+    field_name: str,
+) -> None:
+    """S3 Files joins helper options into one `mount -o` string. A comma is a new option."""
+    manifest = Manifest(entries={"data": mount})
+    acknowledged = manifest.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+
+    with pytest.raises(MountConfigError, match="must not contain s3fs option delimiters") as exc:
+        validate_manifest_mount_credential_boundaries(acknowledged)
+
+    assert exc.value.context["configuration_fields"] == (field_name,)
+
+
+@pytest.mark.parametrize(
     "mount",
     [
         AzureBlobMount(


### PR DESCRIPTION
## Summary

`S3FilesMountPattern.apply()` turns helper options into one `mount -t s3files -o …` argument by comma-joining every key/value:

```python
rendered_options = ",".join(
    key if value is None else f"{key}={value}" for key, value in options.items()
)
cmd.extend(["-o", rendered_options])
```

`extra_options`, `mount_target_ip`, `access_point`, and `region` all go into that string. A comma in any of them is a new `-o` token.

```python
S3FilesMount(
    file_system_id="fs-123",
    extra_options={"mounttargetip": "10.0.0.1,ro"},
    mount_strategy=InContainerMountStrategy(pattern=S3FilesMountPattern()),
)
```

renders (after the usual join):

```
mount -t s3files -o mounttargetip=10.0.0.1,ro … fs-123 /workspace/data
```

`ro` was not requested. The same form works with a key (`"foo,ro": "1"`) or with `mount_target_ip="10.0.0.1,subdir=/"`.

Blaxel s3fs already rejects this class of injection (`cloud mount configuration values must not contain s3fs option delimiters` / `test_rejects_blaxel_s3fs_endpoint_option_injection`). S3 Files has the same join and no check. Broad-credential acknowledgement still lets the comma through, because that acknowledgement is about ambient IAM, not about `-o` syntax.

## Why

I was reading the in-container mount helpers next to the Blaxel delimiter tests. The S3 Files path builds the same comma-joined `-o` list and never calls `_value_contains_s3fs_option_delimiter`. I put a comma in `extra_options` after acknowledging broad IAM and `validate_manifest_mount_credential_boundaries` accepted it.

This matters when a manifest is assembled from more than one source: a shared template, a restored session, or a third-party example. The person who runs the sandbox may not have written every option field.

## How

Reuse `_value_contains_s3fs_option_delimiter` on S3 Files joined fields and on `extra_options` keys/values (mount object and pattern options). The existing Blaxel error path now includes those fields. No new helper type.

## Testing

Added `test_rejects_s3_files_mount_option_delimiter_injection`.

```
uv run pytest tests/sandbox/test_mount_security.py::test_rejects_s3_files_mount_option_delimiter_injection tests/sandbox/test_mount_security.py::test_s3_files_require_broad_acknowledgement_before_ambient_iam_can_be_used tests/sandbox/test_mount_security.py::test_rejects_blaxel_s3fs_endpoint_option_injection -q
```

9 passed.

Safe `extra_options={"tlsport": "4049"}` still works after acknowledgement.