### PR TITLE
fix(sandbox): distinguish directory modes from sockets and devices

### DIFF
--- a/src/agents/sandbox/types.py
+++ b/src/agents/sandbox/types.py
@@ -51,7 +51,8 @@ class Permissions(BaseModel):
             owner=(mode >> 6) & 0b111,
             group=(mode >> 3) & 0b111,
             other=(mode >> 0) & 0b111,
-            directory=bool(mode & stat.S_IFDIR),
+            # File types share bits; sockets and block devices also contain S_IFDIR's bit.
+            directory=stat.S_ISDIR(mode),
         )
 
     @classmethod

--- a/tests/sandbox/test_types.py
+++ b/tests/sandbox/test_types.py
@@ -1,4 +1,29 @@
+import stat
+
+import pytest
+
 from agents.sandbox.types import Group, Permissions, User
+
+
+@pytest.mark.parametrize(
+    ("file_type", "is_directory"),
+    [
+        pytest.param(stat.S_IFDIR, True, id="directory"),
+        pytest.param(stat.S_IFREG, False, id="regular-file"),
+        pytest.param(stat.S_IFLNK, False, id="symlink"),
+        pytest.param(stat.S_IFSOCK, False, id="socket"),
+        pytest.param(stat.S_IFBLK, False, id="block-device"),
+        pytest.param(stat.S_IFCHR, False, id="character-device"),
+        pytest.param(stat.S_IFIFO, False, id="fifo"),
+        pytest.param(0, False, id="permission-bits-only"),
+    ],
+)
+def test_permissions_from_mode_classifies_file_type(file_type: int, is_directory: bool) -> None:
+    permissions = Permissions.from_mode(file_type | 0o754)
+
+    assert permissions.directory is is_directory
+    assert (permissions.owner, permissions.group, permissions.other) == (0o7, 0o5, 0o4)
+    assert str(permissions) == ("d" if is_directory else "-") + "rwxr-xr--"
 
 
 def test_permissions_is_hashable() -> None:


### PR DESCRIPTION
### Summary

This pull request fixes directory classification in `Permissions.from_mode`. The current bitwise check treats `stat.S_IFDIR` as an independent flag, but Unix file types share bits: socket mode `0o140000` and block-device mode `0o060000` also contain `0o040000`.

As a result, `UnixLocalSandboxSession.ls()` can return a socket with `kind=OTHER` and directory permissions such as `drwxr-xr--`. Use `stat.S_ISDIR(mode)` to classify the complete file-type field while preserving rwx extraction. No public signature, permission enforcement, or stored schema changes.

### Test plan

- Before the fix, the new socket and block-device regression cases fail.
- After the fix, `uv run pytest tests/sandbox/test_types.py tests/sandbox/test_parse_utils.py -q`: 23 passed.
- Regression coverage includes directories, regular files, symlinks, sockets, block/character devices, FIFOs, and permission-only modes.
- Independent review completed with no actionable findings.
- Confirmed `UnixLocalSandboxSession.ls()` reports `directory=False` for a real Unix socket.
- `make format`, `make lint`, `make mypy`, and `make pyright`: passed.
- Full parallel tests on macOS/Python 3.14: 9,476 passed, 55 skipped, 1 failed. Serial tests: 77 passed, 4 skipped.
- The failing test, `tests/sandbox/test_runtime.py::test_runner_merges_sandbox_instructions_and_tools`, also fails with the unchanged upstream runtime. The workspace sandbox prevents creating the default snapshot directory under the user's Library/Application Support directory, so runtime falls back to `NoopSnapshotSpec` while the test expects `LocalSnapshotSpec`. A direct probe confirms `PermissionError`. This is unrelated to file-type classification.
- Used `OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1` as prescribed. Native macOS sandbox tests remain for the dedicated CI runner. The verification wrapper was invoked, but restricted process inspection made its status accounting unreliable; results above come from the documented direct commands, with the serial suite run separately after the environment failure.

### Issue number

No existing issue found for this metadata-classification bug.

### Checks

- [x] I've added new tests, if relevant.
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`.
- [ ] I've confirmed all verification steps pass. One reproduced upstream environment failure remains, as detailed above.
- [x] Independent Codex review completed before submission.
