### PR TITLE
docs: make the encrypted session quick start self-contained

### DIFF
--- a/docs/sessions/encrypted_session.md
+++ b/docs/sessions/encrypted_session.md
@@ -14,36 +14,34 @@
 Encrypted sessions require the `encrypt` extra:
 
 ```bash
-pip install openai-agents[encrypt]
+pip install 'openai-agents[encrypt]'
 ```
 
 ## Quick start
 
+This example uses an in-memory `SQLiteSession`. The built-in session does not require a separate database driver.
+
 ```python
 import asyncio
-from agents import Agent, Runner
-from agents.extensions.memory import EncryptedSession, SQLAlchemySession
+from agents import Agent, Runner, SQLiteSession
+from agents.extensions.memory import EncryptedSession
 
 async def main():
     agent = Agent("Assistant")
-    
-    # Create underlying session
-    underlying_session = SQLAlchemySession.from_url(
-        "user-123",
-        url="sqlite+aiosqlite:///:memory:",
-        create_tables=True
-    )
-    
-    # Wrap with encryption
-    session = EncryptedSession(
-        session_id="user-123",
-        underlying_session=underlying_session,
-        encryption_key="your-secret-key-here",
-        ttl=600  # 10 minutes
-    )
-    
-    result = await Runner.run(agent, "Hello", session=session)
-    print(result.final_output)
+
+    underlying_session = SQLiteSession("user-123")
+    try:
+        session = EncryptedSession(
+            session_id="user-123",
+            underlying_session=underlying_session,
+            encryption_key="your-secret-key-here",
+            ttl=600  # 10 minutes
+        )
+
+        result = await Runner.run(agent, "Hello", session=session)
+        print(result.final_output)
+    finally:
+        underlying_session.close()
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -117,6 +115,12 @@ session = EncryptedSession(
 
 ### With SQLAlchemy sessions
 
+Install the `encrypt` and `sqlalchemy` extras for the PostgreSQL example below. The `sqlalchemy` extra includes the `asyncpg` driver used by the `postgresql+asyncpg://` URL.
+
+```bash
+pip install 'openai-agents[encrypt,sqlalchemy]'
+```
+
 ```python
 from agents.extensions.memory import EncryptedSession, SQLAlchemySession
 
@@ -133,6 +137,8 @@ session = EncryptedSession(
     encryption_key="secret-key"
 )
 ```
+
+The application is responsible for disposing of the engine created by `SQLAlchemySession.from_url()`. After all `SQLAlchemySession` instances using that engine are no longer needed, call `await underlying.engine.dispose()` in the application's cleanup path, even if a run fails.
 
 !!! warning "Advanced Session Features"
 


### PR DESCRIPTION
### Summary

The encrypted-session page currently installs only the `encrypt` extra, but its quick start immediately uses `SQLAlchemySession` with the `aiosqlite` driver, so following the page from a clean environment requires dependencies that were never installed.

This pull request makes the quick start self-contained by using the built-in `SQLiteSession`, which works with the documented `encrypt` installation. The example also closes the underlying session in a `finally` block so cleanup still happens if wrapper construction or the agent run fails.

The PostgreSQL example remains available for users who want SQLAlchemy-backed storage, with its required extras and engine cleanup made explicit. The cleanup instruction uses the public `engine` property, not private `_engine` state.

SDK APIs and encryption behavior are unchanged.

### Test plan

- Verified the quick-start imports and encrypted SQLite round trip in an isolated SDK 0.22.0 environment with only the documented `encrypt` extra.
- Executed the quick-start body with `Runner.run` replaced by an offline storage operation. Verified real SQLite cleanup on normal completion, a simulated run failure, and an empty-key failure from the real `EncryptedSession` constructor. No model API calls were made.
- Verified the PostgreSQL example's dependency and engine-lifecycle instructions against the current SQLAlchemy session API; no live PostgreSQL server was used.
- Passed `uv run docs/scripts/generate_ref_files.py` and `uv run mkdocs build`, the two commands in `make build-docs`, on Windows where `make` is unavailable. Verified the revised English page in the generated output.
- Passed `git diff --check` and completed independent review of the final documentation content.

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant (documentation-only change; validated with focused offline probes).
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (not required for this documentation-only content change).
- [x] I've confirmed the applicable documentation verification steps pass.
- [ ] If using Codex, I've run `/review` before submitting this PR (independent review was completed; the `/review` command was not run).
