### PR TITLE
fix(sandbox): prevent UnixLocal file API symlink races

### DIFF
--- a/src/agents/sandbox/sandboxes/_unix_local_file_ops.py
+++ b/src/agents/sandbox/sandboxes/_unix_local_file_ops.py
@@ -1,0 +1,177 @@
+"""Standard-library file operations for trusted UnixLocal callers and its user worker."""
+
+from __future__ import annotations
+
+import sys
+
+if sys.platform == "win32":  # pragma: no cover
+    raise ImportError("UnixLocal file operations are not supported on Windows.")
+
+import grp
+import io
+import json
+import os
+import pwd
+import shutil
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import cast
+
+_DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+_TRAVERSE_FLAGS = (
+    getattr(os, "O_SEARCH", getattr(os, "O_PATH", os.O_RDONLY)) | os.O_DIRECTORY | os.O_NOFOLLOW
+)
+
+
+class _FileOps:
+    """Operate on canonical absolute paths already authorized by the owning session."""
+
+    @contextmanager
+    def parent(
+        self, path: Path, *, for_write: bool = False, create_parents: bool = False
+    ) -> Iterator[tuple[int, str]]:
+        fd = os.open("/", _TRAVERSE_FLAGS)
+        try:
+            for part in path.parts[1:-1]:
+                try:
+                    child_fd = os.open(part, _TRAVERSE_FLAGS, dir_fd=fd)
+                except FileNotFoundError:
+                    if not create_parents:
+                        raise
+                    try:
+                        os.mkdir(part, dir_fd=fd)
+                    except FileExistsError:
+                        pass
+                    child_fd = os.open(part, _TRAVERSE_FLAGS, dir_fd=fd)
+                os.close(fd)
+                fd = child_fd
+            yield fd, path.name or "."
+        finally:
+            os.close(fd)
+
+    def read(self, path: Path) -> io.IOBase:
+        with self.parent(path) as (parent_fd, name):
+            fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=parent_fd)
+        try:
+            return os.fdopen(fd, "rb")
+        except BaseException:
+            os.close(fd)
+            raise
+
+    def write(self, path: Path, stream: io.IOBase) -> None:
+        with self.parent(path, for_write=True, create_parents=True) as (parent_fd, name):
+            fd = os.open(
+                name,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                0o666,
+                dir_fd=parent_fd,
+            )
+        try:
+            out = os.fdopen(fd, "wb")
+        except BaseException:
+            os.close(fd)
+            raise
+        with out:
+            shutil.copyfileobj(stream, out)
+
+    def mkdir(self, path: Path, *, parents: bool) -> None:
+        with self.parent(path, for_write=True, create_parents=parents) as (parent_fd, name):
+            try:
+                os.mkdir(name, dir_fd=parent_fd)
+            except FileExistsError:
+                # exist_ok only applies to a directory, never to a replacement symlink.
+                if not stat.S_ISDIR(os.stat(name, dir_fd=parent_fd, follow_symlinks=False).st_mode):
+                    raise
+
+    @contextmanager
+    def directory(self, path: Path) -> Iterator[int]:
+        with self.parent(path) as (parent_fd, name):
+            fd = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
+        try:
+            yield fd
+        finally:
+            os.close(fd)
+
+    def rm(self, path: Path, *, recursive: bool) -> None:
+        with self.parent(path, for_write=True) as (parent_fd, name):
+            _remove_at(parent_fd, name, recursive=recursive)
+
+    def listing(self, path: Path) -> list[dict[str, str | int]]:
+        with self.parent(path) as (parent_fd, name):
+            entry = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            if not stat.S_ISDIR(entry.st_mode):
+                return [_entry(path, entry)]
+            fd = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
+        try:
+            with os.scandir(fd) as entries:
+                return [
+                    _entry(path / entry.name, entry.stat(follow_symlinks=False))
+                    for entry in entries
+                ]
+        finally:
+            os.close(fd)
+
+
+def _entry(path: Path, entry: os.stat_result) -> dict[str, str | int]:
+    try:
+        owner = pwd.getpwuid(entry.st_uid).pw_name
+    except KeyError:
+        owner = str(entry.st_uid)
+    try:
+        group = grp.getgrgid(entry.st_gid).gr_name
+    except KeyError:
+        group = str(entry.st_gid)
+    if stat.S_ISDIR(entry.st_mode):
+        kind = "directory"
+    elif stat.S_ISREG(entry.st_mode):
+        kind = "file"
+    elif stat.S_ISLNK(entry.st_mode):
+        kind = "symlink"
+    else:
+        kind = "other"
+    return {
+        "path": str(path),
+        "mode": entry.st_mode,
+        "owner": owner,
+        "group": group,
+        "size": entry.st_size,
+        "kind": kind,
+    }
+
+
+def _remove_at(parent_fd: int, name: str, *, recursive: bool) -> None:
+    entry = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    if not stat.S_ISDIR(entry.st_mode):
+        os.unlink(name, dir_fd=parent_fd)
+        return
+    if recursive:
+        fd = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
+        try:
+            with os.scandir(fd) as entries:
+                for child in entries:
+                    try:
+                        _remove_at(fd, child.name, recursive=True)
+                    except FileNotFoundError:
+                        pass
+        finally:
+            os.close(fd)
+    os.rmdir(name, dir_fd=parent_fd)
+
+
+def _main() -> None:
+    # The application supplies this code and an authorized path directly, never via the workspace.
+    operation, raw_path = sys.argv[1:]
+    files = _FileOps()
+    path = Path(raw_path)
+    if operation == "write":
+        files.write(path, cast(io.IOBase, sys.stdin.buffer))
+    elif operation == "ls":
+        print(json.dumps(files.listing(path), ensure_ascii=True))
+    else:
+        raise ValueError("Unsupported UnixLocal file operation")
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/agents/sandbox/sandboxes/_unix_local_files.py
+++ b/src/agents/sandbox/sandboxes/_unix_local_files.py
@@ -1,0 +1,50 @@
+"""Descriptor-relative host I/O for the UnixLocal workspace boundary."""
+
+from __future__ import annotations
+
+import sys
+
+if sys.platform == "win32":  # pragma: no cover
+    raise ImportError("UnixLocal file operations are not supported on Windows.")
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from ..manifest import Manifest
+from ..workspace_paths import WorkspacePathPolicy
+from ._unix_local_file_ops import _FileOps
+
+
+class _UnixLocalFiles(_FileOps):
+    def __init__(self, manifest: Manifest) -> None:
+        self._roots: dict[str, Path] = {}
+        self.configure(manifest)
+
+    def configure(self, manifest: Manifest) -> None:
+        # Trusted configuration can change grants, but unchanged aliases must stay pinned even
+        # when an occupant replaces their filesystem entries between operations.
+        paths = (manifest.root, *(grant.path for grant in manifest.extra_path_grants))
+        self._roots = {
+            path: self._roots[path] if path in self._roots else Path(path).resolve()
+            for path in paths
+        }
+        self._policy = WorkspacePathPolicy(
+            root=self._roots[manifest.root],
+            extra_path_grants=tuple(
+                grant.model_copy(update={"path": str(self._roots[grant.path])})
+                for grant in manifest.extra_path_grants
+            ),
+        )
+
+    def authorize(self, path: Path, *, for_write: bool = False) -> Path:
+        # Reauthorize resolved paths against captured roots without following new symlinks.
+        return self._policy.normalize_path(path, for_write=for_write)
+
+    @contextmanager
+    def parent(
+        self, path: Path, *, for_write: bool = False, create_parents: bool = False
+    ) -> Iterator[tuple[int, str]]:
+        path = self.authorize(path, for_write=for_write)
+        with super().parent(path, for_write=for_write, create_parents=create_parents) as parent:
+            yield parent

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -9,12 +9,15 @@ if sys.platform == "win32":  # pragma: no cover
 import asyncio
 import errno
 import fcntl
