### PR TITLE
fix(memory): close SQLite connections when setup fails

### DIFF
--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -85,7 +85,9 @@ class SQLiteSession(SessionABC):
                     ) as init_conn:
                         self._configure_connection(init_conn)
                         self._init_db_for_connection(init_conn)
-        except Exception:
+        except BaseException:
+            if self._is_memory_db and hasattr(self, "_shared_connection"):
+                self._invalidate_connection(self._shared_connection)
             if self._lock_path is not None and not self._lock_released:
                 self._release_file_lock(self._lock_path)
                 self._lock_released = True
@@ -142,7 +144,7 @@ class SQLiteSession(SessionABC):
                 raise
 
     def _invalidate_connection(self, conn: sqlite3.Connection) -> None:
-        """Close and evict a connection that could not roll back safely."""
+        """Close and evict a connection that cannot be used safely."""
         try:
             conn.close()
         except BaseException:
@@ -175,7 +177,11 @@ class SQLiteSession(SessionABC):
                     str(self.db_path),
                     check_same_thread=False,
                 )
-                self._configure_connection(connection)
+                try:
+                    self._configure_connection(connection)
+                except BaseException:
+                    self._invalidate_connection(connection)
+                    raise
                 self._local.connection = connection
                 with self._connections_lock:
                     self._connections.add(connection)

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sqlite3
+import sys
 import tempfile
 import threading
 from pathlib import Path
@@ -267,6 +268,79 @@ async def test_sqlite_session_close_closes_worker_thread_connections():
         assert session._connections == set()
         with pytest.raises(sqlite3.ProgrammingError):
             connections[0].execute("SELECT 1")
+
+
+@pytest.mark.asyncio
+async def test_sqlite_session_failed_connection_configuration_closes_and_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed worker connection must close without preventing a later retry."""
+    db_path = tmp_path / "configuration_failure.db"
+    session = SQLiteSession("configuration_failure", db_path)
+    connect = sqlite3.connect
+    connections: list[sqlite3.Connection] = []
+
+    def tracked_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        # Make lock failure immediate; elapsed retry duration is not under test.
+        kwargs["timeout"] = 0
+        connection = connect(*args, **kwargs)
+        connections.append(connection)
+        return connection
+
+    blocker = connect(db_path, isolation_level=None)
+    try:
+        blocker.execute("PRAGMA journal_mode=DELETE")
+        blocker.execute("BEGIN EXCLUSIVE")
+        monkeypatch.setattr("agents.memory.sqlite_session.sqlite3.connect", tracked_connect)
+
+        with pytest.raises(sqlite3.OperationalError, match="database is locked") as exc_info:
+            await session.get_items()
+        if sys.version_info >= (3, 11):
+            assert exc_info.value.sqlite_errorcode == sqlite3.SQLITE_BUSY
+        assert len(connections) == 1
+        with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+            connections[0].execute("PRAGMA busy_timeout")
+
+        blocker.rollback()
+        items: list[TResponseInputItem] = [{"role": "user", "content": "retry succeeded"}]
+        await session.add_items(items)
+        assert await session.get_items() == items
+
+        session.close()
+        for connection in connections:
+            with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+                connection.execute("SELECT 1")
+    finally:
+        blocker.close()
+        session.close()
+        for connection in connections:
+            connection.close()
+
+
+def test_sqlite_session_failed_memory_initialization_closes_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failed construction must release the newly allocated in-memory database."""
+    connect = sqlite3.connect
+    connections: list[sqlite3.Connection] = []
+
+    def tracked_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        connection = connect(*args, **kwargs)
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr("agents.memory.sqlite_session.sqlite3.connect", tracked_connect)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="syntax error") as exc_info:
+            SQLiteSession("initialization_failure", messages_table="select")
+        if sys.version_info >= (3, 11):
+            assert exc_info.value.sqlite_errorcode == sqlite3.SQLITE_ERROR
+        assert len(connections) == 1
+        with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+            connections[0].execute("SELECT 1")
+    finally:
+        for connection in connections:
+            connection.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes SQLiteSession connection cleanup when configuration or initialization fails, preserving the original exception and allowing file-backed sessions to retry after a transient lock clears.

This is a draft while the full verification gap described below remains open. Implementation and regression tests were developed with Codex.

### Summary

Each new file-backed worker connection is configured before it is registered for normal cleanup. If enabling WAL fails because another connection holds an exclusive lock, that connection remains open and untracked by session.close(). In-memory construction similarly leaves its shared connection open when initialization raises.

Both failure paths now use the existing connection invalidation policy. Public APIs, table schemas, WAL retry timing, and successful operations remain unchanged. Two regression tests exercise real SQLite errors, verify connection closure, and cover recovery and normal close behavior.

### Test plan

- Both new regressions fail against the original runtime source and pass with the fix.
- CPython 3.10.20: 57 passed, covering the full SQLiteSession test file and two adjacent AdvancedSQLiteSession tests. Only optional numeric error-code assertions are restricted to Python 3.11+; exception class/message, cleanup, and retry checks run on Python 3.10.
- CPython 3.12.13: focused SQLiteSession tests 55 passed.
- Installed all locked development dependencies and extras with uv sync --frozen --all-extras --all-packages --group dev.
- Ran the documented manual workflow using the unchanged Makefile: make format, make lint, make typecheck, then make tests. Format and lint passed; Mypy passed for 310 source files; Pyright reported zero errors and warnings.
- Full local test verification remains blocked by the Windows environment. The parallel phase finished with 14 failed, 8,539 passed, 91 skipped. Twelve unchanged sandbox Docker/tar tests fail at os.symlink with WinError 1314 because this process lacks the required Windows privilege. The other two failures are unchanged Daytona example tests reading UTF-8 text with the local GBK default; both pass in a separate PYTHONUTF8=1 rerun. The complete suite was not rerun, and the serial phase was not reached because the first test phase failed. No privilege escalation, test exclusions, or repository verification changes were applied.
- Two rounds of independent review used two fresh-context reviewers per round. The first round identified the Python 3.10 test-metadata compatibility issue; after correction, both second-round reviewers returned clean results. Content and repository fingerprints remained unchanged through final verification.

### Issue number

No existing issue; found while inspecting SQLiteSession resource ownership.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run .agents/skills/code-change-verification/scripts/run.sh
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run /review before submitting this PR

The script and literal /review checkboxes remain unchecked: verification used the documented manual workflow with locally installed GNU Make and Windows Python, and review used the repository's independent-review procedure. The full-pass checkbox remains unchecked because of the environment failures above.

