### PR TITLE
fix(examples): honor zero limits in FileSession

### DIFF
--- a/examples/memory/file_session.py
+++ b/examples/memory/file_session.py
@@ -47,7 +47,7 @@ class FileSession(Session):
         session_id = await self._ensure_session_id()
         items = await self._read_items(session_id)
         if limit is not None and limit >= 0:
-            return items[-limit:]
+            return items[-limit:] if limit else []
         return items
 
     async def add_items(self, items: list[Any]) -> None:

--- a/tests/memory/test_file_session_example.py
+++ b/tests/memory/test_file_session_example.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+from examples.memory.file_session import FileSession
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("limit", "expected"),
+    [
+        pytest.param(None, ["first", "second"], id="unlimited"),
+        pytest.param(0, [], id="zero"),
+        pytest.param(1, ["second"], id="latest-item"),
+        pytest.param(3, ["first", "second"], id="larger-than-history"),
+    ],
+)
+async def test_file_session_get_items_limit(
+    tmp_path: Path, limit: int | None, expected: list[str]
+) -> None:
+    session = FileSession(dir=tmp_path, session_id="limit-test")
+    items = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+    ]
+    await session.add_items(items)
+
+    assert [item["content"] for item in await session.get_items(limit=limit)] == expected
+    assert await session.get_items() == items


### PR DESCRIPTION
This pull request fixes `FileSession.get_items(limit=0)` returning the entire conversation instead of an empty list.

### Summary

- Python treats `items[-0:]` as `items[0:]`, so the example previously returned all stored items for a zero limit. Return an empty list for that case, consistent with `SQLiteSession`.
- Preserve unlimited and positive-limit reads, existing negative-limit behavior, and stored history.
- Add parameterized regression coverage for unlimited, zero, one-item, and larger-than-history limits, including a subsequent unlimited read to verify history is unchanged.

### Test plan

- Before the fix, the new zero-limit regression failed and the other three cases passed. After the fix, all four passed.
- Ran the required full verification workflow: formatting, lint, type checks, and tests all passed.
  ```sh
  /usr/bin/env -u OPENAI_API_KEY OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1 UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh
  ```
  The repository's Codex/macOS environment marker skips unsupported nested-sandbox tests locally; those remain covered by CI.
- Completed independent final review of the exact two-file patch with no actionable findings. This was an independent Codex reviewer, not a `/review` slash-command invocation.

### Issue number

No existing issue found.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've completed independent final review before submitting this PR (see Test plan)