+import inspect
 import io
+import json
 import logging
 import os
 import shlex
 import shutil
 import signal
+import subprocess
 import tarfile
 import tempfile
 import termios
@@ -69,7 +72,11 @@ from ..util.tar_utils import (
     should_skip_tar_member,
 )
 from ..workspace_paths import _raise_if_filesystem_root
+from . import _unix_local_file_ops
+from ._unix_local_files import _UnixLocalFiles
 
+# Capture installed SDK code at import, before a session can run workspace processes.
+_USER_FILE_WORKER_SOURCE = inspect.getsource(_unix_local_file_ops)
 _DEFAULT_WORKSPACE_PREFIX = "sandbox-local-"
 _DEFAULT_MANIFEST_ROOT = cast(str, Manifest.model_fields["root"].default)
 _PTY_READ_CHUNK_BYTES = 16_384
@@ -156,6 +163,10 @@ class UnixLocalSandboxSession(BaseSandboxSession):
     """
     Unix-only session implementation that runs commands on the host and uses the host filesystem
     as the workspace (rooted at `self.state.manifest.root`).
+
+    User-scoped listing and writing require sudo access to a system python3 and its standard
+    library. These operations run a trusted file worker in Python isolated mode, independently
+    of the application's interpreter or virtual environment.
     """
 
     state: UnixLocalSandboxSessionState
@@ -174,6 +185,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         self._reserved_pty_process_ids = set()
         self._fd_close_tasks = set()
         self._host_environment_allowlist = None
+        self._files = _UnixLocalFiles(state.manifest)
 
     @classmethod
     def from_state(cls, state: UnixLocalSandboxSessionState) -> "UnixLocalSandboxSession":
@@ -891,6 +903,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         return "/", rewritten
 
     def normalize_path(self, path: Path | str, *, for_write: bool = False) -> Path:
+        self._files.configure(self.state.manifest)
         policy = self._workspace_path_policy()
         return policy.normalize_path(path, for_write=for_write, resolve_symlinks=True)
 
@@ -900,13 +913,44 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         *,
         user: str | User | None = None,
     ) -> list[FileEntry]:
-        if user is not None:
-            return await super().ls(path, user=user)
-
         normalized = self.normalize_path(path)
+        if user is not None:
+            command = ("ls", "-la", "--", str(normalized))
+            try:
+                result = await self._run_file_operation_as_user("ls", normalized, user=user)
+            except OSError as e:
+                raise ExecNonZeroError(
+                    ExecResult(stdout=b"", stderr=str(e).encode("utf-8"), exit_code=1),
+                    command=command,
+                    cause=e,
+                ) from e
+            if result.returncode:
+                raise ExecNonZeroError(
+                    ExecResult(
+                        stdout=result.stdout, stderr=result.stderr, exit_code=result.returncode
+                    ),
+                    command=command,
+                )
+            return [
+                FileEntry(
+                    path=entry["path"],
+                    permissions=Permissions.from_mode(entry["mode"]).model_copy(
+                        update={"directory": entry["kind"] == "directory"}
+                    ),
+                    owner=entry["owner"],
+                    group=entry["group"],
+                    size=entry["size"],
+                    kind=EntryKind(entry["kind"]),
+                )
+                for entry in json.loads(result.stdout)
+            ]
+
         command = ("ls", "-la", "--", str(normalized))
         try:
