### PR TITLE
fix(chat-completions): drop unrepresentable tool output parts instead of failing the turn

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -75,6 +75,12 @@ ResponseInputContentWithAudioParam = (
 
 _OMITTED_TOOL_OUTPUT_PLACEHOLDER = "[tool output omitted]"
 
+# Content part types that never convert to a text part, so they are dropped from a tool
+# output before conversion when only the text is being kept.
+_NON_TEXT_TOOL_OUTPUT_CONTENT_TYPES = frozenset(
+    {"input_image", "image_url", "input_file", "input_audio", "video_url"}
+)
+
 
 class Converter:
     @classmethod
@@ -872,7 +878,20 @@ class Converter:
                 if preserve_tool_output_all_content:
                     tool_result_content = cls.extract_all_content(output_content)
                 else:
-                    all_output_content = cls.extract_all_content(output_content)
+                    keepable_output_content = output_content
+                    if not isinstance(output_content, str):
+                        # Parts that cannot become a text part are dropped here rather than
+                        # converted and then filtered out, so an unrepresentable one (an image
+                        # carrying file_id, say) omits itself instead of failing the turn.
+                        keepable_output_content = [
+                            c
+                            for c in output_content
+                            if not (
+                                isinstance(c, dict)
+                                and c.get("type") in _NON_TEXT_TOOL_OUTPUT_CONTENT_TYPES
+                            )
+                        ]
+                    all_output_content = cls.extract_all_content(keepable_output_content)
                     if isinstance(all_output_content, str):
                         tool_result_content = all_output_content
                     else:

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -880,10 +880,11 @@ class Converter:
                 else:
                     keepable_output_content = output_content
                     if not isinstance(output_content, str):
-                        # Parts that cannot become a text part are dropped here rather than
-                        # converted and then filtered out, so an unrepresentable one (an image
-                        # carrying file_id, say) omits itself instead of failing the turn.
-                        keepable_output_content = [
+                        # Text sitting alongside a part this API cannot express is still worth
+                        # sending, so those parts are dropped before conversion instead of being
+                        # converted and filtered out afterwards. Output carrying no text is left
+                        # alone, so it keeps whatever conversion already does with it.
+                        remaining_output_content = [
                             c
                             for c in output_content
                             if not (
@@ -891,6 +892,8 @@ class Converter:
                                 and c.get("type") in _NON_TEXT_TOOL_OUTPUT_CONTENT_TYPES
                             )
                         ]
+                        if remaining_output_content:
+                            keepable_output_content = remaining_output_content
                     all_output_content = cls.extract_all_content(keepable_output_content)
                     if isinstance(all_output_content, str):
                         tool_result_content = all_output_content

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -683,6 +683,59 @@ def test_items_to_messages_with_mixed_function_output_keeps_text_by_default(
     assert "tool output omitted" not in caplog.text
 
 
+def test_items_to_messages_with_file_id_image_function_output_uses_placeholder_by_default(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A file-id image is not representable here, so it should be omitted like a URL image."""
+    func_output_item: FunctionCallOutput = {
+        "type": "function_call_output",
+        "call_id": "somecall",
+        "output": [
+            {
+                "type": "input_image",
+                "file_id": "file-abc123",
+            }
+        ],
+    }
+
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        messages = Converter.items_to_messages([func_output_item])
+
+    assert len(messages) == 1
+    tool_msg = messages[0]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == func_output_item["call_id"]
+    assert tool_msg["content"] == "[tool output omitted]"
+    assert "Replacing the tool output with a placeholder" in caplog.text
+
+
+def test_items_to_messages_with_mixed_file_id_image_function_output_keeps_text_by_default(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Text alongside a file-id image should survive, as it does alongside a URL image."""
+    func_output_item: FunctionCallOutput = {
+        "type": "function_call_output",
+        "call_id": "somecall",
+        "output": [
+            {"type": "input_text", "text": "visible text"},
+            {
+                "type": "input_image",
+                "file_id": "file-abc123",
+            },
+        ],
+    }
+
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        messages = Converter.items_to_messages([func_output_item])
+
+    assert len(messages) == 1
+    tool_msg = messages[0]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == func_output_item["call_id"]
+    assert tool_msg["content"] == [{"type": "text", "text": "visible text"}]
+    assert "tool output omitted" not in caplog.text
+
+
 def test_items_to_messages_can_preserve_non_text_function_output() -> None:
     """Compatible providers can opt in to preserving non-text tool output."""
     func_output_item: FunctionCallOutput = {

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -683,10 +683,12 @@ def test_items_to_messages_with_mixed_function_output_keeps_text_by_default(
     assert "tool output omitted" not in caplog.text
 
 
-def test_items_to_messages_with_file_id_image_function_output_uses_placeholder_by_default(
-    caplog: pytest.LogCaptureFixture,
-):
-    """A file-id image is not representable here, so it should be omitted like a URL image."""
+def test_items_to_messages_with_file_id_image_only_function_output_still_raises():
+    """Output carrying no text has nothing to preserve, so it keeps raising as before.
+
+    A file id is an uploaded-file reference, so the error points the caller at a model
+    that can actually read it rather than quietly degrading the run to a placeholder.
+    """
     func_output_item: FunctionCallOutput = {
         "type": "function_call_output",
         "call_id": "somecall",
@@ -698,15 +700,8 @@ def test_items_to_messages_with_file_id_image_function_output_uses_placeholder_b
         ],
     }
 
-    with caplog.at_level(logging.WARNING, logger="openai.agents"):
-        messages = Converter.items_to_messages([func_output_item])
-
-    assert len(messages) == 1
-    tool_msg = messages[0]
-    assert tool_msg["role"] == "tool"
-    assert tool_msg["tool_call_id"] == func_output_item["call_id"]
-    assert tool_msg["content"] == "[tool output omitted]"
-    assert "Replacing the tool output with a placeholder" in caplog.text
+    with pytest.raises(UserError, match="Only image URLs are supported for input_image"):
+        Converter.items_to_messages([func_output_item])
 
 
 def test_items_to_messages_with_mixed_file_id_image_function_output_keeps_text_by_default(


### PR DESCRIPTION
### Summary

A function tool that returns `ToolOutputImage(file_id=...)` kills the run on the Chat Completions path, in the branch whose job is to discard non-text tool output.

With `preserve_tool_output_all_content` false (the default), `items_to_messages` converts the whole tool output through `extract_all_content` first and only then filters down to text parts. An `input_image` carrying `file_id` instead of `image_url` has no Chat Completions representation, so it raises at `chatcmpl_converter.py:450` on its way to being thrown away. In the mixed case the accompanying text is destroyed with it, and the turn after the tool executed fails.

That is the opposite of what this branch is documented to do. #3312 built it specifically to convert non-text-only output "to a non-empty placeholder string instead of raising", gated the `UserError` behind `strict_feature_validation=True`, and kept "mixed text/non-text outputs preserving only the text parts by default". A URL image already takes that path; only `file_id` fails, and `ToolOutputImage` accepts `file_id` alone by its own validator.

The fix drops the part types that can never become a text part before conversion, rather than converting them and filtering them out afterwards.

### Test plan

- Two cases added to `tests/models/test_openai_chatcompletions_converter.py`, mirroring the existing `..._non_text_only_...` and `..._mixed_function_output_...` tests with `file_id` in place of `image_url`. Both fail on `main` with `UserError: Only image URLs are supported for input_image {'type': 'input_image', 'file_id': 'file-abc123'}`.
- `tests/models/test_openai_chatcompletions_converter.py`: 58 passed, including the existing strict-mode and placeholder cases.
- Full suite before: 20 failed, 7837 passed, 31 errors. After: 20 failed, 7839 passed, 31 errors. Same failure and error sets; the remaining ones are environmental on this machine.
- `ruff check`, `ruff format --check` and `mypy` clean on both files.

One behaviour change worth naming rather than leaving to be found: a malformed non-text part that previously raised while being discarded now gets discarded quietly, since it is dropped before conversion. Unknown part types still reach `extract_all_content` and still raise `Unknown content`. If you would rather keep the strict read there, I am happy to narrow this to `input_image` alone.

`litellm_model.py` and `any_llm_model.py` both pass `preserve_tool_output_all_content=True`, so they take the other branch and are unaffected.