### PR TITLE
fix(sessions): use LONGTEXT for MySQL message storage

### DIFF
--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -48,6 +48,7 @@ from sqlalchemy import (
     text as sql_text,
     update,
 )
+from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
@@ -64,7 +65,12 @@ _T = TypeVar("_T")
 
 
 class SQLAlchemySession(SessionABC):
-    """SQLAlchemy implementation of [`Session`][agents.memory.session.Session]."""
+    """SQLAlchemy implementation of [`Session`][agents.memory.session.Session].
+
+    Newly created MySQL and MariaDB message tables use LONGTEXT for serialized items.
+    Existing tables are not migrated; applications must widen their message_data column
+    to store items larger than the existing column's limit.
+    """
 
     _table_init_locks: ClassVar[dict[tuple[str, str, str], threading.Lock]] = {}
     _table_init_locks_guard: ClassVar[threading.Lock] = threading.Lock()
@@ -215,7 +221,11 @@ class SQLAlchemySession(SessionABC):
                 ForeignKey(f"{sessions_table}.session_id", ondelete="CASCADE"),
                 nullable=False,
             ),
-            Column("message_data", Text, nullable=False),
+            Column(
+                "message_data",
+                Text().with_variant(LONGTEXT(), "mysql", "mariadb"),
+                nullable=False,
+            ),
             Column(
                 "created_at",
                 TIMESTAMP(timezone=False),

--- a/tests/extensions/memory/test_sqlalchemy_session.py
+++ b/tests/extensions/memory/test_sqlalchemy_session.py
@@ -18,7 +18,11 @@ from openai.types.responses.response_reasoning_item_param import (
     Summary,
 )
 from sqlalchemy import event, insert, select, text, update
+from sqlalchemy.dialects import mysql, postgresql, sqlite
+from sqlalchemy.dialects.mysql.mariadb import MariaDBDialect
+from sqlalchemy.engine import Dialect
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.schema import CreateColumn
 from sqlalchemy.sql import Select
 
 pytest.importorskip("sqlalchemy")  # Skip tests if SQLAlchemy is not installed
@@ -106,6 +110,27 @@ async def test_sqlalchemy_session_direct_ops(agent: Agent):
     await session.clear_session()
     retrieved_after_clear = await session.get_items()
     assert len(retrieved_after_clear) == 0
+
+
+@pytest.mark.parametrize(
+    ("dialect", "expected_type"),
+    [
+        pytest.param(mysql.dialect(), "LONGTEXT", id="mysql"),
+        pytest.param(MariaDBDialect(), "LONGTEXT", id="mariadb"),
+        pytest.param(postgresql.dialect(), "TEXT", id="postgresql"),
+        pytest.param(sqlite.dialect(), "TEXT", id="sqlite"),
+    ],
+)
+async def test_message_data_column_type(dialect: Dialect, expected_type: str):
+    """MySQL needs large text storage; other dialects retain the existing TEXT column."""
+    session = SQLAlchemySession.from_url("message_column", url=DB_URL)
+    try:
+        column = session._messages.c.message_data
+        assert str(CreateColumn(column).compile(dialect=dialect)) == (
+            f"message_data {expected_type} NOT NULL"
+        )
+    finally:
+        await session.engine.dispose()
 
 
 async def test_sqlalchemy_session_defaults_to_escaped_non_ascii_storage():


### PR DESCRIPTION
### Summary

This pull request changes the `message_data` column to `LONGTEXT` for newly created MySQL and MariaDB message tables. Other dialects retain `TEXT`; serialization, session identifiers, transactions, and public APIs are unchanged. Existing tables are not migrated.

MySQL-family `TEXT` storage is too small for some serialized session items. In a live example, Chinese/emoji content serialized to 1,200,028 bytes: strict mode rejected the `TEXT` insert with error 1406, while non-strict mode logged truncation and stored 65,535 bytes of invalid JSON that the SDK could not return as the original item. A `LONGTEXT` column preserved the full item through SDK add/get/pop in both modes.

**Draft dependency:** current `main` cannot automatically create these MySQL/MariaDB tables because the `session_id` columns use an unbounded `String`. #4741, an open PR from another contributor, proposes fixing that separate problem. This PR contains none of its changes and does not independently restore automatic table creation. It is open as a draft to discuss the column-capacity change while the schema-creation work is reviewed. Users who already manage their own `LONGTEXT` schema do not need this patch.

Before marking this ready, I will refresh against the accepted schema-creation baseline, verify the combined automatic-create and large-item path, and finish the final review and verification gates.

### Test plan

- `tests/extensions/memory/test_sqlalchemy_session.py`: 47 passed, including four new column-compilation cases for MySQL, MariaDB, PostgreSQL, and SQLite.
- Ruff check and format check passed for both changed files; `git diff --check` passed.
- Real MySQL 8.0.46 and MariaDB 11.8.9, using caller-managed tables and `SQLAlchemySession(create_tables=False)`: small-item controls passed; strict `TEXT` raised error 1406; non-strict `TEXT` produced truncated, invalid JSON; `LONGTEXT` preserved the complete 1,200,028-byte serialized value and exact SDK get/pop results in both modes.
- Offline complete-table compilation: current main plus this change still fails on unbounded `session_id`; #4741's schema plus the proposed column type compiles for both MySQL and MariaDB. This was a disposable metadata composition check, not a combined-source live automatic-creation test.
- The full repository verification stack and final schema-change review are still pending for this early draft. No full-stack pass is claimed.

### Issue number

N/A. Related schema-creation work: #4741.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