-            with os.scandir(normalized) as entries:
+            with (
+                self._files.directory(normalized) as directory_fd,
+                os.scandir(directory_fd) as entries,
+            ):
                 listed: list[FileEntry] = []
                 for entry in entries:
                     stat_result = entry.stat(follow_symlinks=False)
@@ -920,7 +964,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
                         kind = EntryKind.OTHER
                     listed.append(
                         FileEntry(
-                            path=entry.path,
+                            path=str(normalized / entry.name),
                             permissions=Permissions.from_mode(stat_result.st_mode),
                             owner=str(stat_result.st_uid),
                             group=str(stat_result.st_gid),
@@ -948,7 +992,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         else:
             normalized = self.normalize_path(path, for_write=True)
         try:
-            normalized.mkdir(parents=parents, exist_ok=True)
+            self._files.mkdir(normalized, parents=parents)
         except OSError as e:
             raise WorkspaceArchiveWriteError(path=normalized, cause=e) from e
 
@@ -964,13 +1008,10 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         else:
             normalized = self.normalize_path(path, for_write=True)
         try:
-            if normalized.is_dir() and not normalized.is_symlink():
-                if recursive:
-                    await run_blocking_workspace_io(shutil.rmtree, normalized)
-                else:
-                    normalized.rmdir()
+            if recursive:
+                await run_blocking_workspace_io(partial(self._files.rm, normalized, recursive=True))
             else:
-                normalized.unlink()
+                self._files.rm(normalized, recursive=False)
         except FileNotFoundError as e:
             if recursive:
                 return
@@ -988,7 +1029,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
 
         workspace_path = self.normalize_path(path)
         try:
-            return workspace_path.open("rb")
+            return self._files.read(workspace_path)
         except FileNotFoundError as e:
             raise WorkspaceReadNotFoundError(path=path, cause=e) from e
         except OSError as e:
@@ -1009,9 +1050,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
             return
 
         try:
-            workspace_path.parent.mkdir(parents=True, exist_ok=True)
-            with workspace_path.open("wb") as f:
-                shutil.copyfileobj(payload.stream, f)
+            self._files.write(workspace_path, payload.stream)
         except OSError as e:
             raise WorkspaceArchiveWriteError(path=workspace_path, cause=e) from e
 
@@ -1022,58 +1061,67 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         *,
         user: str | User,
     ) -> None:
-        env, cwd = await self._resolved_exec_context()
-        workspace_root = Path(cwd).resolve()
-        command_parts = self._prepare_exec_command(
-            "sh",
-            "-c",
-            'mkdir -p "$(dirname "$1")" && cat > "$1"',
-            "sh",
-            str(path),
-            shell=False,
-            user=user,
-        )
-        command_parts = self._workspace_relative_command_parts(command_parts, workspace_root)
-        process_cwd, command_parts = self._shell_workspace_process_context(
-            command_parts=command_parts,
-            workspace_root=workspace_root,
-            cwd=cwd,
-        )
-        exec_command = self._confined_exec_command(
-            command_parts=command_parts,
-            workspace_root=workspace_root,
-            env=env,
-        )
-
         payload = stream.read()
         if isinstance(payload, str):
             payload = payload.encode("utf-8")
         elif not isinstance(payload, bytes):
             payload = bytes(payload)
-
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *exec_command,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=process_cwd,
-                env=env,
-                start_new_session=True,
+            result = await self._run_file_operation_as_user(
+                "write", path, user=user, payload=payload
             )
-            stdout, stderr = await proc.communicate(payload)
         except OSError as e:
             raise WorkspaceArchiveWriteError(path=path, cause=e) from e
-
-        if proc.returncode:
+        if result.returncode:
             raise WorkspaceArchiveWriteError(
                 path=path,
                 context={
-                    "command": command_parts,
-                    "stdout": stdout.decode("utf-8", errors="replace"),
-                    "stderr": stderr.decode("utf-8", errors="replace"),
+                    "stderr": result.stderr.decode("utf-8", errors="replace"),
+                    "operation": "write",
                 },
             )
+
+    async def _run_file_operation_as_user(
+        self,
+        operation: Literal["ls", "write"],
+        path: Path,
+        *,
+        user: str | User,
+        payload: bytes = b"",
+    ) -> subprocess.CompletedProcess[bytes]:
+        # Authorization is synchronous and captured for this operation before dispatch.
+        path = self._files.authorize(path, for_write=operation == "write")
+        command = self._prepare_exec_command(
+            "python3",
+            "-I",
+            "-S",
+            "-c",
+            _USER_FILE_WORKER_SOURCE,
+            operation,
+            str(path),
+            shell=False,
+            user=user,
+        )
+        # Resolve sudo from trusted host configuration, never the workspace's command environment.
+        executable = shutil.which(command[0])
+        if executable is None:
+            raise FileNotFoundError(f"UnixLocal user dispatcher is unavailable: {command[0]}")
+        command[0] = executable
+
+        # This trusted worker enforces the file boundary itself, like direct host file I/O.
+        # It does not execute workspace commands or load workspace Python modules.
+        def run_worker() -> subprocess.CompletedProcess[bytes]:
+            return subprocess.run(
+                command,
+                input=payload,
+                capture_output=True,
+                cwd="/",
+                env={"PATH": os.defpath},
+                start_new_session=True,
+                check=False,
+            )
+
+        return await run_blocking_workspace_io(run_worker)
 
     async def running(self) -> bool:
         return self._running

--- a/tests/sandbox/test_unix_local_file_io.py
+++ b/tests/sandbox/test_unix_local_file_io.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from agents.editor import ApplyPatchOperation
+from agents.run_config import SandboxRunConfig
+from agents.sandbox.apply_patch import WorkspaceEditor
+from agents.sandbox.capabilities import Capability
+from agents.sandbox.errors import (
+    ExecNonZeroError,
+    InvalidManifestPathError,
+    WorkspaceArchiveReadError,
+    WorkspaceArchiveWriteError,
+)
+from agents.sandbox.manifest import Manifest, SandboxPathGrant
+from agents.sandbox.runtime_session_manager import SandboxRuntimeSessionManager
+from agents.sandbox.sandbox_agent import SandboxAgent
+from agents.sandbox.snapshot import NoopSnapshot
+
+if TYPE_CHECKING or sys.platform != "win32":
+    from agents.sandbox.sandboxes.unix_local import (
+        UnixLocalSandboxSession,
+        UnixLocalSandboxSessionState,
+    )
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.skipif(sys.platform == "win32", reason="Unix only")]
+
+
+def _session(root: Path, *, grants: tuple[SandboxPathGrant, ...] = ()) -> UnixLocalSandboxSession:
+    return UnixLocalSandboxSession(
+        state=UnixLocalSandboxSessionState(
+            manifest=Manifest(root=str(root), extra_path_grants=grants),
+            snapshot=NoopSnapshot(id="file-io"),
+        )
+    )
+
+
+async def _operate(session: UnixLocalSandboxSession, operation: str, path: Path) -> object:
+    if operation == "read":
+        with await session.read(path) as stream:
+            return stream.read()
+    if operation == "write":
+        await session.write(path, io.BytesIO(b"new"))
+    elif operation == "mkdir":
+        await session.mkdir(path, parents=True)
+    elif operation == "ls":
+        return await session.ls(path)
+    elif operation == "patch":
+        return await WorkspaceEditor(session).apply_operation(
+            ApplyPatchOperation(type="create_file", path=str(path), diff="+new\n")
+        )
+    elif operation in {"rm", "rmtree"}:
+        await session.rm(path, recursive=operation == "rmtree")
+    return None
+
+
+@pytest.mark.parametrize("operation", ["read", "write", "mkdir", "ls", "rm", "rmtree", "patch"])
+async def test_parent_swap_after_validation_cannot_access_outside(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    parent = workspace / "parent"
+    parent.mkdir(parents=True)
+    outside.mkdir()
+    directory = operation in {"mkdir", "ls", "rmtree"}
+    for root in (parent, outside):
+        if directory:
+            (root / "target").mkdir()
+            (root / "target" / "sentinel").write_bytes(b"original content")
+        else:
+            (root / "target").write_bytes(b"original content")
+    session = _session(workspace)
+    normalize = session.normalize_path
+    swapped = False
+
+    def swap(path: Path | str, *, for_write: bool = False) -> Path:
+        nonlocal swapped
+        result = normalize(path, for_write=for_write)
+        if not swapped and (operation != "patch" or (for_write and result.name == "target")):
+            swapped = True
+            parent.rename(workspace / "original")
+            parent.symlink_to(outside, target_is_directory=True)
+        return result
+
+    # Suspend at the check/use boundary without replacing the actual OS file operations.
+    monkeypatch.setattr(session, "normalize_path", swap)
+    with pytest.raises(
+        (
+            OSError,
+            ExecNonZeroError,
+            WorkspaceArchiveReadError,
+            WorkspaceArchiveWriteError,
+            InvalidManifestPathError,
+        )
+    ):
+        await _operate(session, operation, Path("parent/target"))
+    assert swapped
+    sentinel = outside / "target" / "sentinel" if directory else outside / "target"
+    assert sentinel.read_bytes() == b"original content"
+
+
+@pytest.mark.parametrize("operation", ["read", "write", "mkdir", "ls", "rm", "rmtree"])
+async def test_leaf_swap_does_not_follow_new_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    target = workspace / "target"
+    directory = operation in {"mkdir", "ls", "rmtree"}
+    for path in (target, outside):
+        if directory:
+            path.mkdir()
+            (path / "sentinel").write_bytes(b"original content")
+        else:
+            path.write_bytes(b"original content")
+    session = _session(workspace)
+    normalize = session.normalize_path
+
+    def swap(path: Path | str, *, for_write: bool = False) -> Path:
+        result = normalize(path, for_write=for_write)
+        target.rename(workspace / "original")
+        target.symlink_to(outside, target_is_directory=directory)
+        return result
+
+    monkeypatch.setattr(session, "normalize_path", swap)
+    if operation in {"rm", "rmtree"}:
+        await _operate(session, operation, Path("target"))
+    else:
+        with pytest.raises(
+            (OSError, ExecNonZeroError, WorkspaceArchiveReadError, WorkspaceArchiveWriteError)
+        ):
+            await _operate(session, operation, Path("target"))
+    sentinel = outside / "sentinel" if directory else outside
+    assert sentinel.read_bytes() == b"original content"
+
+
+async def test_safe_symlinks_grants_and_listing_paths_remain_supported(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    (readonly / "file").write_bytes(b"read only")
+    alias = tmp_path / "alias"
+    alias.symlink_to(workspace, target_is_directory=True)
+    session = _session(
+        alias,
+        grants=(
+            SandboxPathGrant(path=str(allowed)),
+            SandboxPathGrant(path=str(readonly), read_only=True),
+        ),
+    )
+    (workspace / "internal").symlink_to(workspace / "real", target_is_directory=True)
+    (workspace / "external").symlink_to(allowed, target_is_directory=True)
+    stream = io.BytesIO(b"bytes\x00\xff")
+    await session.write(Path("internal/nested/file"), stream)
+    assert not stream.closed
+    assert (workspace / "real/nested/file").read_bytes() == b"bytes\x00\xff"
+    await session.write(Path("external/file"), io.BytesIO(b"allowed"))
+    with await session.read(Path("external/file")) as handle:
+        assert handle.read() == b"allowed"
+    with await session.read(readonly / "file") as handle:
+        assert handle.read() == b"read only"
+    with pytest.raises(WorkspaceArchiveWriteError):
+        await session.write(readonly / "file", io.BytesIO(b"denied"))
+    listed = await session.ls(Path("internal/nested"))
+    assert [entry.path for entry in listed] == [str(workspace / "real/nested/file")]
+    await session.rm(Path("internal"), recursive=True)
+    assert not (workspace / "real").exists()
+    assert (allowed / "file").read_bytes() == b"allowed"
+
+
+async def test_root_replacement_cannot_reauthorize_an_outside_directory(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "file").write_bytes(b"original content")
+    session = _session(root)
+    root.rename(tmp_path / "original")
+    root.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(InvalidManifestPathError):
+        await session.write(Path("file"), io.BytesIO(b"new"))
+    assert (outside / "file").read_bytes() == b"original content"
+
+
+async def test_open_read_handle_survives_parent_replacement(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "file").write_bytes(b"inside")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "file").write_bytes(b"original content")
+    session = _session(root)
+    with await session.read(Path("file")) as handle:
+        root.rename(tmp_path / "original")
+        root.symlink_to(outside, target_is_directory=True)
+        assert handle.read() == b"inside"
+
+
+async def test_copy_failure_closes_output_without_closing_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session = _session(tmp_path)
+    opened: list[int] = []
+    real_open = os.open
+
+    def record_open(
+        path: str | os.PathLike[str], flags: int, mode: int = 0o777, *, dir_fd: int | None = None
+    ) -> int:
+        fd = real_open(path, flags, mode, dir_fd=dir_fd)
+        opened.append(fd)
+        return fd
+
+    class BrokenInput(io.BytesIO):
+        def read(self, size: int | None = -1) -> bytes:
+            raise RuntimeError("broken input")
+
+    monkeypatch.setattr(os, "open", record_open)
+    data = BrokenInput(b"data")
+    with pytest.raises(RuntimeError, match="broken input"):
+        await session.write(Path("file"), data)
+    assert not data.closed
+    for fd in set(opened):
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+async def test_open_parent_stays_pinned_when_its_name_is_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    workspace = tmp_path / "workspace"
+    parent = workspace / "parent"
+    parent.mkdir(parents=True)
+    (parent / "file").write_bytes(b"inside")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "file").write_bytes(b"original content")
+    session = _session(workspace)
+    real_open = os.open
+    swapped = False
+
+    def swap_after_open(
+        path: str | os.PathLike[str], flags: int, mode: int = 0o777, *, dir_fd: int | None = None
+    ) -> int:
+        nonlocal swapped
+        fd = real_open(path, flags, mode, dir_fd=dir_fd)
+        if path == "parent" and dir_fd is not None:
+            parent.rename(workspace / "original")
+            parent.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return fd
+
+    monkeypatch.setattr(os, "open", swap_after_open)
+    result = await _operate(session, operation, Path("parent/file"))
+    assert swapped
+    assert (outside / "file").read_bytes() == b"original content"
+    if operation == "read":
+        assert result == b"inside"
+    else:
+        assert (workspace / "original/file").read_bytes() == b"new"
+
+
+async def test_search_only_parent_does_not_require_directory_listing_permission(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    (parent / "file").write_bytes(b"inside")
+    session = _session(tmp_path)
+    parent.chmod(0o111)
+    try:
+        with await session.read(Path("parent/file")) as handle:
+            assert handle.read() == b"inside"
+        await session.write(Path("parent/file"), io.BytesIO(b"new"))
+        await session.mkdir(Path("parent"))
+    finally:
+        parent.chmod(0o700)
+    assert (parent / "file").read_bytes() == b"new"
+
+
+async def test_replacing_grant_alias_does_not_expand_authority(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    granted = tmp_path / "granted"
+    granted.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "file").write_bytes(b"original content")
+    alias = tmp_path / "alias"
+    alias.symlink_to(granted, target_is_directory=True)
+    session = _session(workspace, grants=(SandboxPathGrant(path=str(alias)),))
+    alias.unlink()
+    alias.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(InvalidManifestPathError):
+        await session.write(alias / "file", io.BytesIO(b"new"))
+    assert (outside / "file").read_bytes() == b"original content"
+
+
+async def test_mkdir_existing_directory_does_not_require_search_permission(tmp_path: Path) -> None:
+    target = tmp_path / "locked"
+    target.mkdir()
+    session = _session(tmp_path)
+    target.chmod(0)
+    try:
+        await session.mkdir(Path("locked"))
+    finally:
+        target.chmod(0o700)
+    assert target.is_dir()
+
+
+async def test_injected_session_uses_current_grants_without_rebinding_aliases(
+    tmp_path: Path,
+) -> None:
+    class ConfigureGrants(Capability):
+        type: str = "configure_grants"
+        grants: tuple[SandboxPathGrant, ...]
+
+        def process_manifest(self, manifest: Manifest) -> Manifest:
+            return manifest.model_copy(update={"extra_path_grants": self.grants})
+
+    workspace = tmp_path / "workspace"
+    granted = tmp_path / "granted"
+    added = tmp_path / "added"
+    outside = tmp_path / "outside"
+    for directory in (workspace, granted, added, outside):
+        directory.mkdir()
+    (outside / "file").write_bytes(b"original content")
+    alias = tmp_path / "alias"
+    alias.symlink_to(granted, target_is_directory=True)
+    session = _session(workspace, grants=(SandboxPathGrant(path=str(alias), read_only=True),))
+    agent = SandboxAgent(name="File grant lifecycle")
+    manager = SandboxRuntimeSessionManager(
+        starting_agent=agent, sandbox_config=SandboxRunConfig(session=session), run_state=None
+    )
+
+    async def configure(*grants: SandboxPathGrant) -> None:
+        # Exercise the owner of capability updates without starting native process confinement.
+        resources = await manager._create_resources(
+            agent=agent, capabilities=[ConfigureGrants(grants=grants)], is_resumed_state=False
+        )
+        assert resources.session is session
+
+    await configure(SandboxPathGrant(path=str(alias)), SandboxPathGrant(path=str(added)))
+    await session.write(alias / "file", io.BytesIO(b"upgraded"))
+    await session.mkdir(added / "directory")
+    await session.write(added / "directory/file", io.BytesIO(b"added"))
+    with await session.read(added / "directory/file") as stream:
+        assert stream.read() == b"added"
+    assert (granted / "file").read_bytes() == b"upgraded"
+    await session.rm(added / "directory", recursive=True)
+
+    alias.unlink()
+    alias.symlink_to(outside, target_is_directory=True)
+    await configure(
+        SandboxPathGrant(path=str(alias)), SandboxPathGrant(path=str(added), read_only=True)
+    )
+    with pytest.raises(InvalidManifestPathError):
+        await session.write(alias / "file", io.BytesIO(b"new"))
+    with pytest.raises(WorkspaceArchiveWriteError):
+        await session.write(added / "file", io.BytesIO(b"new"))
+    assert (outside / "file").read_bytes() == b"original content"
+
+    await configure()
+    with pytest.raises(InvalidManifestPathError):
+        await session.ls(added)
+
+
+async def test_recursive_removal_keeps_worker_owned_until_cancelled_io_finishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "workspace"
+    child = root / "child"
+    child.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "sentinel").write_bytes(b"original content")
+    (child / "external").symlink_to(outside, target_is_directory=True)
+    session = _session(root)
+    started = threading.Event()
+    release = threading.Event()
+    real_scandir = os.scandir
+    opened: list[int] = []
+
+    def paused_scandir(path: int):
+        opened.append(path)
+        started.set()
+        if not release.wait(timeout=5):
+            raise RuntimeError("worker was not released")
+        return real_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", paused_scandir)
+    task = asyncio.create_task(session.rm(Path("child"), recursive=True))
+    try:
+        assert await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+    finally:
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert not child.exists()
+    assert (outside / "sentinel").read_bytes() == b"original content"
+    for fd in opened:
+        with pytest.raises(OSError):
+            os.fstat(fd)

