### PR TITLE
docs(dapr): clarify requested state consistency guarantees

### DIFF
--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -420,7 +420,7 @@ Notes:
 -   `from_address(...)` creates and owns the Dapr client for you. If your app already manages one, construct `DaprSession(...)` directly with `dapr_client=...`.
 -   Exiting the context or calling `close()` makes an owned-client session terminal; subsequent session operations raise `RuntimeError`, while repeated or concurrent `close()` calls are safe. With an injected client, `close()` is a no-op and the session remains usable.
 -   If the backing state store supports TTL, pass `ttl=...` so it automatically applies TTL expiration to the session data.
--   Pass `consistency=DAPR_CONSISTENCY_STRONG` when you need stronger read-after-write guarantees.
+-   Pass `consistency=DAPR_CONSISTENCY_STRONG` to request strong consistency on state writes and deletes (store-dependent). Note that wire-level read consistency requires upstream Dapr Python client support for setting consistency on `get_state`.
 -   The Dapr Python SDK also checks the HTTP sidecar endpoint. In local development, start Dapr with `--dapr-http-port 3500` as well as the gRPC port used in `dapr_address`.
 -   See [`examples/memory/dapr_session_example.py`](https://github.com/openai/openai-agents-python/tree/main/examples/memory/dapr_session_example.py) for a full setup walkthrough, including local components and troubleshooting.
 

--- a/examples/memory/dapr_session_example.py
+++ b/examples/memory/dapr_session_example.py
@@ -27,7 +27,7 @@ PRODUCTION FEATURES (provided by Dapr):
 - Built-in observability: Distributed tracing, metrics, telemetry (zero code)
 - Data isolation: App-level or namespace-level state scoping for multi-tenancy
 - TTL support: Automatic session expiration (store-dependent)
-- Consistency levels: Eventual (faster) or strong (read-after-write guarantee)
+- Consistency levels: Eventual (faster) or strong (requests strong write consistency; store-dependent)
 - State encryption: AES-GCM encryption at the Dapr component level
 - Cloud-native: Seamless Kubernetes integration (Dapr runs as sidecar)
 - Cloud Service Provider (CSP) native authentication and authorization support.
@@ -263,7 +263,7 @@ async def demonstrate_advanced_features():
                 print("Eventual consistency: Better performance, may have slight delays")
                 await eventual_session.add_items([{"role": "user", "content": "Test eventual"}])
 
-        # Strong consistency (guaranteed read-after-write)
+        # Strong consistency (requests strong write consistency; store-dependent)
         async with DaprSession.from_address(
             "strong_session",
             state_store_name=DEFAULT_STATE_STORE,
@@ -271,7 +271,9 @@ async def demonstrate_advanced_features():
             consistency=DAPR_CONSISTENCY_STRONG,
         ) as strong_session:
             if await strong_session.ping():
-                print("Strong consistency: Guaranteed immediate consistency")
+                print(
+                    "Strong consistency: Requested for write operations (guarantees depend on state store)"
+                )
                 await strong_session.add_items([{"role": "user", "content": "Test strong"}])
 
         # Multi-tenancy example

--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -93,7 +93,9 @@ class DaprSession(SessionABC):
                 the underlying state store implementation. Defaults to None.
             consistency (ConsistencyLevel, optional): Consistency level for state operations.
                 Use DAPR_CONSISTENCY_EVENTUAL or DAPR_CONSISTENCY_STRONG constants.
-                Defaults to DAPR_CONSISTENCY_EVENTUAL.
+                Note that strong consistency is requested for write and delete operations
+                (store-dependent); read operations depend on the underlying Dapr client
+                exposing wire-level consistency. Defaults to DAPR_CONSISTENCY_EVENTUAL.
             session_settings (SessionSettings | None): Session configuration settings including
                 default limit for retrieving items. If None, uses default SessionSettings().
         """
@@ -160,7 +162,9 @@ class DaprSession(SessionABC):
     def _get_read_metadata(self) -> dict[str, str]:
         """Get metadata for read operations including consistency.
 
-        The consistency level is passed through state_metadata as per Dapr's state API.
+        Passes consistency through state_metadata. Note that Dapr's gRPC runtime
+        expects consistency as a dedicated field on GetStateRequest, which is not
+        currently exposed by the Dapr Python client.
         """
         metadata: dict[str, str] = {}
         # Add consistency level to metadata for read operations


### PR DESCRIPTION
### Summary

This pull request corrects the Dapr session documentation's read-after-write guarantee. With `dapr==1.16.0`, selecting `DAPR_CONSISTENCY_STRONG` requests strong consistency for writes and deletes, but reads pass the setting as metadata and leave `GetStateRequest.consistency` unspecified.

Update the session guide, constructor/helper docstrings, and example output to describe the requested write/delete consistency and its dependence on state-store support. Session behavior and public signatures are unchanged.

A local gRPC capture using the actual Dapr async client confirmed that reads carry `metadata={"consistency": "strong"}` with `CONSISTENCY_UNSPECIFIED`, while writes carry `CONSISTENCY_STRONG` in their options. This verifies request encoding, not stale reads against a real state store. Upstream support is tracked in dapr/python-sdk#1200.

### Test plan

- `make build-docs` passed on the final patch (135.74 seconds).
- `uv run pytest tests/extensions/memory/test_dapr_session.py` passed (52 tests).
- `.agents/skills/code-change-verification/scripts/run.sh` passed: formatting, lint, mypy/pyright, and the full test suite.
- Independent review of the final three-file patch, including Japanese/Korean/Chinese translation considerations for the changed English documentation, reported no actionable findings.
- The local gRPC reproduction was rerun successfully. No new unit tests are included because the change corrects documentation and example messaging rather than SDK behavior.

### Issue number

Related upstream request: dapr/python-sdk#1200. This PR does not implement or close that request.

### Checks

- [x] I've added new tests, if relevant (not applicable to this clarification).
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`.
- [x] I've confirmed all verification steps pass.
- [x] The patch received an independent agent review before submission.
