### PR TITLE
fix: simplify verification and stabilize sandbox tests

### DIFF
--- a/.agents/skills/code-change-verification/SKILL.md
+++ b/.agents/skills/code-change-verification/SKILL.md
@@ -15,8 +15,8 @@ Ensure work is only marked complete after formatting, linting, type checking, an
 2. Codex on macOS/Linux: `/usr/bin/env -u OPENAI_API_KEY OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1 UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`.
 3. Other macOS/Linux environments: `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`.
 4. Windows: `powershell -ExecutionPolicy Bypass -File .agents/skills/code-change-verification/scripts/run.ps1`.
-5. The scripts run `make format` first, then run `make lint`, `make typecheck`, and `make tests` in parallel with fail-fast semantics.
-6. While the parallel steps are still running, the scripts emit periodic heartbeat updates so you can tell that work is still in progress.
+5. On macOS/Linux, the script runs `make format`, `make lint`, `make typecheck`, and `make tests` sequentially and stops at the first failure. Parallelism inside each Make target, including pytest workers, is unchanged.
+6. The Bash script streams each command's output directly. The Windows wrapper retains parallel lint, typecheck, and test steps with periodic heartbeat updates.
 7. If any command fails, fix the issue, rerun the script, and report the failing output.
 8. Confirm completion only when all commands succeed with no remaining issues.
 
@@ -46,14 +46,14 @@ On Linux, some Python packages with native extensions may require system package
 - For a fresh checkout, or if dependencies are not installed or have changed, run `make sync` first to install dev requirements via `uv`.
 - Run from the repository root with `make format` first, then `make lint`, `make typecheck`, and `make tests`.
 - Do not skip steps; stop and fix issues immediately when a command fails.
-- If you run the steps manually, you may parallelize `make lint`, `make typecheck`, and `make tests` after `make format` completes, but you must stop the remaining steps as soon as one fails.
+- Run the manual steps sequentially and stop at the first failure. Keep the parallelism provided by each Make target.
 - Re-run the full stack after applying fixes so the commands execute in the required order.
 
 ## Resources
 
 ### scripts/run.sh
 
-- Executes `make format` first, then runs `make lint`, `make typecheck`, and `make tests` in parallel with fail-fast semantics from the repository root. It also emits periodic heartbeat updates while the parallel steps are still running. Prefer this entry point to preserve the required ordering while reducing total runtime.
+- Runs `make format`, `make lint`, `make typecheck`, and `make tests` sequentially from the repository root. It streams output, preserves the first failure or cancellation status, and cleans up the active step's process group before continuing or exiting.
 
 ### scripts/run.ps1
 

--- a/.agents/skills/code-change-verification/scripts/run.sh
+++ b/.agents/skills/code-change-verification/scripts/run.sh
@@ -11,14 +11,12 @@ REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../../.." && pwd)}"
 cd "${REPO_ROOT}"
 
 LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/code-change-verification.XXXXXX")"
-STATUS_PIPE="${LOG_DIR}/status.fifo"
 HEARTBEAT_INTERVAL_SECONDS="${CODE_CHANGE_VERIFICATION_HEARTBEAT_SECONDS:-10}"
 declare -a STEP_LAUNCHER=()
 declare -a STEP_PIDS=()
 declare -a STEP_NAMES=()
 declare -a STEP_LOGS=()
 declare -a STEP_STARTS=()
