### PR TITLE
fix(sessions): preserve Session transformations during generation tracking

### DIFF
--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -37,7 +37,13 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from typing_extensions import TypedDict
 
 from ...items import TResponseInputItem
-from ...memory.session import SessionABC, _call_session_method, _get_session_wrapper
+from ...memory.openai_responses_compaction_session import OpenAIResponsesCompactionSession
+from ...memory.session import (
+    OpenAIResponsesCompactionArgs,
+    SessionABC,
+    _call_session_method,
+    _get_session_wrapper,
+)
 from ...memory.session_settings import SessionSettings, resolve_session_limit
 from ...run_context import RunContextWrapper
 
@@ -134,8 +140,46 @@ class EncryptedSession(SessionABC):
         self._kid = "hkdf-v1"
         self._ver = 1
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
+        # Expose compaction only when the underlying session actually supports it.
+        if isinstance(self.underlying_session, OpenAIResponsesCompactionSession):
+            if name == "run_compaction":
+                return self._run_compaction
+            if name == "_defer_compaction":
+                return self._defer_encrypted_compaction
         return getattr(self.underlying_session, name)
+
+    async def _run_compaction(
+        self,
+        args: OpenAIResponsesCompactionArgs | None = None,
+        *,
+        wrapper: RunContextWrapper[Any] | None = None,
+    ) -> None:
+        session = cast(OpenAIResponsesCompactionSession, self.underlying_session)
+        await session._run_compaction(
+            args,
+            wrapper=wrapper,
+            read_items=lambda: _call_session_method(
+                self.get_items, wrapper=_get_session_wrapper(self, wrapper)
+            ),
+            prepare_items=self._encrypt_items,
+        )
+
+    async def _defer_encrypted_compaction(
+        self,
+        response_id: str,
+        store: bool | None = None,
+        *,
+        wrapper: RunContextWrapper[Any] | None = None,
+    ) -> None:
+        session = cast(OpenAIResponsesCompactionSession, self.underlying_session)
+        await session._defer_compaction(
+            response_id,
+            store,
+            read_items=lambda: _call_session_method(
+                self.get_items, wrapper=_get_session_wrapper(self, wrapper)
+            ),
+        )
 
     @property
     def session_settings(self) -> SessionSettings | None:
@@ -217,6 +261,9 @@ class EncryptedSession(SessionABC):
         )
         return self._unwrap_valid_items(encrypted_items)
 
+    def _encrypt_items(self, items: list[TResponseInputItem]) -> list[TResponseInputItem]:
+        return cast(list[TResponseInputItem], [self._wrap(item) for item in items])
+
     async def add_items(
         self,
         items: list[TResponseInputItem],
@@ -224,10 +271,9 @@ class EncryptedSession(SessionABC):
         wrapper: RunContextWrapper[Any] | None = None,
     ) -> None:
         wrapper = _get_session_wrapper(self.underlying_session, wrapper)