--- a/tests/sandbox/test_unix_local_user_file_io.py
+++ b/tests/sandbox/test_unix_local_user_file_io.py
@@ -1,0 +1,332 @@
+"""Exercise user file operations with in-memory OS and subprocess boundaries."""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import io
+import os
+import stat
+import subprocess
+import sys
+import threading
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+from unittest.mock import Mock
+
+import pytest
+
+from agents.sandbox.errors import (
+    ExecNonZeroError,
+    InvalidManifestPathError,
+    WorkspaceArchiveWriteError,
+)
+from agents.sandbox.manifest import Manifest, SandboxPathGrant
+from agents.sandbox.snapshot import NoopSnapshot
+from agents.sandbox.types import User
+
+if TYPE_CHECKING or sys.platform != "win32":
+    from agents.sandbox.sandboxes import _unix_local_file_ops as ops, unix_local
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Unix only")
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> unix_local.UnixLocalSandboxSession:
+    # Paths are synthetic; permission and lookup outcomes are supplied at the OS boundary.
+    monkeypatch.setattr(Path, "resolve", lambda self, **kwargs: self)
+    for name in ("open", "close", "mkdir", "unlink", "rmdir", "scandir", "fdopen"):
+        monkeypatch.setattr(
+            os, name, Mock(side_effect=AssertionError(f"Unexpected OS call: {name}"))
+        )
+    monkeypatch.setattr(
+        subprocess, "run", Mock(side_effect=AssertionError("Unexpected subprocess"))
+    )
+    monkeypatch.setattr(unix_local.shutil, "which", lambda command: "/usr/bin/sudo")
+    return unix_local.UnixLocalSandboxSession(
+        state=unix_local.UnixLocalSandboxSessionState(
+            manifest=Manifest(root="/workspace"), snapshot=NoopSnapshot(id="mock-user-files")
+        )
+    )
+
+
+def _worker(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+    """Execute the shipped worker code with mocked OS calls, never start a process."""
+    assert command[:4] == ["/usr/bin/sudo", "-u", "example-user", "--"]
+    assert command[4:8] == ["python3", "-I", "-S", "-c"]
+    assert kwargs["env"] == {"PATH": os.defpath}
+    assert kwargs["cwd"] == "/"
+    namespace: dict[str, Any] = {"__name__": "mock_worker"}
+    exec(compile(command[8], "<trusted-user-file-worker>", "exec"), namespace)
+    stdout = io.StringIO()
+    # The child boundary owns these streams; the SDK caller's stream is a separate object.
+    with pytest.MonkeyPatch.context() as patch, redirect_stdout(stdout):
+        patch.setattr(sys, "argv", ["-c", *command[9:]])
+        patch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(kwargs["input"])))
+        try:
+            namespace["_main"]()
+        except OSError as error:
+            return subprocess.CompletedProcess(command, 1, b"", str(error).encode())
+    return subprocess.CompletedProcess(command, 0, stdout.getvalue().encode(), b"")
+
+
+@pytest.mark.asyncio
+async def test_user_write_uses_shared_traversal_and_preserves_input(
+    session: unix_local.UnixLocalSandboxSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    opened = Mock(side_effect=[10, 11, 12, 13])
+    closed = Mock()
+    monkeypatch.setattr(os, "open", opened)
+    monkeypatch.setattr(os, "close", closed)
+    written: list[bytes] = []
+
+    class Output(io.BytesIO):
+        def close(self) -> None:
+            written.append(self.getvalue())
+            super().close()
+
+    output = Output()
+    fdopen = Mock(return_value=output)
+    monkeypatch.setattr(os, "fdopen", fdopen)
+    dispatch = Mock(side_effect=_worker)
+    monkeypatch.setattr(subprocess, "run", dispatch)
+    data = io.BytesIO(b"a\x00b\xff")
+    await session.write(Path("parent/file"), data, user=User(name="example-user"))
+    assert written == [b"a\x00b\xff"]
+    assert not data.closed
+    assert dispatch.call_count == 1
+    assert [call.args[0] for call in opened.call_args_list] == ["/", "workspace", "parent", "file"]
+    assert [call.kwargs for call in opened.call_args_list] == [
+        {},
+        {"dir_fd": 10},
+        {"dir_fd": 11},
+        {"dir_fd": 12},
+    ]
+    assert all(call.args[1] & os.O_NOFOLLOW for call in opened.call_args_list)
+    assert opened.call_args.args[1] & os.O_TRUNC
+    fdopen.assert_called_once_with(13, "wb")
+    assert [call.args[0] for call in closed.call_args_list] == [10, 11, 12]
+    assert output.closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [errno.EACCES, errno.ELOOP])
+@pytest.mark.parametrize("operation", ["ls", "write"])
+async def test_user_lookup_failure_stops_before_file_io(
+    session: unix_local.UnixLocalSandboxSession,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: int,
+    operation: str,
+) -> None:
+    opened = Mock(side_effect=[10, 11, OSError(failure, "Lookup refused")])
+    closed = Mock()
+    monkeypatch.setattr(os, "open", opened)
+    monkeypatch.setattr(os, "close", closed)
+    dispatch = Mock(side_effect=_worker)
+    monkeypatch.setattr(subprocess, "run", dispatch)
+    if operation == "ls":
+        with pytest.raises(ExecNonZeroError):
+            await session.ls("parent/file", user="example-user")
+    else:
+        with pytest.raises(WorkspaceArchiveWriteError):
+            await session.write(Path("parent/file"), io.BytesIO(b"value"), user="example-user")
+    assert dispatch.call_count == 1
+    assert [call.args[0] for call in opened.call_args_list] == ["/", "workspace", "parent"]
+    assert [call.args[0] for call in closed.call_args_list] == [10, 11]
+
+
+@pytest.mark.asyncio
+async def test_user_leaf_permission_failure_does_not_write(
+    session: unix_local.UnixLocalSandboxSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    opened = Mock(side_effect=[10, 11, PermissionError("File is not writable")])
+    closed = Mock()
+    monkeypatch.setattr(os, "open", opened)
+    monkeypatch.setattr(os, "close", closed)
+    dispatch = Mock(side_effect=_worker)
+    monkeypatch.setattr(subprocess, "run", dispatch)
+    with pytest.raises(WorkspaceArchiveWriteError):
+        await session.write(Path("file"), io.BytesIO(b"value"), user="example-user")
+    assert dispatch.call_count == 1
+    assert opened.call_args.args[0] == "file"
+    assert [call.args[0] for call in closed.call_args_list] == [10, 11]
+
+
+@pytest.mark.asyncio
+async def test_user_operation_rechecks_captured_authority(
+    session: unix_local.UnixLocalSandboxSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Model a different result from symlink normalization without changing any real path.
+    monkeypatch.setattr(session, "normalize_path", lambda *args, **kwargs: Path("/ungranted/file"))
+    with pytest.raises(InvalidManifestPathError):
+        await session.write(Path("file"), io.BytesIO(b"value"), user="example-user")
+    subprocess.run.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "kind", "permissions"),
+    [
+        pytest.param(stat.S_IFLNK, "symlink", "-rwxrwxrwx", id="symlink"),
+        pytest.param(stat.S_IFSOCK, "other", "-rwxrwxrwx", id="socket"),
+        pytest.param(stat.S_IFDIR, "directory", "drwxrwxrwx", id="directory"),
+    ],
+)
+async def test_user_listing_preserves_metadata_and_names(
+    session: unix_local.UnixLocalSandboxSession,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: int,
+    kind: str,
+    permissions: str,
+) -> None:
+    monkeypatch.setattr(os, "open", Mock(side_effect=[10, 11, 12]))
+    closed = Mock()
+    monkeypatch.setattr(os, "close", closed)
+    directory = os.stat_result((stat.S_IFDIR | 0o755, 0, 0, 1, 501, 20, 0, 0, 0, 0))
+    entry_stat = os.stat_result((mode | 0o777, 0, 0, 1, 501, 20, 12, 0, 0, 0))
+    monkeypatch.setattr(os, "stat", Mock(return_value=directory))
+    entry = SimpleNamespace(name="name\nwith spaces", stat=Mock(return_value=entry_stat))
+    entries = Mock()
+    entries.__enter__ = Mock(return_value=iter([entry]))
+    entries.__exit__ = Mock(return_value=False)
+    monkeypatch.setattr(os, "scandir", Mock(return_value=entries))
+    monkeypatch.setattr(ops.pwd, "getpwuid", lambda uid: SimpleNamespace(pw_name="owner"))
+    monkeypatch.setattr(ops.grp, "getgrgid", lambda gid: SimpleNamespace(gr_name="group"))
+    monkeypatch.setattr(subprocess, "run", Mock(side_effect=_worker))
+    result = await session.ls("parent", user="example-user")
+    assert len(result) == 1
+    assert result[0].path == "/workspace/parent/name\nwith spaces"
+    assert result[0].owner == "owner"
+    assert result[0].group == "group"
+    assert result[0].size == 12
+    assert result[0].kind.value == kind
+    assert str(result[0].permissions) == permissions
+    assert result[0].permissions.directory is (kind == "directory")
+    entry.stat.assert_called_once_with(follow_symlinks=False)
+    assert [call.args[0] for call in closed.call_args_list] == [10, 11, 12]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["ls", "write"])
+async def test_ungranted_path_never_dispatches(
+    session: unix_local.UnixLocalSandboxSession, operation: str
+) -> None:
+    with pytest.raises(InvalidManifestPathError):
+        if operation == "ls":
+            await session.ls("/ungranted/file", user="example-user")
+        else:
+            await session.write(Path("/ungranted/file"), io.BytesIO(b"value"), user="example-user")
+    subprocess.run.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_read_only_grant_rejects_user_write_before_dispatch(
+    session: unix_local.UnixLocalSandboxSession,
+) -> None:
+    session.state.manifest.extra_path_grants = (SandboxPathGrant(path="/shared", read_only=True),)
+    with pytest.raises(WorkspaceArchiveWriteError) as error:
+        await session.write(Path("/shared/file"), io.BytesIO(b"value"), user="example-user")
+    assert error.value.context["reason"] == "read_only_extra_path_grant"
+    subprocess.run.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_missing_user_runtime_reports_error_without_fallback(
+    session: unix_local.UnixLocalSandboxSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dispatch = Mock(
+        return_value=subprocess.CompletedProcess([], 1, b"", b"Python: permission denied")
+    )
+    monkeypatch.setattr(subprocess, "run", dispatch)
+    with pytest.raises(WorkspaceArchiveWriteError) as error:
+        await session.write(Path("file"), io.BytesIO(b"value"), user="example-user")
+    assert error.value.context["stderr"] == "Python: permission denied"
+    assert dispatch.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["ls", "write"])
+async def test_user_file_operation_does_not_use_application_runtime(
+    session: unix_local.UnixLocalSandboxSession,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    monkeypatch.setattr(sys, "executable", "/private/application/.venv/bin/python")
+    monkeypatch.setenv("VIRTUAL_ENV", "/private/application/.venv")
+    monkeypatch.setenv("PATH", "/private/application/.venv/bin:/workspace/bin")
+    monkeypatch.setenv("PYTHONPATH", "/workspace/python")
+    dispatch = Mock(return_value=subprocess.CompletedProcess([], 0, b"[]", b""))
+    monkeypatch.setattr(subprocess, "run", dispatch)
+    if operation == "ls":
+        assert await session.ls("directory", user="example-user") == []
+    else:
+        await session.write(Path("file"), io.BytesIO(b"value"), user="example-user")
+    command = dispatch.call_args.args[0]
+    assert command[:8] == ["/usr/bin/sudo", "-u", "example-user", "--", "python3", "-I", "-S", "-c"]
+    assert sys.executable not in command
+    assert dispatch.call_args.kwargs["cwd"] == "/"
+    assert dispatch.call_args.kwargs["env"] == {"PATH": os.defpath}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["ls", "write"])
+async def test_missing_system_python_does_not_retry_with_application_runtime(
+    session: unix_local.UnixLocalSandboxSession,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    dispatch = Mock(
+        return_value=subprocess.CompletedProcess([], 1, b"", b"sudo: python3: command not found")
+    )
+    monkeypatch.setattr(subprocess, "run", dispatch)
+    if operation == "ls":
+        with pytest.raises(ExecNonZeroError):
+            await session.ls("directory", user="example-user")
+    else:
+        with pytest.raises(WorkspaceArchiveWriteError):
+            await session.write(Path("file"), io.BytesIO(b"value"), user="example-user")
+    assert dispatch.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancellation_waits_for_user_worker_completion(
+    session: unix_local.UnixLocalSandboxSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A thread-controlled fake process exposes the existing worker ownership boundary.
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def dispatch(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        started.set()
+        assert release.wait(timeout=5)
+        finished.set()
+        return subprocess.CompletedProcess([], 0, b"", b"")
+
+    monkeypatch.setattr(subprocess, "run", dispatch)
+    task = asyncio.create_task(
+        session.write(Path("file"), io.BytesIO(b"value"), user="example-user")
+    )
+    try:
+        assert await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        assert not finished.is_set()
+    finally:
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert finished.is_set()
+
+
+def test_search_only_flag_is_preferred() -> None:
+    # Check the available platform primitive without opening a directory.
+    if hasattr(os, "O_SEARCH"):
+        assert ops._TRAVERSE_FLAGS & os.O_SEARCH == os.O_SEARCH
+    elif hasattr(os, "O_PATH"):
+        assert ops._TRAVERSE_FLAGS & os.O_PATH == os.O_PATH


### PR DESCRIPTION
This pull request addresses a potential filesystem race in UnixLocal sandbox file APIs. If a workspace process replaces a validated path with a symlink between validation and the filesystem operation, the operation could reach a location outside the workspace or explicit grants.

For UnixLocal sessions, use descriptor-relative filesystem operations to avoid following replacement symlinks during traversal, file opening, and recursive removal. This also applies to apply_patch through its existing workspace file APIs.

Preserve supported symlinks, trusted manifest grant updates, stream ownership, user permission checks, error handling, and Python 3.10 compatibility. Other sandbox backends are unchanged.