-RUNNING_STEPS=0
 EXIT_STATUS=0
 
 resolve_executable_path() {
@@ -58,12 +56,13 @@ configure_step_launcher() {
 
 configure_step_launcher
 
-mkfifo "${STATUS_PIPE}"
-exec 3<> "${STATUS_PIPE}"
-
 cleanup() {
   local trap_status="$?"
   local status="${EXIT_STATUS}"
+
+  # Repeated signals must not interrupt cleanup or replace the primary failure.
+  trap - EXIT
+  trap '' INT TERM
 
   if [ "${status}" -eq 0 ]; then
     status="${trap_status}"
@@ -73,19 +72,20 @@ cleanup() {
     stop_running_steps
   fi
 
-  exec 3>&- 3<&- || true
   rm -rf "${LOG_DIR}"
   exit "${status}"
 }
 
 on_interrupt() {
-  EXIT_STATUS=130
-  exit 130
+  if [ "${EXIT_STATUS}" -eq 0 ]; then
+    EXIT_STATUS=130
+  fi
 }
 
 on_terminate() {
-  EXIT_STATUS=143
-  exit 143
+  if [ "${EXIT_STATUS}" -eq 0 ]; then
+    EXIT_STATUS=143
+  fi
 }
 
 stop_running_steps() {
@@ -98,6 +98,8 @@ stop_running_steps() {
   for pid in "${STEP_PIDS[@]}"; do
     if [ -n "${pid}" ]; then
       kill -TERM -- "-${pid}" 2>/dev/null || true
+      # The launcher may not have created its process group yet.
+      kill -TERM "${pid}" 2>/dev/null || true
     fi
   done
 
@@ -107,6 +109,7 @@ stop_running_steps() {
     if [ -n "${pid}" ]; then
       # A process group can remain alive after its leader exits, so escalate by group id unconditionally.
       kill -KILL -- "-${pid}" 2>/dev/null || true
+      kill -KILL "${pid}" 2>/dev/null || true
     fi
   done
 
@@ -120,21 +123,6 @@ stop_running_steps() {
   STEP_NAMES=()
   STEP_LOGS=()
   STEP_STARTS=()
-  RUNNING_STEPS=0
-}
-
-find_step_index() {
-  local target_name="$1"
-  local idx=""
-
-  for idx in "${!STEP_NAMES[@]}"; do
-    if [ "${STEP_NAMES[$idx]}" = "${target_name}" ]; then
-      echo "${idx}"
-      return 0
-    fi
-  done
-
-  return 1
 }
 
 clear_step() {
@@ -144,25 +132,6 @@ clear_step() {
   STEP_NAMES[$idx]=""
   STEP_LOGS[$idx]=""
   STEP_STARTS[$idx]=""
-  RUNNING_STEPS=$((RUNNING_STEPS - 1))
-}
-
-step_pid_is_alive() {
-  local pid="$1"
-  local state=""
-
-  if ! kill -0 "${pid}" 2>/dev/null; then
-    return 1
-  fi
-
-  state="$(ps -o stat= -p "${pid}" 2>/dev/null | tr -d '[:space:]')"
-  case "${state}" in
-    Z*|z*|"")
-      return 1
-      ;;
-  esac
-
-  return 0
 }
 
 print_heartbeat() {
@@ -200,50 +169,42 @@ start_step() {
   shift
   local log_file="${LOG_DIR}/${name}.log"
 
+  if [ "${EXIT_STATUS}" -ne 0 ]; then
+    return "${EXIT_STATUS}"
+  fi
+
   echo "Running make ${name}..."
   : > "${log_file}"
   # Start each step in its own process group so fail-fast cleanup can stop pytest worker trees too.
-  "${STEP_LAUNCHER[@]}" \
-    bash -c '
-      step_name="$1"
-      log_file="$2"
-      status_pipe="$3"
-      shift 3
-
-      if "$@" >"$log_file" 2>&1; then
-        status=0
-      else
-        status=$?
-      fi
-
-      printf "%s\t%s\n" "$step_name" "$status" >"$status_pipe"
-      exit "$status"
-    ' \
-    bash "${name}" "${log_file}" "${STATUS_PIPE}" "$@" &
+  "${STEP_LAUNCHER[@]}" "$@" >"${log_file}" 2>&1 &
 
   STEP_PIDS+=("$!")
   STEP_NAMES+=("${name}")
   STEP_LOGS+=("${log_file}")
   STEP_STARTS+=("$(date +%s)")
-  RUNNING_STEPS=$((RUNNING_STEPS + 1))
 }
 
 finish_step() {
-  local name="$1"
-  local status="$2"
-  local idx=""
+  local idx="$1"
+  local name="${STEP_NAMES[$idx]}"
+  local status=0
   local pid=""
   local log_file=""
   local start_time=""
   local now
 
-  idx="$(find_step_index "${name}")"
   pid="${STEP_PIDS[$idx]}"
   log_file="${STEP_LOGS[$idx]}"
   start_time="${STEP_STARTS[$idx]}"
 
+  # Only wait supplies an exit status; the job table is just a readiness hint.
+  wait "${pid}" || status=$?
   now=$(date +%s)
-  wait "${pid}" 2>/dev/null || true
+
+  if [ "${status}" -eq 0 ] && kill -0 -- "-${pid}" 2>/dev/null; then
+    echo "code-change-verification: make ${name} left running processes." >&2
+    status=1
+  fi
 
   if [ "${status}" -eq 0 ]; then
     clear_step "${idx}"
@@ -254,114 +215,50 @@ finish_step() {
   echo "code-change-verification: make ${name} failed with exit code ${status} after $((now - start_time))s." >&2
   echo "--- ${name} log (last 80 lines) ---" >&2
   tail -n 80 "${log_file}" >&2 || true
-  stop_running_steps
   return "${status}"
 }
 
-check_for_missing_reporters() {
+wait_for_parallel_steps() {
   local idx=""
   local pid=""
-  local name=""
-  local log_file=""
-  local start_time=""
-  local now
-  local step_status=0
-
-  for idx in "${!STEP_PIDS[@]}"; do
-    pid="${STEP_PIDS[$idx]}"
-    if [ -z "${pid}" ] || step_pid_is_alive "${pid}"; then
-      continue
-    fi
-
-    if try_finish_step_from_status_pipe 1; then
-      if [ "${STATUS_PIPE_DRAINED}" -eq 1 ]; then
-        return 0
-      fi
-    else
-      step_status=$?
-      return "${step_status}"
-    fi
-
-    name="${STEP_NAMES[$idx]}"
-    log_file="${STEP_LOGS[$idx]}"
-    start_time="${STEP_STARTS[$idx]}"
-    now=$(date +%s)
-    set +e
-    wait "${pid}" 2>/dev/null
-    step_status=$?
-    set -e
-
-    if [ "${step_status}" -eq 0 ]; then
-      finish_step "${name}" 0
-      return 0
-    fi
-
-    echo "code-change-verification: make ${name} exited before reporting completion status after $((now - start_time))s." >&2
-    echo "--- ${name} log (last 80 lines) ---" >&2
-    tail -n 80 "${log_file}" >&2 || true
-    stop_running_steps
-    return "${step_status}"
-  done
-
-  return 0
-}
-
-STATUS_PIPE_DRAINED=0
-
-try_finish_step_from_status_pipe() {
-  local timeout="$1"
-  local name=""
-  local status=""
-  local step_status=0
-
-  STATUS_PIPE_DRAINED=0
-  if ! IFS=$'\t' read -r -t "${timeout}" name status <&3; then
-    return 0
-  fi
-
-  STATUS_PIPE_DRAINED=1
-  finish_step "${name}" "${status}"
-  step_status=$?
-  if [ "${step_status}" -ne 0 ]; then
-    return "${step_status}"
-  fi
-
-  return 0
-}
-
-wait_for_parallel_steps() {
-  local name=""
-  local status=""
-  local step_status=""
+  local running_pids=""
+  local pending_steps=0
   local next_heartbeat_at
   local now
 
   next_heartbeat_at=$(( $(date +%s) + HEARTBEAT_INTERVAL_SECONDS ))
 
-  while [ "${RUNNING_STEPS}" -gt 0 ]; do
-    if try_finish_step_from_status_pipe 1; then
-      if [ "${STATUS_PIPE_DRAINED}" -eq 1 ]; then
+  while :; do
+    pending_steps=0
+    # Defer cancellation until every launched PID has been registered.
+    if [ "${EXIT_STATUS}" -ne 0 ]; then
+      return "${EXIT_STATUS}"
+    fi
+    # Bash owns these jobs, so completion detection does not need sandboxed ps.
+    running_pids="$(jobs -pr)"
+    for idx in "${!STEP_PIDS[@]}"; do
+      pid="${STEP_PIDS[$idx]}"
+      if [ -z "${pid}" ]; then
         continue
       fi
-    else
-      step_status=$?
-      if [ "${step_status}" -ne 0 ]; then
-        return "${step_status}"
-      fi
-      continue
-    fi
+      case $'\n'"${running_pids}"$'\n' in
+        *$'\n'"${pid}"$'\n'*)
+          pending_steps=1
+          continue
+          ;;
+      esac
+      finish_step "${idx}" || return $?
+    done
 
-    check_for_missing_reporters
-    step_status=$?
-    if [ "${step_status}" -ne 0 ]; then
-      return "${step_status}"
+    if [ "${pending_steps}" -eq 0 ]; then
+      break
     fi
-
     now=$(date +%s)
     if [ "${now}" -ge "${next_heartbeat_at}" ]; then
       print_heartbeat
       next_heartbeat_at=$((now + HEARTBEAT_INTERVAL_SECONDS))
     fi
+    sleep 0.1
   done
 }
 
@@ -369,12 +266,8 @@ trap cleanup EXIT
 trap on_interrupt INT
 trap on_terminate TERM
 
-echo "Running make format..."
-set +e
-make format
-EXIT_STATUS=$?
-set -e
-
+start_step "format" make format
+wait_for_parallel_steps || EXIT_STATUS=$?
 if [ "${EXIT_STATUS}" -ne 0 ]; then
   exit "${EXIT_STATUS}"
 fi
@@ -383,16 +276,12 @@ echo "Running make lint, make typecheck, and make tests in parallel..."
 start_step "lint" make lint
 start_step "typecheck" make typecheck
 start_step "tests" make tests
-set +e
-wait_for_parallel_steps
-EXIT_STATUS=$?
-set -e
+wait_for_parallel_steps || EXIT_STATUS=$?
 
 if [ "${EXIT_STATUS}" -ne 0 ]; then
   exit "${EXIT_STATUS}"
 fi
 
 trap - EXIT INT TERM
-exec 3>&- 3<&-
 rm -rf "${LOG_DIR}"
 echo "code-change-verification: all commands passed."

--- a/.agents/skills/code-change-verification/scripts/run.sh
+++ b/.agents/skills/code-change-verification/scripts/run.sh
@@ -1,287 +1,81 @@
 #!/usr/bin/env bash
-# Fail fast on any error or undefined variable.
 set -euo pipefail
+# Job control gives each background make invocation its own process group.
+set -m
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if command -v git >/dev/null 2>&1; then
   REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || true)"
 fi
 REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../../.." && pwd)}"
-
 cd "${REPO_ROOT}"
 
-LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/code-change-verification.XXXXXX")"
-HEARTBEAT_INTERVAL_SECONDS="${CODE_CHANGE_VERIFICATION_HEARTBEAT_SECONDS:-10}"
-declare -a STEP_LAUNCHER=()
-declare -a STEP_PIDS=()
-declare -a STEP_NAMES=()
-declare -a STEP_LOGS=()
-declare -a STEP_STARTS=()
+STEP_PID=""
 EXIT_STATUS=0
 
-resolve_executable_path() {
-  local name="$1"
-  type -P "${name}" 2>/dev/null || true
+stop_step() {
+  if [ -z "${STEP_PID}" ]; then
+    return
+  fi
+  # Descendants can outlive make, so always address its process group.
+  if kill -TERM -- "-${STEP_PID}" 2>/dev/null; then
+    sleep 1
+    kill -KILL -- "-${STEP_PID}" 2>/dev/null || true
+  fi
+  wait "${STEP_PID}" 2>/dev/null || true
+  STEP_PID=""
 }
-
-configure_step_launcher() {
-  local perl_path=""
-  local python_path=""
-  local uv_path=""
-
-  perl_path="$(resolve_executable_path perl)"
-  if [ -n "${perl_path}" ]; then
-    STEP_LAUNCHER=("${perl_path}" -MPOSIX=setsid -e 'setsid() or die $!; exec @ARGV')
-    return 0
-  fi
-
-  python_path="$(resolve_executable_path python3)"
-  if [ -z "${python_path}" ]; then
-    python_path="$(resolve_executable_path python)"
-  fi
-  if [ -n "${python_path}" ]; then
-    STEP_LAUNCHER=("${python_path}" -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])')
-    return 0
-  fi
-
-  uv_path="$(resolve_executable_path uv)"
-  if [ -n "${uv_path}" ]; then
-    STEP_LAUNCHER=("${uv_path}" run --no-sync python -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])')
-    return 0
-  fi
-
-  echo "code-change-verification: perl, python3, python, or uv is required to manage parallel step process groups." >&2
-  exit 1
-}
-
-configure_step_launcher
 
 cleanup() {
-  local trap_status="$?"
-  local status="${EXIT_STATUS}"
-
-  # Repeated signals must not interrupt cleanup or replace the primary failure.
+  local status=$?
+  if [ "${EXIT_STATUS}" -ne 0 ]; then
+    status=${EXIT_STATUS}
+  fi
   trap - EXIT
   trap '' INT TERM
-
-  if [ "${status}" -eq 0 ]; then
-    status="${trap_status}"
-  fi
-
-  if [ "${#STEP_PIDS[@]}" -gt 0 ]; then
-    stop_running_steps
-  fi
-
-  rm -rf "${LOG_DIR}"
+  stop_step
   exit "${status}"
 }
 
-on_interrupt() {
+cancel() {
   if [ "${EXIT_STATUS}" -eq 0 ]; then
-    EXIT_STATUS=130
+    EXIT_STATUS=$1
   fi
-}
-
-on_terminate() {
-  if [ "${EXIT_STATUS}" -eq 0 ]; then
-    EXIT_STATUS=143
+  # Defer only until a just-launched PID has been registered.
+  if [ -n "${STEP_PID}" ]; then
+    exit "${EXIT_STATUS}"
   fi
-}
-
-stop_running_steps() {
-  local pid=""
-
-  if [ "${#STEP_PIDS[@]}" -eq 0 ]; then
-    return
-  fi
-
-  for pid in "${STEP_PIDS[@]}"; do
-    if [ -n "${pid}" ]; then
-      kill -TERM -- "-${pid}" 2>/dev/null || true
-      # The launcher may not have created its process group yet.
-      kill -TERM "${pid}" 2>/dev/null || true
-    fi
-  done
-
-  sleep 1
-
-  for pid in "${STEP_PIDS[@]}"; do
-    if [ -n "${pid}" ]; then
-      # A process group can remain alive after its leader exits, so escalate by group id unconditionally.
-      kill -KILL -- "-${pid}" 2>/dev/null || true
-      kill -KILL "${pid}" 2>/dev/null || true
-    fi
-  done
-
-  for pid in "${STEP_PIDS[@]}"; do
-    if [ -n "${pid}" ]; then
-      wait "${pid}" 2>/dev/null || true
-    fi
-  done
-
-  STEP_PIDS=()
-  STEP_NAMES=()
-  STEP_LOGS=()
-  STEP_STARTS=()
-}
-
-clear_step() {
-  local idx="$1"
-
-  STEP_PIDS[$idx]=""
-  STEP_NAMES[$idx]=""
-  STEP_LOGS[$idx]=""
-  STEP_STARTS[$idx]=""
-}
-
-print_heartbeat() {
-  local now
-  local idx=""
-  local name=""
-  local start_time=""
-  local elapsed=""
-  local running=""
-
-  now=$(date +%s)
-
-  for idx in "${!STEP_NAMES[@]}"; do
-    name="${STEP_NAMES[$idx]}"
-    start_time="${STEP_STARTS[$idx]}"
-
-    if [ -z "${name}" ]; then
-      continue
-    fi
-
-    elapsed=$((now - start_time))
-    if [ -n "${running}" ]; then
-      running="${running}, "
-    fi
-    running="${running}${name} (${elapsed}s)"
-  done
-
-  if [ -n "${running}" ]; then
-    echo "code-change-verification: still running: ${running}."
-  fi
-}
-
-start_step() {
-  local name="$1"
-  shift
-  local log_file="${LOG_DIR}/${name}.log"
-
-  if [ "${EXIT_STATUS}" -ne 0 ]; then
-    return "${EXIT_STATUS}"
-  fi
-
-  echo "Running make ${name}..."
-  : > "${log_file}"
-  # Start each step in its own process group so fail-fast cleanup can stop pytest worker trees too.
-  "${STEP_LAUNCHER[@]}" "$@" >"${log_file}" 2>&1 &
-
-  STEP_PIDS+=("$!")
-  STEP_NAMES+=("${name}")
-  STEP_LOGS+=("${log_file}")
-  STEP_STARTS+=("$(date +%s)")
-}
-
-finish_step() {
-  local idx="$1"
-  local name="${STEP_NAMES[$idx]}"
-  local status=0
-  local pid=""
-  local log_file=""
-  local start_time=""
-  local now
-
-  pid="${STEP_PIDS[$idx]}"
-  log_file="${STEP_LOGS[$idx]}"
-  start_time="${STEP_STARTS[$idx]}"
-
-  # Only wait supplies an exit status; the job table is just a readiness hint.
-  wait "${pid}" || status=$?
-  now=$(date +%s)
-
-  if [ "${status}" -eq 0 ] && kill -0 -- "-${pid}" 2>/dev/null; then
-    echo "code-change-verification: make ${name} left running processes." >&2
-    status=1
-  fi
-
-  if [ "${status}" -eq 0 ]; then
-    clear_step "${idx}"
-    echo "make ${name} passed in $((now - start_time))s."
-    return 0
-  fi
-
-  echo "code-change-verification: make ${name} failed with exit code ${status} after $((now - start_time))s." >&2
-  echo "--- ${name} log (last 80 lines) ---" >&2
-  tail -n 80 "${log_file}" >&2 || true
-  return "${status}"
-}
-
-wait_for_parallel_steps() {
-  local idx=""
-  local pid=""
-  local running_pids=""
-  local pending_steps=0
-  local next_heartbeat_at
-  local now
-
-  next_heartbeat_at=$(( $(date +%s) + HEARTBEAT_INTERVAL_SECONDS ))
-
-  while :; do
-    pending_steps=0
-    # Defer cancellation until every launched PID has been registered.
-    if [ "${EXIT_STATUS}" -ne 0 ]; then
-      return "${EXIT_STATUS}"
-    fi
-    # Bash owns these jobs, so completion detection does not need sandboxed ps.
-    running_pids="$(jobs -pr)"
-    for idx in "${!STEP_PIDS[@]}"; do
-      pid="${STEP_PIDS[$idx]}"
-      if [ -z "${pid}" ]; then
-        continue
-      fi
-      case $'\n'"${running_pids}"$'\n' in
-        *$'\n'"${pid}"$'\n'*)
-          pending_steps=1
-          continue
-          ;;
-      esac
-      finish_step "${idx}" || return $?
-    done
-
-    if [ "${pending_steps}" -eq 0 ]; then
-      break
-    fi
-    now=$(date +%s)
-    if [ "${now}" -ge "${next_heartbeat_at}" ]; then
-      print_heartbeat
-      next_heartbeat_at=$((now + HEARTBEAT_INTERVAL_SECONDS))
-    fi
-    sleep 0.1
-  done
 }
 
 trap cleanup EXIT
-trap on_interrupt INT
-trap on_terminate TERM
+trap 'cancel 130' INT
+trap 'cancel 143' TERM
 
-start_step "format" make format
-wait_for_parallel_steps || EXIT_STATUS=$?
-if [ "${EXIT_STATUS}" -ne 0 ]; then
-  exit "${EXIT_STATUS}"
-fi
+for step in format lint typecheck tests; do
+  if [ "${EXIT_STATUS}" -ne 0 ]; then
+    exit "${EXIT_STATUS}"
+  fi
+  echo "Running make ${step}..."
+  started=${SECONDS}
+  make "${step}" &
+  STEP_PID=$!
+  if [ "${EXIT_STATUS}" -eq 0 ]; then
+    wait "${STEP_PID}" || {
+      status=$?
+      if [ "${EXIT_STATUS}" -eq 0 ]; then
+        EXIT_STATUS=${status}
+      fi
+    }
+  fi
+  if [ "${EXIT_STATUS}" -ne 0 ]; then
+    echo "code-change-verification: make ${step} failed with exit code ${EXIT_STATUS}." >&2
+    exit "${EXIT_STATUS}"
+  fi
+  stop_step
+  if [ "${EXIT_STATUS}" -ne 0 ]; then
+    exit "${EXIT_STATUS}"
+  fi
+  echo "make ${step} passed in $((SECONDS - started))s."
+done
 
-echo "Running make lint, make typecheck, and make tests in parallel..."
-start_step "lint" make lint
-start_step "typecheck" make typecheck
-start_step "tests" make tests
-wait_for_parallel_steps || EXIT_STATUS=$?
-
-if [ "${EXIT_STATUS}" -ne 0 ]; then
-  exit "${EXIT_STATUS}"
-fi
-
-trap - EXIT INT TERM
-rm -rf "${LOG_DIR}"
 echo "code-change-verification: all commands passed."

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -131,7 +131,8 @@ def _create_owner_bearing_structure_tables(
 
 
 def _multiprocessing_context() -> Any:
-    method = "spawn" if sys.platform == "win32" else "forkserver"
+    # Spawn avoids the forkserver's Unix listener, which macOS sandboxes can deny.
+    method = "spawn" if sys.platform in {"win32", "darwin"} else "forkserver"
     return multiprocessing.get_context(method)
 
 

--- a/tests/test_code_change_verification_runner.py
+++ b/tests/test_code_change_verification_runner.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Bash process-group runner")
+_SCRIPT = (
+    Path(__file__).resolve().parents[1] / ".agents/skills/code-change-verification/scripts/run.sh"
+)
+_STEPS = ("format", "lint", "typecheck", "tests")
+
+# Each fake make waits for an explicit release, and owns a real child process.
+_MAKE = r'''
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+root = Path(os.environ["DRIVER_TEST_ROOT"])
+step = sys.argv[1]
+child_code = """
+import os, signal, sys, time
+from pathlib import Path
+root, step = Path(sys.argv[1]), sys.argv[2]
+def terminate(*_):
+    (root / (step + '.terminated')).touch()
+    sys.exit(0)
+signal.signal(signal.SIGTERM, terminate)
+(root / (step + '.child')).write_text(str(os.getpid()))
+release = step + ('.child-release' if os.environ.get('ORPHAN_STEP') == step else '.release')
+while not (root / release).exists():
+    time.sleep(0.01)
+"""
+child = subprocess.Popen([sys.executable, "-c", child_code, str(root), step])
+def terminate(*_):
+    # Reap the worker so process absence is observable on every supported OS.
+    child.wait(timeout=5)
+    sys.exit(143)
+signal.signal(signal.SIGTERM, terminate)
+(root / (step + '.started')).write_text(str(os.getpid()))
+if os.environ.get('ORPHAN_STEP') == step:
+    while not (root / (step + '.release')).exists():
+        time.sleep(0.01)
+    sys.exit(0)
+child.wait()
+(root / (step + '.finished')).touch()
+status = int((root / (step + '.release')).read_text())
+print('controlled ' + step + ' output', flush=True)
+sys.exit(status)
+'''
+
+
+def _await(predicate: Callable[[], bool]) -> None:
+    deadline = time.monotonic() + 15
+    while not predicate():
+        if time.monotonic() >= deadline:
+            pytest.fail("Timed out waiting for a controlled process transition")
+        time.sleep(0.01)
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+class _Run:
+    def __init__(self, root: Path, process: subprocess.Popen[bytes]) -> None:
+        self.root = root
+        self.process = process
+
+    def output(self) -> str:
+        return (self.root / "output").read_text()
+
+    def ready(self, step: str) -> None:
+        _await(lambda: (self.root / f"{step}.child").exists())
+
+    def release(self, step: str, status: int = 0) -> None:
+        (self.root / f"{step}.release").write_text(str(status))
+
+    def passed(self, step: str) -> None:
+        _await(lambda: f"make {step} passed in " in self.output())
+
+    def assert_stopped(self) -> None:
+        for path in [*self.root.glob("*.started"), *self.root.glob("*.child")]:
+            _await(lambda path=path: not _alive(int(path.read_text())))
+
+
+@contextmanager
+def _run(root: Path, *, orphan_step: str = "", block_date: bool = False) -> Iterator[_Run]:
+    bin_path = root / "bin"
+    bin_path.mkdir()
+    make = bin_path / "make"
+    make.write_text(f"#!{sys.executable}\n" + _MAKE)
+    make.chmod(0o755)
+    ps = bin_path / "ps"
+    ps.write_text("#!/bin/sh\nexit 1\n")
+    ps.chmod(0o755)
+    if block_date:
+        date = bin_path / "date"
+        date.write_text(
+            f"#!{sys.executable}\n"
+            "import os, signal\n"
+            "from pathlib import Path\n"
+            "signal.signal(signal.SIGINT, signal.SIG_DFL)\n"
+            "(Path(os.environ['DRIVER_TEST_ROOT']) / 'date.marker').touch()\n"
+            "signal.pause()\n"
+        )
+        date.chmod(0o755)
+    environment = {
+        key: os.environ[key]
+        for key in ("PATH", "TMPDIR", "SYSTEMROOT", "LANG")
+        if key in os.environ
+    }
+    environment.update(
+        PATH=str(bin_path) + os.pathsep + environment.get("PATH", os.defpath),
+        DRIVER_TEST_ROOT=str(root),
+        CODE_CHANGE_VERIFICATION_HEARTBEAT_SECONDS="1",
+        ORPHAN_STEP=orphan_step,
+    )
+    with (root / "output").open("wb") as output:
+        process = subprocess.Popen(
+            ["bash", str(_SCRIPT)],
+            env=environment,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        run = _Run(root, process)
+        try:
+            yield run
+        finally:
+            # Release gates even after failed assertions, then stop only owned groups.
+            for step in _STEPS:
+                run.release(step)
+                (root / f"{step}.child-release").touch()
+            if process.poll() is None:
+                process.terminate()
+            try:
+                process.wait(timeout=10)
+            finally:
+                for path in root.glob("*.started"):
+                    pid = int(path.read_text())
+                    if _alive(pid):
+                        try:
+                            os.killpg(pid, signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+                if process.poll() is None:
+                    os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=5)
+
+
+@pytest.mark.parametrize("first", ["lint", "typecheck"])
+def test_success_waits_for_every_step_without_ps(tmp_path: Path, first: str) -> None:
+    with _run(tmp_path) as run:
+        run.ready("format")
+        assert not (tmp_path / "lint.started").exists()
+        run.release("format")
+        for step in _STEPS[1:]:
+            run.ready(step)
+        _await(lambda: "still running: lint" in run.output())
+        run.release(first)
+        run.passed(first)
+        other = "typecheck" if first == "lint" else "lint"
+        run.release(other)
+        run.passed(other)
+        _await(lambda: "still running: tests" in run.output())
+        assert run.process.poll() is None, run.output()
+        assert "all commands passed" not in run.output()
+        assert not (tmp_path / "tests.finished").exists()
+        run.release("tests")
+        assert run.process.wait(timeout=10) == 0, run.output()
+        assert (tmp_path / "tests.finished").exists()
+        for step in _STEPS:
+            assert run.output().count(f"make {step} passed in ") == 1
+        assert run.output().count("all commands passed") == 1
+        assert all(int(seconds) < 60 for seconds in re.findall(r"passed in (\d+)s", run.output()))
+        run.assert_stopped()
+
+
+@pytest.mark.parametrize("failing", ["format", "lint", "tests"])
+def test_failure_reaps_remaining_steps_and_preserves_status(tmp_path: Path, failing: str) -> None:
+    with _run(tmp_path) as run:
+        run.ready("format")
+        if failing != "format":
+            run.release("format")
+            for step in _STEPS[1:]:
+                run.ready(step)
+        run.release(failing, 23)
+        assert run.process.wait(timeout=10) == 23, run.output()
+        assert f"make {failing} failed with exit code 23" in run.output()
+        assert f"controlled {failing} output" in run.output()
+        assert "all commands passed" not in run.output()
+        if failing == "format":
+            assert not (tmp_path / "lint.started").exists()
+        run.assert_stopped()
+
+
+def test_successful_leader_with_running_child_is_rejected(tmp_path: Path) -> None:
+    with _run(tmp_path, orphan_step="tests") as run:
+        run.ready("format")
+        run.release("format")
+        for step in _STEPS[1:]:
+            run.ready(step)
+        run.release("tests")
+        assert run.process.wait(timeout=10) == 1, run.output()
+        assert "make tests left running processes" in run.output()
+        assert "all commands passed" not in run.output()
+        run.assert_stopped()
+
+
+@pytest.mark.parametrize("interrupt", [signal.SIGINT, signal.SIGTERM])
+def test_cancellation_during_launch_reaps_registered_processes(
+    tmp_path: Path, interrupt: signal.Signals
+) -> None:
+    with _run(tmp_path, block_date=True) as run:
+        run.ready("format")
+        _await(lambda: (tmp_path / "date.marker").exists())
+        # Interrupt the timestamp subprocess while the formatter has its own group.
+        os.killpg(run.process.pid, interrupt)
+        assert run.process.wait(timeout=10) == 128 + interrupt, run.output()
+        assert "all commands passed" not in run.output()
+        run.assert_stopped()
+
+
+@pytest.mark.parametrize("phase", ["format", "parallel"])
+@pytest.mark.parametrize("interrupt", [signal.SIGINT, signal.SIGTERM])
+def test_cancellation_reaps_owned_processes(
+    tmp_path: Path, phase: str, interrupt: signal.Signals
+) -> None:
+    with _run(tmp_path) as run:
+        run.ready("format")
+        active = "format"
+        if phase == "parallel":
+            run.release("format")
+            for step in _STEPS[1:]:
+                run.ready(step)
+            run.release("lint")
+            run.passed("lint")
+            active = "tests"
+        run.process.send_signal(interrupt)
+        _await(lambda: (tmp_path / f"{active}.terminated").exists())
+        # A second signal during cleanup must preserve the original exit status.
+        run.process.send_signal(signal.SIGTERM)
+        assert run.process.wait(timeout=10) == 128 + interrupt, run.output()
+        assert "all commands passed" not in run.output()
+        run.assert_stopped()

--- a/tests/test_code_change_verification_runner.py
+++ b/tests/test_code_change_verification_runner.py
@@ -37,7 +37,9 @@ def terminate(*_):
     (root / (step + '.terminated')).touch()
     sys.exit(0)
 signal.signal(signal.SIGTERM, terminate)
-(root / (step + '.child')).write_text(str(os.getpid()))
+pending = root / (step + '.child.tmp')
+pending.write_text(str(os.getpid()))
+pending.replace(root / (step + '.child'))
 release = step + ('.child-release' if os.environ.get('ORPHAN_STEP') == step else '.release')
 while not (root / release).exists():
     time.sleep(0.01)
@@ -48,7 +50,10 @@ def terminate(*_):
     child.wait(timeout=5)
     sys.exit(143)
 signal.signal(signal.SIGTERM, terminate)
-(root / (step + '.started')).write_text(str(os.getpid()))
+parent_marker = root / (step + '.started')
+parent_pending = root / (step + '.started.tmp')
+parent_pending.write_text(str(os.getpid()))
+parent_pending.replace(parent_marker)
 if os.environ.get('ORPHAN_STEP') == step:
     while not (root / (step + '.release')).exists():
         time.sleep(0.01)
@@ -70,6 +75,13 @@ def _await(predicate: Callable[[], bool]) -> None:
 
 
 def _alive(pid: int) -> bool:
+    if sys.platform == "linux":
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text()
+        except (FileNotFoundError, ProcessLookupError):
+            return False
+        # Zombies have terminated even if the container's PID 1 has not reaped them.
+        return stat.rsplit(")", 1)[1].split()[0] != "Z"
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -86,10 +98,15 @@ class _Run:
         return (self.root / "output").read_text()
 
     def ready(self, step: str) -> None:
-        _await(lambda: (self.root / f"{step}.child").exists())
+        _await(
+            lambda: (self.root / f"{step}.started").exists()
+            and (self.root / f"{step}.child").exists()
+        )
 
     def release(self, step: str, status: int = 0) -> None:
-        (self.root / f"{step}.release").write_text(str(status))
+        pending = self.root / f"{step}.release.tmp"
+        pending.write_text(str(status))
+        pending.replace(self.root / f"{step}.release")
 
     def passed(self, step: str) -> None:
         _await(lambda: f"make {step} passed in " in self.output())
@@ -99,8 +116,59 @@ class _Run:
             _await(lambda path=path: not _alive(int(path.read_text())))
 
 
+@pytest.mark.parametrize(("state", "alive"), [("S", True), ("Z", False)])
+def test_linux_liveness_distinguishes_zombies(
+    monkeypatch: pytest.MonkeyPatch, state: str, alive: bool
+) -> None:
+    pid = os.getpid()
+
+    def read_stat(path: Path) -> str:
+        assert path == Path(f"/proc/{pid}/stat")
+        return f"{pid} (fake (worker)) {state} 1 2 3"
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(Path, "read_text", read_stat)
+    assert _alive(pid) is alive
+
+
+@pytest.mark.parametrize("error", [FileNotFoundError, ProcessLookupError])
+def test_linux_liveness_accepts_disappeared_process(
+    monkeypatch: pytest.MonkeyPatch, error: type[OSError]
+) -> None:
+    def read_stat(path: Path) -> str:
+        raise error(path)
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(Path, "read_text", read_stat)
+    assert not _alive(os.getpid())
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Requires Linux waitid and procfs")
+def test_stopped_assertion_accepts_unreaped_child(tmp_path: Path) -> None:
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stdin.buffer.read()"], stdin=subprocess.PIPE
+    )
+    try:
+        assert child.stdin is not None
+        (tmp_path / "worker.child").write_text(str(child.pid))
+        assert _alive(child.pid)
+        child.stdin.close()
+        # Observe termination without reaping, independently of PID 1's behavior.
+        _await(
+            lambda: os.waitid(os.P_PID, child.pid, os.WEXITED | os.WNOWAIT | os.WNOHANG) is not None
+        )
+        os.kill(child.pid, 0)
+        _Run(tmp_path, child).assert_stopped()
+    finally:
+        if child.stdin is not None:
+            child.stdin.close()
+        child.wait(timeout=10)
+
+
 @contextmanager
-def _run(root: Path, *, orphan_step: str = "", block_date: bool = False) -> Iterator[_Run]:
+def _run(
+    root: Path, *, orphan_step: str = "", interrupt_before_wait: signal.Signals | None = None
+) -> Iterator[_Run]:
     bin_path = root / "bin"
     bin_path.mkdir()
     make = bin_path / "make"
@@ -109,17 +177,6 @@ def _run(root: Path, *, orphan_step: str = "", block_date: bool = False) -> Iter
     ps = bin_path / "ps"
     ps.write_text("#!/bin/sh\nexit 1\n")
     ps.chmod(0o755)
-    if block_date:
-        date = bin_path / "date"
-        date.write_text(
-            f"#!{sys.executable}\n"
-            "import os, signal\n"
-            "from pathlib import Path\n"
-            "signal.signal(signal.SIGINT, signal.SIG_DFL)\n"
-            "(Path(os.environ['DRIVER_TEST_ROOT']) / 'date.marker').touch()\n"
-            "signal.pause()\n"
-        )
-        date.chmod(0o755)
     environment = {
         key: os.environ[key]
         for key in ("PATH", "TMPDIR", "SYSTEMROOT", "LANG")
@@ -128,12 +185,34 @@ def _run(root: Path, *, orphan_step: str = "", block_date: bool = False) -> Iter
     environment.update(
         PATH=str(bin_path) + os.pathsep + environment.get("PATH", os.defpath),
         DRIVER_TEST_ROOT=str(root),
-        CODE_CHANGE_VERIFICATION_HEARTBEAT_SECONDS="1",
         ORPHAN_STEP=orphan_step,
     )
+    command = ["bash", str(_SCRIPT)]
+    if interrupt_before_wait is not None:
+        # Inject cancellation after the status guard, before the real wait starts.
+        command = [
+            "bash",
+            "-c",
+            f"""
+wait() {{
+  if [ -z "${{cancel_sent:-}}" ]; then
+    cancel_sent=1
+    while [ ! -f "${{DRIVER_TEST_ROOT}}/format.started" ] ||
+          [ ! -f "${{DRIVER_TEST_ROOT}}/format.child" ]; do
+      sleep 0.01
+    done
+    kill -{interrupt_before_wait.name} "$$"
+  fi
+  builtin wait "$@"
+}}
+source "$1"
+""",
+            "bash",
+            str(_SCRIPT),
+        ]
     with (root / "output").open("wb") as output:
         process = subprocess.Popen(
-            ["bash", str(_SCRIPT)],
+            command,
             env=environment,
             stdout=output,
             stderr=subprocess.STDOUT,
@@ -154,37 +233,67 @@ def _run(root: Path, *, orphan_step: str = "", block_date: bool = False) -> Iter
             finally:
                 for path in root.glob("*.started"):
                     pid = int(path.read_text())
-                    if _alive(pid):
-                        try:
-                            os.killpg(pid, signal.SIGKILL)
-                        except ProcessLookupError:
-                            pass
+                    # Descendants may still run after their group leader terminates.
+                    try:
+                        os.killpg(pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
                 if process.poll() is None:
                     os.killpg(process.pid, signal.SIGKILL)
                     process.wait(timeout=5)
 
 
-@pytest.mark.parametrize("first", ["lint", "typecheck"])
-def test_success_waits_for_every_step_without_ps(tmp_path: Path, first: str) -> None:
+def test_ready_waits_for_parent_ownership(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        globals(),
+        "_MAKE",
+        _MAKE.replace(
+            "parent_pending.replace(parent_marker)",
+            "if step == 'format':\n"
+            "    while not (root / 'parent-release').exists():\n"
+            "        time.sleep(0.01)\n"
+            "parent_pending.replace(parent_marker)",
+        ),
+    )
     with _run(tmp_path) as run:
-        run.ready("format")
-        assert not (tmp_path / "lint.started").exists()
-        run.release("format")
-        for step in _STEPS[1:]:
+        try:
+            _await(lambda: (tmp_path / "format.child").exists())
+            assert not (tmp_path / "format.started").exists()
+            await_transition = _await
+
+            def publish_parent(predicate: Callable[[], bool]) -> None:
+                # The live worker alone must not release the ownership barrier.
+                assert not predicate()
+                (tmp_path / "parent-release").touch()
+                await_transition(predicate)
+
+            with monkeypatch.context() as readiness:
+                readiness.setitem(globals(), "_await", publish_parent)
+                run.ready("format")
+            for step in _STEPS:
+                run.ready(step)
+                run.release(step)
+                run.passed(step)
+            assert run.process.wait(timeout=10) == 0, run.output()
+            run.assert_stopped()
+        finally:
+            (tmp_path / "parent-release").touch()
+
+
+def test_success_waits_for_each_step_without_ps(tmp_path: Path) -> None:
+    with _run(tmp_path) as run:
+        for index, step in enumerate(_STEPS):
             run.ready(step)
-        _await(lambda: "still running: lint" in run.output())
-        run.release(first)
-        run.passed(first)
-        other = "typecheck" if first == "lint" else "lint"
-        run.release(other)
-        run.passed(other)
-        _await(lambda: "still running: tests" in run.output())
-        assert run.process.poll() is None, run.output()
-        assert "all commands passed" not in run.output()
-        assert not (tmp_path / "tests.finished").exists()
-        run.release("tests")
+            assert run.process.poll() is None, run.output()
+            assert "all commands passed" not in run.output()
+            assert not (tmp_path / f"{step}.finished").exists()
+            for later in _STEPS[index + 1 :]:
+                assert not (tmp_path / f"{later}.started").exists()
+            run.release(step)
+            run.passed(step)
+            assert (tmp_path / f"{step}.finished").exists()
+            assert f"controlled {step} output" in run.output()
         assert run.process.wait(timeout=10) == 0, run.output()
-        assert (tmp_path / "tests.finished").exists()
         for step in _STEPS:
             assert run.output().count(f"make {step} passed in ") == 1
         assert run.output().count("all commands passed") == 1
@@ -192,70 +301,93 @@ def test_success_waits_for_every_step_without_ps(tmp_path: Path, first: str) -> 
         run.assert_stopped()
 
 
-@pytest.mark.parametrize("failing", ["format", "lint", "tests"])
-def test_failure_reaps_remaining_steps_and_preserves_status(tmp_path: Path, failing: str) -> None:
+@pytest.mark.parametrize("failing", _STEPS)
+def test_failure_stops_before_the_next_step(tmp_path: Path, failing: str) -> None:
     with _run(tmp_path) as run:
-        run.ready("format")
-        if failing != "format":
-            run.release("format")
-            for step in _STEPS[1:]:
-                run.ready(step)
+        for step in _STEPS[: _STEPS.index(failing)]:
+            run.ready(step)
+            run.release(step)
+            run.passed(step)
+        run.ready(failing)
         run.release(failing, 23)
         assert run.process.wait(timeout=10) == 23, run.output()
         assert f"make {failing} failed with exit code 23" in run.output()
         assert f"controlled {failing} output" in run.output()
         assert "all commands passed" not in run.output()
-        if failing == "format":
-            assert not (tmp_path / "lint.started").exists()
+        for later in _STEPS[_STEPS.index(failing) + 1 :]:
+            assert not (tmp_path / f"{later}.started").exists()
         run.assert_stopped()
 
 
-def test_successful_leader_with_running_child_is_rejected(tmp_path: Path) -> None:
-    with _run(tmp_path, orphan_step="tests") as run:
+def test_step_completion_cleans_descendants_before_the_next_step(tmp_path: Path) -> None:
+    with _run(tmp_path, orphan_step="format") as run:
         run.ready("format")
+        worker = int((tmp_path / "format.child").read_text())
         run.release("format")
+        run.ready("lint")
+        assert not _alive(worker)
         for step in _STEPS[1:]:
             run.ready(step)
-        run.release("tests")
-        assert run.process.wait(timeout=10) == 1, run.output()
-        assert "make tests left running processes" in run.output()
-        assert "all commands passed" not in run.output()
+            run.release(step)
+            run.passed(step)
+        assert run.process.wait(timeout=10) == 0, run.output()
         run.assert_stopped()
+
+
+def test_harness_cleans_descendants_after_the_group_leader_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Keep the orphan alive even when the harness releases its normal exit gate.
+    monkeypatch.setitem(
+        globals(),
+        "_MAKE",
+        _MAKE.replace(
+            "while not (root / release).exists():",
+            "while step == 'format' or not (root / release).exists():",
+        ),
+    )
+    with _run(tmp_path, orphan_step="format") as run:
+        run.ready("format")
+        run.process.kill()
+        run.process.wait(timeout=10)
+        run.release("format")
+        leader = int((tmp_path / "format.started").read_text())
+        worker = int((tmp_path / "format.child").read_text())
+        _await(lambda: not _alive(leader))
+        assert _alive(worker)
+    run.assert_stopped()
 
 
 @pytest.mark.parametrize("interrupt", [signal.SIGINT, signal.SIGTERM])
-def test_cancellation_during_launch_reaps_registered_processes(
+def test_cancellation_before_wait_stops_the_active_step(
     tmp_path: Path, interrupt: signal.Signals
 ) -> None:
-    with _run(tmp_path, block_date=True) as run:
-        run.ready("format")
-        _await(lambda: (tmp_path / "date.marker").exists())
-        # Interrupt the timestamp subprocess while the formatter has its own group.
-        os.killpg(run.process.pid, interrupt)
+    with _run(tmp_path, interrupt_before_wait=interrupt) as run:
         assert run.process.wait(timeout=10) == 128 + interrupt, run.output()
+        assert (tmp_path / "format.terminated").exists()
+        assert not (tmp_path / "format.finished").exists()
+        assert not (tmp_path / "lint.started").exists()
         assert "all commands passed" not in run.output()
         run.assert_stopped()
 
 
-@pytest.mark.parametrize("phase", ["format", "parallel"])
+@pytest.mark.parametrize("phase", ["format", "tests"])
 @pytest.mark.parametrize("interrupt", [signal.SIGINT, signal.SIGTERM])
 def test_cancellation_reaps_owned_processes(
     tmp_path: Path, phase: str, interrupt: signal.Signals
 ) -> None:
     with _run(tmp_path) as run:
-        run.ready("format")
-        active = "format"
-        if phase == "parallel":
-            run.release("format")
-            for step in _STEPS[1:]:
-                run.ready(step)
-            run.release("lint")
-            run.passed("lint")
-            active = "tests"
+        for step in _STEPS[: _STEPS.index(phase)]:
+            run.ready(step)
+            run.release(step)
+            run.passed(step)
+        run.ready(phase)
         run.process.send_signal(interrupt)
-        _await(lambda: (tmp_path / f"{active}.terminated").exists())
+        _await(lambda: (tmp_path / f"{phase}.terminated").exists())
         # A second signal during cleanup must preserve the original exit status.
         run.process.send_signal(signal.SIGTERM)
         assert run.process.wait(timeout=10) == 128 + interrupt, run.output()
         assert "all commands passed" not in run.output()
+        for later in _STEPS[_STEPS.index(phase) + 1 :]:
+            assert not (tmp_path / f"{later}.started").exists()
         run.assert_stopped()

--- a/tests/test_integration_runner.py
+++ b/tests/test_integration_runner.py
@@ -14,6 +14,12 @@ RUNNER = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "run_inte
 INTEGRATION_CONFTEST = RUNNER.parents[2] / "integration_tests" / "conftest.py"
 
 
+@pytest.fixture(autouse=True)
+def isolate_runner_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The runner deliberately mutates its environment before starting subprocesses.
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+
+
 def _sanitizer() -> Callable[[Path], Any]:
     return cast(Callable[[Path], Any], runpy.run_path(str(RUNNER))["_sanitize_and_load_junit"])
 


### PR DESCRIPTION
This pull request simplifies the Bash verification runner and fixes test-environment failures observed in the macOS Codex sandbox.

Run `make format`, `make lint`, `make typecheck`, and `make tests` sequentially. Coordinating these commands in parallel required custom completion tracking and cancellation bookkeeping, which introduced failure modes in the verification wrapper itself. Sequential execution makes each Make exit status authoritative and limits cleanup to one process group at a time.

This accepts a potential increase in elapsed time to reduce maintenance and cleanup complexity. Parallelism inside Make targets, including pytest workers, is unchanged.

- Stream command output directly and remove completion polling, PID arrays, launcher discovery, heartbeat management, and temporary step logs.
- Preserve failure and cancellation status, including cancellation immediately before waiting, and clean up remaining child processes.
- Treat Linux zombie workers and disappeared processes as stopped. Publish test PID and release markers atomically.
- Use `spawn` for macOS AdvancedSQLiteSession multiprocessing tests while preserving their cross-process assertions.
- Isolate mocked integration runner environments so credential removal does not affect later tests. Production credential handling is unchanged.
- Keep the Windows wrapper unchanged.