-        wrapped: list[EncryptedEnvelope] = [self._wrap(it) for it in items]
         await _call_session_method(
             self.underlying_session.add_items,
-            cast(list[TResponseInputItem], wrapped),
+            self._encrypt_items(items),
             wrapper=wrapper,
         )
 

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -182,6 +182,16 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         When a run context is provided, the billed compaction request contributes to
         that run's usage totals.
         """
+        await self._run_compaction(args, wrapper=wrapper)
+
+    async def _run_compaction(
+        self,
+        args: OpenAIResponsesCompactionArgs | None,
+        *,
+        wrapper: RunContextWrapper[Any] | None,
+        read_items: Callable[[], Awaitable[list[TResponseInputItem]]] | None = None,
+        prepare_items: Callable[[list[TResponseInputItem]], list[TResponseInputItem]] | None = None,
+    ) -> None:
         # Keep one wrapper mutation boundary from the snapshot through replacement.
         # A concurrent add, pop, or clear waits here and then runs against the
         # compacted state instead of being overwritten by a stale replacement.
@@ -203,13 +213,17 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
                     "run appended its items."
                 )
                 return
-            await self._run_compaction_locked(args, wrapper=wrapper)
+            await self._run_compaction_locked(
+                args, wrapper=wrapper, read_items=read_items, prepare_items=prepare_items
+            )
 
     async def _run_compaction_locked(
         self,
         args: OpenAIResponsesCompactionArgs | None,
         *,
         wrapper: RunContextWrapper[Any] | None,
+        read_items: Callable[[], Awaitable[list[TResponseInputItem]]] | None = None,
+        prepare_items: Callable[[list[TResponseInputItem]], list[TResponseInputItem]] | None = None,
     ) -> None:
         if args and args.get("response_id"):
             self._response_id = args["response_id"]
@@ -234,7 +248,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
                 "when using previous_response_id compaction."
             )
 
-        compaction_candidate_items, session_items = await self._ensure_compaction_candidates()
+        compaction_candidate_items, session_items = await self._ensure_compaction_candidates(
+            read_items
+        )
 
         force = args.get("force", False) if args else False
         should_compact = force or self.should_trigger_compaction(
@@ -278,18 +294,25 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             _normalize_compaction_output_items(compacted.output or [])
         )
 
+        # Prepare output before any destructive operation. Keep the rollback snapshot in
+        # its original storage form so restoring encrypted history does not renew its TTL.
+        stored_output_items = (
+            prepare_items(output_items) if prepare_items is not None else output_items
+        )
         previous_items = await self._get_all_underlying_session_items()
         try:
             await self._replace_underlying_session_items(
-                output_items=output_items,
+                output_items=stored_output_items,
                 previous_items=previous_items,
             )
         except (Exception, asyncio.CancelledError):
             self._mutation_generation += 1
             raise
         self._mutation_generation += 1
-        self._compaction_candidate_items = select_compaction_candidate_items(output_items)
-        self._session_items = output_items
+        self._compaction_candidate_items = (
+            None if read_items is not None else select_compaction_candidate_items(output_items)
+        )
+        self._session_items = None if read_items is not None else output_items
 
         logger.debug(
             "compact: done for %s (mode=%s, output=%s, candidates=%s)",
@@ -303,11 +326,12 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         return await self.underlying_session.get_items(limit)
 
     async def _get_items_with_generation(
-        self, limit: int | None = None
+        self, read_items: Callable[[], Awaitable[list[TResponseInputItem]]]
     ) -> tuple[list[TResponseInputItem], int]:
         """Read one Runner snapshot with its exact wrapper generation."""
         async with self._mutation_lock:
-            items = await self.underlying_session.get_items(limit)
+            # Read through the outer Session so its decryption and filtering still apply.
+            items = await read_items()
             return items, self._mutation_generation
 
     async def _get_all_underlying_session_items(self) -> list[TResponseInputItem]:
@@ -428,25 +452,34 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             replacement_error,
         )
 
-    async def _defer_compaction(self, response_id: str, store: bool | None = None) -> None:
-        if self._deferred_response_id is not None:
-            return
-        compaction_candidate_items, session_items = await self._ensure_compaction_candidates()
-        resolved_mode = self._resolve_compaction_mode_for_response(
-            response_id=response_id,
-            store=store,
-            requested_mode=None,
-        )
-        should_compact = self.should_trigger_compaction(
-            {
-                "response_id": response_id,
-                "compaction_mode": resolved_mode,
-                "compaction_candidate_items": compaction_candidate_items,
-                "session_items": session_items,
-            }
-        )
-        if should_compact:
-            self._deferred_response_id = response_id
+    async def _defer_compaction(
+        self,
+        response_id: str,
+        store: bool | None = None,
+        *,
+        read_items: Callable[[], Awaitable[list[TResponseInputItem]]] | None = None,
+    ) -> None:
+        async with self._mutation_lock:
+            if self._deferred_response_id is not None:
+                return
+            compaction_candidate_items, session_items = await self._ensure_compaction_candidates(
+                read_items
+            )
+            resolved_mode = self._resolve_compaction_mode_for_response(
+                response_id=response_id,
+                store=store,
+                requested_mode=None,
+            )
+            should_compact = self.should_trigger_compaction(
+                {
+                    "response_id": response_id,
+                    "compaction_mode": resolved_mode,
+                    "compaction_candidate_items": compaction_candidate_items,
+                    "session_items": session_items,
+                }
+            )
+            if should_compact:
+                self._deferred_response_id = response_id
 
     def _get_deferred_compaction_response_id(self) -> str | None:
         return self._deferred_response_id
@@ -460,15 +493,18 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
 
     async def _add_items_with_generation(
         self,
-        items: list[TResponseInputItem],
+        write_items: Callable[[], Awaitable[None]],
         *,
         expected_generation: int | None,
     ) -> int | None:
         """Append one Runner batch and retain ownership only when its read stayed current."""
-        async with self._mutation_lock:
-            owns_generation = expected_generation == self._mutation_generation
-            await self._add_items_locked(items)
-            return self._mutation_generation if owns_generation else None
+        # The outer Session applies its transformations before our public add_items acquires
+        # the mutation lock. Any intervening mutation revokes ownership, including a write
+        # that completes while the outer Session is awaiting acknowledgement after our append.
+        await write_items()
+        if expected_generation is not None and self._mutation_generation == expected_generation + 1:
+            return self._mutation_generation
+        return None
 
     async def _add_items_locked(self, items: list[TResponseInputItem]) -> None:
         try:
@@ -521,8 +557,15 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
 
     async def _ensure_compaction_candidates(
         self,
+        read_items: Callable[[], Awaitable[list[TResponseInputItem]]] | None = None,
     ) -> tuple[list[TResponseInputItem], list[TResponseInputItem]]:
         """Lazy-load and cache compaction candidates."""
+        if read_items is not None:
+            # The outer view can change through TTL expiration without a mutation. Its
+            # logical items also differ from the raw items maintained by our append cache.
+            history = _normalize_compaction_session_items(await read_items())
+            return select_compaction_candidate_items(history), history
+
         if self._compaction_candidate_items is not None and self._session_items is not None:
             return (self._compaction_candidate_items[:], self._session_items[:])
 

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -202,20 +202,23 @@ async def _session_get_items(
     capture_compaction_generation: bool = False,
 ) -> list[TResponseInputItem]:
     """Read session items while preserving the legacy method call shape."""
+    session_wrapper = _get_session_wrapper(session, wrapper)
+
+    async def read_items() -> list[TResponseInputItem]:
+        if limit is _SESSION_LIMIT_UNSET:
+            result = await _call_session_method(session.get_items, wrapper=session_wrapper)
+        else:
+            result = await _call_session_method(
+                session.get_items, limit=limit, wrapper=session_wrapper
+            )
+        return cast(list[TResponseInputItem], result)
+
     get_with_generation = getattr(session, "_get_items_with_generation", None)
     if capture_compaction_generation and wrapper is not None and callable(get_with_generation):
-        if limit is _SESSION_LIMIT_UNSET:
-            result, generation = await _call_session_method(get_with_generation)
-        else:
-            result, generation = await _call_session_method(get_with_generation, limit=limit)
+        result, generation = await _call_session_method(get_with_generation, read_items)
         wrapper._session_compaction_generation = generation  # type: ignore[attr-defined]
         return cast(list[TResponseInputItem], result)
-    wrapper = _get_session_wrapper(session, wrapper)
-    if limit is _SESSION_LIMIT_UNSET:
-        result = await _call_session_method(session.get_items, wrapper=wrapper)
-    else:
-        result = await _call_session_method(session.get_items, limit=limit, wrapper=wrapper)
-    return cast(list[TResponseInputItem], result)
+    return await read_items()
 
 
 async def _session_add_items(
@@ -225,18 +228,22 @@ async def _session_add_items(
     wrapper: RunContextWrapper[Any] | None = None,
 ) -> None:
     """Append session items while preserving the legacy method call shape."""
+    session_wrapper = _get_session_wrapper(session, wrapper)
+
+    async def write_items() -> None:
+        await _call_session_method(session.add_items, items, wrapper=session_wrapper)
+
     add_with_generation = getattr(session, "_add_items_with_generation", None)
     if wrapper is not None and callable(add_with_generation):
         expected_generation = getattr(wrapper, "_session_compaction_generation", None)
         generation = await _call_session_method(
             add_with_generation,
-            items,
+            write_items,
             expected_generation=expected_generation,
         )
         wrapper._session_compaction_generation = generation  # type: ignore[attr-defined]
         return
-    wrapper = _get_session_wrapper(session, wrapper)
-    await _call_session_method(session.add_items, items, wrapper=wrapper)
+    await write_items()
 
 
 async def _session_pop_item(
@@ -834,7 +841,7 @@ async def resume_pending_session_write(
             if wrapper is not None and callable(get_with_generation):
                 tail, committed_generation = await _call_session_method(
                     get_with_generation,
-                    limit=len(expected),
+                    lambda: _session_get_items(session, limit=len(expected), wrapper=wrapper),
                 )
             else:
                 tail = await _session_get_items(session, limit=len(expected), wrapper=wrapper)

--- a/tests/extensions/memory/test_encrypt_session.py
+++ b/tests/extensions/memory/test_encrypt_session.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -12,15 +16,20 @@ from cryptography.fernet import Fernet
 
 from agents import (
     Agent,
+    RunConfig,
     RunContextWrapper,
     Runner,
+    RunState,
     SessionSettings,
     SQLiteSession,
     TResponseInputItem,
 )
+from agents.decorators import tool
 from agents.extensions.memory.encrypt_session import EncryptedSession
-from agents.testing import ScriptedModel
-from tests.test_responses import get_text_message
+from agents.memory import OpenAIResponsesCompactionSession
+from agents.memory.openai_responses_compaction_session import OpenAIResponsesCompactionMode
+from agents.testing import ModelStep, ScriptedModel
+from tests.test_responses import get_function_tool_call, get_text_message
 
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
@@ -124,6 +133,615 @@ async def test_encrypted_session_with_runner(
     assert any("Golden Gate Bridge" in str(item.get("content", "")) for item in last_input)
 
     underlying_session.close()
+
+
+async def _run_encrypted_session(
+    agent: Agent[Any], value: str | RunState[Any], session: EncryptedSession, streamed: bool
+):
+    config = RunConfig(tracing_disabled=True)
+    if not streamed:
+        return await Runner.run(agent, value, session=session, run_config=config)
+    result = Runner.run_streamed(agent, value, session=session, run_config=config)
+    async for _ in result.stream_events():
+        pass
+    return result
+
+
+def _decrypt_stored_items(
+    session: EncryptedSession, stored: list[TResponseInputItem]
+) -> list[dict[str, Any]]:
+    # Inspect the storage envelope and decrypt directly, independently of Session.get_items.
+    envelopes = cast(list[dict[str, Any]], stored)
+    assert all(set(item) == {"__enc__", "v", "kid", "payload"} for item in envelopes)
+    assert all(item["__enc__"] == 1 for item in envelopes)
+    return [json.loads(session.cipher.decrypt(item["payload"].encode())) for item in envelopes]
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_runner_encrypts_items_around_compaction(
+    streamed: bool, encryption_key: str, tmp_path: Path
+) -> None:
+    backend = SQLiteSession("encrypted-compaction", tmp_path / "history.db")
+    session = EncryptedSession(
+        backend.session_id,
+        OpenAIResponsesCompactionSession(
+            backend.session_id, backend, should_trigger_compaction=lambda _: False
+        ),
+        encryption_key,
+    )
+    output = get_text_message("private assistant answer")
+    model = ScriptedModel([[output], [get_text_message("followup answer")]])
+    agent = Agent(name="test", model=model)
+    expected = [
+        {"role": "user", "content": "private user input"},
+        output.model_dump(exclude_unset=True),
+    ]
+    try:
+        result = await _run_encrypted_session(agent, "private user input", session, streamed)
+        assert result.final_output == "private assistant answer"
+        assert _decrypt_stored_items(session, await backend.get_items()) == expected
+
+        await _run_encrypted_session(agent, "followup", session, streamed)
+        assert model.calls[-1].input == expected + [{"role": "user", "content": "followup"}]
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("mode", ["input", "previous_response_id"])
+async def test_runner_compacts_encrypted_history(
+    streamed: bool,
+    mode: OpenAIResponsesCompactionMode,
+    encryption_key: str,
+    tmp_path: Path,
+    set_fernet_time: Any,
+) -> None:
+    backend = SQLiteSession("encrypted-active-compaction", tmp_path / "history.db")
+    compacted = {"type": "compaction", "id": "cmp-1", "encrypted_content": "summary"}
+    client = MagicMock()
+    client.responses.compact = AsyncMock(return_value=SimpleNamespace(output=[compacted]))
+    decisions: list[dict[str, Any]] = []
+
+    def should_compact(context: dict[str, Any]) -> bool:
+        decisions.append(context)
+        return True
+
+    session = EncryptedSession(
+        backend.session_id,
+        OpenAIResponsesCompactionSession(
+            backend.session_id,
+            backend,
+            client=client,
+            compaction_mode=mode,
+            should_trigger_compaction=should_compact,
+        ),
+        encryption_key,
+        ttl=10,
+    )
+    output = get_text_message("private answer")
+    next_output = get_text_message("next answer")
+    model = ScriptedModel(
+        [
+            ModelStep(output=[output], response_id="resp-1"),
+            ModelStep(output=[next_output], response_id="resp-2"),
+        ]
+    )
+    agent = Agent(name="test", model=model)
+    try:
+        set_fernet_time(1_000)
+        await session.add_items([{"role": "assistant", "content": "expired private history"}])
+        set_fernet_time(1_020)
+        await session.add_items([{"role": "user", "content": "retained history"}])
+        await _run_encrypted_session(agent, "private input", session, streamed)
+
+        expected = [
+            {"role": "user", "content": "retained history"},
+            {"role": "user", "content": "private input"},
+            output.model_dump(exclude_unset=True),
+        ]
+        if mode == "input":
+            client.responses.compact.assert_awaited_once_with(model="gpt-4.1", input=expected)
+        else:
+            client.responses.compact.assert_awaited_once_with(
+                model="gpt-4.1", previous_response_id="resp-1"
+            )
+        assert decisions[0]["session_items"] == expected
+        assert decisions[0]["compaction_candidate_items"] == [expected[-1]]
+        assert _decrypt_stored_items(session, await backend.get_items()) == [compacted]
+        assert await session.get_items() == [compacted]
+
+        await _run_encrypted_session(agent, "next", session, streamed)
+        assert model.calls[1].input == [compacted, {"role": "user", "content": "next"}]
+        assert decisions[1]["session_items"] == [
+            compacted,
+            {"role": "user", "content": "next"},
+            next_output.model_dump(exclude_unset=True),
+        ]
+        assert decisions[1]["compaction_candidate_items"] == [
+            next_output.model_dump(exclude_unset=True)
+        ]
+        assert _decrypt_stored_items(session, await backend.get_items()) == [compacted]
+
+        # Expiration changes the logical snapshot without changing the mutation generation.
+        set_fernet_time(1_040)
+        await session.run_compaction({"compaction_mode": "input", "force": True})
+        client.responses.compact.assert_awaited_with(model="gpt-4.1", input=[])
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_runner_decrypts_existing_compaction_history_with_ttl_and_limit(
+    streamed: bool, encryption_key: str, tmp_path: Path, set_fernet_time: Any
+) -> None:
+    backend = SQLiteSession("encrypted-history", tmp_path / "history.db")
+    session = EncryptedSession(
+        backend.session_id,
+        OpenAIResponsesCompactionSession(
+            backend.session_id, backend, should_trigger_compaction=lambda _: False
+        ),
+        encryption_key,
+        ttl=10,
+    )
+    expected_history = [{"role": "user", "content": "retained history"}]
+    try:
+        set_fernet_time(1_000)
+        await session.add_items([{"role": "assistant", "content": "expired history"}])
+        expired = (await backend.get_items())[0]
+        set_fernet_time(1_020)
+        await session.add_items(cast(list[TResponseInputItem], expected_history))
+        # An expired tail forces EncryptedSession to expand its one-item retrieval window.
+        await backend.add_items([expired])
+        session.session_settings = SessionSettings(limit=1)
+        model = ScriptedModel([[get_text_message("answer")]])
+
+        await _run_encrypted_session(Agent(name="test", model=model), "next", session, streamed)
+
+        assert model.calls[0].input == expected_history + [{"role": "user", "content": "next"}]
+    finally:
+        backend.close()
+
+
+async def test_runner_defers_compaction_using_decrypted_candidates(
+    encryption_key: str, tmp_path: Path
+) -> None:
+    backend = SQLiteSession("encrypted-deferred", tmp_path / "history.db")
+    client = MagicMock()
+    client.responses.compact = AsyncMock(return_value=SimpleNamespace(output=[]))
+    decisions: list[dict[str, Any]] = []
+
+    def should_compact(context: dict[str, Any]) -> bool:
+        decisions.append(context)
+        return context["response_id"] == "resp-tool" and any(
+            item.get("type") == "function_call_output"
+            for item in context["compaction_candidate_items"]
+        )
+
+    session = EncryptedSession(
+        backend.session_id,
+        OpenAIResponsesCompactionSession(
+            backend.session_id,
+            backend,
+            client=client,
+            compaction_mode="input",
+            should_trigger_compaction=should_compact,
+        ),
+        encryption_key,
+    )
+
+    @tool
+    async def lookup() -> str:
+        return "private lookup result"
+
+    call = get_function_tool_call("lookup", "{}", call_id="lookup-1")
+    output = get_text_message("private answer")
+    model = ScriptedModel(
+        [
+            ModelStep(output=[call], response_id="resp-tool"),
+            ModelStep(output=[output], response_id="resp-final"),
+        ]
+    )
+    try:
+        await _run_encrypted_session(
+            Agent(name="test", model=model, tools=[lookup]), "private request", session, False
+        )
+        expected = [
+            {"role": "user", "content": "private request"},
+            call.model_dump(exclude_unset=True),
+            {
+                "type": "function_call_output",
+                "call_id": "lookup-1",
+                "output": "private lookup result",
+            },
+        ]
+        assert any(context["compaction_candidate_items"] == expected[1:] for context in decisions)
+        client.responses.compact.assert_awaited_once_with(
+            model="gpt-4.1", input=expected + [output.model_dump(exclude_unset=True)]
+        )
+        assert await backend.get_items() == []
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize("cancel", [False, True], ids=["failure", "cancellation"])
+async def test_encrypted_compaction_restores_original_tokens_before_concurrent_append(
+    cancel: bool, encryption_key: str, tmp_path: Path, set_fernet_time: Any
+) -> None:
+    replacement_written = asyncio.Event()
+    release_replacement = asyncio.Event()
+    append_started = asyncio.Event()
+
+    class PausingSQLiteSession(SQLiteSession):
+        """Control a committed replacement failure at the real storage boundary."""
+
+        fail_replacement = False
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            await super().add_items(items)
+            if self.fail_replacement:
+                self.fail_replacement = False
+                replacement_written.set()
+                await release_replacement.wait()
+                raise RuntimeError("replacement acknowledgement lost")
+
+    backend = PausingSQLiteSession("encrypted-rollback", tmp_path / "history.db")
+    compacted = {"type": "compaction", "id": "cmp-1", "encrypted_content": "summary"}
+    client = MagicMock()
+    client.responses.compact = AsyncMock(return_value=SimpleNamespace(output=[compacted]))
+    session = EncryptedSession(
+        backend.session_id,
+        OpenAIResponsesCompactionSession(backend.session_id, backend, client=client),
+        encryption_key,
+        ttl=10,
+    )
+    tasks: list[asyncio.Task[Any]] = []
+    valid = {"role": "user", "content": "valid history"}
+    survivor = {"role": "user", "content": "concurrent survivor"}
+
+    async def append() -> None:
+        append_started.set()
+        await session.add_items([cast(TResponseInputItem, survivor)])
+
+    try:
+        set_fernet_time(1_000)
+        await session.add_items([{"role": "user", "content": "expired history"}])
+        set_fernet_time(1_020)
+        await session.add_items([cast(TResponseInputItem, valid)])
+        original_tokens = await backend.get_items()
+        backend.fail_replacement = True
+        compaction = asyncio.create_task(session.run_compaction({"force": True}))
+        tasks.append(compaction)
+        await asyncio.wait_for(replacement_written.wait(), timeout=2)
+        assert _decrypt_stored_items(session, await backend.get_items()) == [compacted]
+        writer = asyncio.create_task(append())
+        tasks.append(writer)
+        await asyncio.wait_for(append_started.wait(), timeout=2)
+        assert not writer.done()
+
+        if cancel:
+            compaction.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(compaction, timeout=2)
+        else:
+            release_replacement.set()
+            with pytest.raises(RuntimeError, match="replacement acknowledgement lost"):
+                await asyncio.wait_for(compaction, timeout=2)
+        await asyncio.wait_for(writer, timeout=2)
+
+        stored = await backend.get_items()
+        assert stored[:-1] == original_tokens
+        assert _decrypt_stored_items(session, stored[-1:]) == [survivor]
+        assert await session.get_items() == [valid, survivor]
+        await session.run_compaction({"force": True})
+        client.responses.compact.assert_awaited_with(model="gpt-4.1", input=[valid, survivor])
+        assert _decrypt_stored_items(session, await backend.get_items()) == [compacted]
+    finally:
+        release_replacement.set()
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        backend.close()
+
+
+async def test_clear_revokes_encrypted_deferred_compaction(
+    encryption_key: str, tmp_path: Path
+) -> None:
+    snapshot_read, release_snapshot, model_waiting, release_model = (
+        asyncio.Event() for _ in range(4)
+    )
+    clear_started, backend_clear_started = asyncio.Event(), asyncio.Event()
+
+    class ObservedSQLiteSession(SQLiteSession):
+        async def clear_session(self) -> None:
+            backend_clear_started.set()
+            await super().clear_session()
+
+    class PausingEncryptedSession(EncryptedSession):
+        """Suspend a logical tool-output snapshot before its policy decision."""
+
+        paused = False
+
+        async def get_items(self, limit=None):
+            # Preserve the public Session call shape without opting into run context.
+            items = await super().get_items(limit)
+            if not self.paused and any(
+                item.get("type") == "function_call_output" for item in items
+            ):
+                self.paused = True
+                snapshot_read.set()
+                await release_snapshot.wait()
+            return items
+
+    backend = ObservedSQLiteSession("encrypted-deferred-clear", tmp_path / "history.db")
+    client = MagicMock()
+    client.responses.compact = AsyncMock(return_value=SimpleNamespace(output=[]))
+    session = PausingEncryptedSession(
+        backend.session_id,
+        OpenAIResponsesCompactionSession(
+            backend.session_id,
+            backend,
+            client=client,
+            compaction_mode="input",
+            should_trigger_compaction=lambda context: context["response_id"] == "resp-tool",
+        ),
+        encryption_key,
+    )
+
+    @tool
+    async def lookup() -> str:
+        return "private tool output"
+
+    async def held_model(_) -> ModelStep:
+        model_waiting.set()
+        await release_model.wait()
+        return ModelStep(output=[get_text_message("answer-A")], response_id="resp-a")
+
+    async def clear() -> None:
+        clear_started.set()
+        await session.clear_session()
+
+    agent_a = Agent(
+        name="A",
+        tools=[lookup],
+        model=ScriptedModel(
+            [
+                ModelStep(
+                    output=[get_function_tool_call("lookup", "{}", call_id="lookup-a")],
+                    response_id="resp-tool",
+                ),
+                ModelStep.respond(held_model),
+            ]
+        ),
+    )
+    task_a = asyncio.create_task(_run_encrypted_session(agent_a, "input-A", session, False))
+    tasks: list[asyncio.Task[Any]] = [task_a]
+    try:
+        await asyncio.wait_for(snapshot_read.wait(), timeout=2)
+        clearing = asyncio.create_task(clear())
+        tasks.append(clearing)
+        await asyncio.wait_for(clear_started.wait(), timeout=2)
+        clear_entered_before_snapshot_settled = backend_clear_started.is_set()
+        if clear_entered_before_snapshot_settled:
+            # Force the stale-publication interleaving if clear can pass the snapshot.
+            await asyncio.wait_for(clearing, timeout=2)
+        release_snapshot.set()
+        await asyncio.wait_for(model_waiting.wait(), timeout=2)
+        await asyncio.wait_for(clearing, timeout=2)
+
+        output_b = get_text_message("answer-B")
+        agent_b = Agent(
+            name="B", model=ScriptedModel([ModelStep(output=[output_b], response_id="resp-b")])
+        )
+        await _run_encrypted_session(agent_b, "input-B", session, False)
+
+        client.responses.compact.assert_not_awaited()
+        assert not clear_entered_before_snapshot_settled
+        assert _decrypt_stored_items(session, await backend.get_items()) == [
+            {"role": "user", "content": "input-B"},
+            output_b.model_dump(exclude_unset=True),
+        ]
+    finally:
+        release_snapshot.set()
+        release_model.set()
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        backend.close()
+
+
+async def test_encrypted_session_preserves_optional_compaction_delegation(
+    encryption_key: str, tmp_path: Path
+) -> None:
+    calls: list[Any] = []
+
+    class CustomCompactionSession(SQLiteSession):
+        async def run_compaction(self, args=None) -> None:
+            calls.append(args)
+
+    backend = CustomCompactionSession("encrypted-custom-compaction", tmp_path / "history.db")
+    session = EncryptedSession(backend.session_id, backend, encryption_key)
+
+    @tool
+    async def lookup() -> str:
+        return "private lookup result"
+
+    model = ScriptedModel(
+        [
+            ModelStep(
+                output=[get_function_tool_call("lookup", "{}", call_id="lookup-custom")],
+                response_id="resp-tool",
+            ),
+            ModelStep(output=[get_text_message("private answer")], response_id="resp-final"),
+        ]
+    )
+    try:
+        result = await _run_encrypted_session(
+            Agent(name="test", model=model, tools=[lookup]), "private input", session, False
+        )
+        assert result.final_output == "private answer"
+        assert not hasattr(session, "_defer_compaction")
+        assert [args["response_id"] for args in calls] == ["resp-final"]
+        assert len(_decrypt_stored_items(session, await backend.get_items())) == 4
+    finally:
+        backend.close()
+
+
+async def test_compaction_wrapping_encrypted_storage(encryption_key: str, tmp_path: Path) -> None:
+    backend = SQLiteSession("inner-encryption", tmp_path / "history.db")
+    encrypted = EncryptedSession(backend.session_id, backend, encryption_key)
+    compacted = {"type": "compaction", "id": "cmp-1", "encrypted_content": "summary"}
+    client = MagicMock()
+    client.responses.compact = AsyncMock(return_value=SimpleNamespace(output=[compacted]))
+    session = OpenAIResponsesCompactionSession(backend.session_id, encrypted, client=client)
+    try:
+        await session.add_items([{"role": "user", "content": "private history"}])
+        await session.run_compaction({"force": True})
+        client.responses.compact.assert_awaited_once_with(
+            model="gpt-4.1", input=[{"role": "user", "content": "private history"}]
+        )
+        assert _decrypt_stored_items(encrypted, await backend.get_items()) == [compacted]
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_runner_recovers_encrypted_resumed_append(
+    streamed: bool, encryption_key: str, tmp_path: Path
+) -> None:
+    class LostAckSQLiteSession(SQLiteSession):
+        """Fail after a real committed batch to exercise public Runner recovery."""
+
+        fail_after_commit = False
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            await super().add_items(items)
+            if self.fail_after_commit:
+                self.fail_after_commit = False
+                raise RuntimeError("append acknowledgement lost")
+
+    backend = LostAckSQLiteSession("encrypted-resume", tmp_path / "history.db")
+    session = EncryptedSession(
+        backend.session_id,
+        OpenAIResponsesCompactionSession(
+            backend.session_id, backend, should_trigger_compaction=lambda _: False
+        ),
+        encryption_key,
+    )
+    effects: list[str] = []
+
+    @tool(needs_approval=True)
+    async def record() -> str:
+        effects.append("recorded")
+        return "private tool receipt"
+
+    call = get_function_tool_call("record", "{}", call_id="record-1")
+    output = get_text_message("private final answer")
+    model = ScriptedModel([[call], [output]])
+    agent = Agent(name="test", model=model, tools=[record])
+    try:
+        paused = await _run_encrypted_session(agent, "private request", session, streamed)
+        state = paused.to_state()
+        state.approve(state.get_interruptions()[0])
+        backend.fail_after_commit = True
+        with pytest.raises(RuntimeError, match="append acknowledgement lost"):
+            await _run_encrypted_session(agent, state, session, streamed)
+        assert effects == ["recorded"]
+        assert len(model.calls) == 1
+        state = await RunState.from_json(agent, state.to_json())
+
+        result = await _run_encrypted_session(agent, state, session, streamed)
+
+        assert result.final_output == "private final answer"
+        assert effects == ["recorded"]
+        assert "pending_session_write" not in result.to_state().to_json()
+        assert _decrypt_stored_items(session, await backend.get_items()) == [
+            {"role": "user", "content": "private request"},
+            call.model_dump(exclude_unset=True),
+            {
+                "type": "function_call_output",
+                "call_id": "record-1",
+                "output": "private tool receipt",
+            },
+            output.model_dump(exclude_unset=True),
+        ]
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize(
+    "pause_before_append", [False, True], ids=["after-append", "before-append"]
+)
+async def test_encrypted_runner_skips_compaction_after_interleaved_outer_write(
+    pause_before_append: bool, encryption_key: str, tmp_path: Path
+) -> None:
+    paused = asyncio.Event()
+    release = asyncio.Event()
+
+    class PausingEncryptedSession(EncryptedSession):
+        """Suspend at the outer public append boundary while another Runner completes."""
+
+        async def add_items(
+            self,
+            items: list[TResponseInputItem],
+            *,
+            wrapper: RunContextWrapper[Any] | None = None,
+        ) -> None:
+            is_run_a_output = "answer-A" in json.dumps(items)
+            if is_run_a_output and pause_before_append:
+                paused.set()
+                await release.wait()
+            await super().add_items(items, wrapper=wrapper)
+            if is_run_a_output and not pause_before_append:
+                paused.set()
+                await release.wait()
+
+    backend = SQLiteSession("encrypted-concurrent", tmp_path / "history.db")
+    client = MagicMock()
+    client.responses.compact = AsyncMock(return_value=SimpleNamespace(output=[]))
+    session = PausingEncryptedSession(
+        backend.session_id,
+        OpenAIResponsesCompactionSession(
+            backend.session_id,
+            backend,
+            client=client,
+            should_trigger_compaction=lambda context: context["response_id"] == "resp-a",
+        ),
+        encryption_key,
+    )
+    output_a = get_text_message("answer-A")
+    output_b = get_text_message("answer-B")
+    agent_a = Agent(
+        name="A", model=ScriptedModel([ModelStep(output=[output_a], response_id="resp-a")])
+    )
+    agent_b = Agent(
+        name="B", model=ScriptedModel([ModelStep(output=[output_b], response_id="resp-b")])
+    )
+    run_a = asyncio.create_task(_run_encrypted_session(agent_a, "input-A", session, False))
+    try:
+        await asyncio.wait_for(paused.wait(), timeout=2)
+        result_b = await asyncio.wait_for(
+            _run_encrypted_session(agent_b, "input-B", session, False), timeout=2
+        )
+        assert result_b.final_output == "answer-B"
+        release.set()
+        result_a = await asyncio.wait_for(run_a, timeout=2)
+        assert result_a.final_output == "answer-A"
+        client.responses.compact.assert_not_awaited()
+        expected = [
+            {"role": "user", "content": "input-A"},
+            {"role": "user", "content": "input-B"},
+            output_b.model_dump(exclude_unset=True),
+        ]
+        expected.insert(3 if pause_before_append else 1, output_a.model_dump(exclude_unset=True))
+        assert _decrypt_stored_items(session, await backend.get_items()) == expected
+    finally:
+        release.set()
+        if not run_a.done():
+            run_a.cancel()
+        await asyncio.gather(run_a, return_exceptions=True)
+        backend.close()
 
 
 async def test_encrypted_session_pop_item(encryption_key: str, underlying_session: SQLiteSession):

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import warnings as warnings_module
+from collections.abc import Awaitable, Callable
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1722,13 +1723,13 @@ class TestCompactionMutationSerialization:
         class PausingCompactionSession(OpenAIResponsesCompactionSession):
             async def _add_items_with_generation(
                 self,
-                items: list[TResponseInputItem],
+                write_items: Callable[[], Awaitable[None]],
                 *,
                 expected_generation: int | None,
             ) -> int | None:
                 nonlocal add_calls
                 generation = await super()._add_items_with_generation(
-                    items,
+                    write_items,
                     expected_generation=expected_generation,
                 )
                 add_calls += 1
@@ -1863,13 +1864,13 @@ class TestCompactionMutationSerialization:
         class PausingCompactionSession(OpenAIResponsesCompactionSession):
             async def _add_items_with_generation(
                 self,
-                items: list[TResponseInputItem],
+                write_items: Callable[[], Awaitable[None]],
                 *,
                 expected_generation: int | None,
             ) -> int | None:
                 nonlocal add_calls
                 generation = await super()._add_items_with_generation(
-                    items,
+                    write_items,
                     expected_generation=expected_generation,
                 )
                 add_calls += 1


### PR DESCRIPTION
This pull request fixes an encryption regression introduced by #4736, which addressed the compaction race in #4679. When `EncryptedSession` wraps `OpenAIResponsesCompactionSession`, generation-aware Runner reads and writes could bypass the outer wrapper, causing plaintext storage and skipping decryption and TTL filtering.

The fix routes these operations through the outer Session's public history methods while preserving generation-based conflict detection and resumed-write recovery. Public APIs and stored formats are unchanged.