### PR TITLE
fix(sessions): reset compaction response chain after pop

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -530,8 +530,12 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             try:
                 popped = await self.underlying_session.pop_item()
             except (Exception, asyncio.CancelledError):
+                # The deletion may have committed before acknowledgement failed.
                 self._compaction_candidate_items = None
                 self._session_items = None
+                self._response_id = None
+                self._deferred_response_id = None
+                self._last_unstored_response_id = None
                 self._mutation_generation += 1
                 raise
             if popped:

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -537,6 +537,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             if popped:
                 self._compaction_candidate_items = None
                 self._session_items = None
+                self._response_id = None
+                self._deferred_response_id = None
+                self._last_unstored_response_id = None
                 self._mutation_generation += 1
             return popped
 

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
+import threading
 import warnings as warnings_module
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -191,13 +194,8 @@ class TestOpenAIResponsesCompactionSession:
         assert mock_client.responses.compact.await_args.kwargs["previous_response_id"] == "resp-new"
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("outcome", ["empty", "error", "cancelled"])
-    async def test_pop_item_preserves_response_chain_without_removal(self, outcome: str) -> None:
+    async def test_empty_pop_preserves_response_chain(self) -> None:
         underlying = self.create_mock_session()
-        if outcome == "error":
-            underlying.pop_item.side_effect = RuntimeError("pop failed")
-        elif outcome == "cancelled":
-            underlying.pop_item.side_effect = asyncio.CancelledError()
         mock_client = MagicMock()
         mock_client.responses.compact = AsyncMock(
             return_value=SimpleNamespace(output=[], usage=None)
@@ -213,20 +211,88 @@ class TestOpenAIResponsesCompactionSession:
         session.should_trigger_compaction = lambda ctx: True
         await session._defer_compaction("resp-old")
 
-        if outcome == "empty":
-            assert await session.pop_item() is None
-        elif outcome == "error":
-            with pytest.raises(RuntimeError, match="pop failed"):
-                await session.pop_item()
-        else:
-            with pytest.raises(asyncio.CancelledError):
-                await session.pop_item()
+        assert await session.pop_item() is None
 
         assert session._get_deferred_compaction_response_id() == "resp-old"
         assert session._last_unstored_response_id == "resp-old"
         await session.run_compaction({"force": True})
         assert mock_client.responses.compact.await_args is not None
         assert mock_client.responses.compact.await_args.kwargs["previous_response_id"] == "resp-old"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("outcome", ["cancelled", "error"])
+    async def test_settled_pop_failure_invalidates_response_chain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, outcome: str
+    ) -> None:
+        # Gate the real SQLite commit acknowledgement so cancellation cannot undo the pop.
+        committed = threading.Event()
+        allow_return = threading.Event()
+
+        class PausingCommitConnection(sqlite3.Connection):
+            pause_commit = True
+
+            def commit(self) -> None:
+                super().commit()
+                if self.pause_commit:
+                    self.pause_commit = False
+                    committed.set()
+                    assert allow_return.wait(timeout=10)
+                    if outcome == "error":
+                        raise RuntimeError("commit acknowledgement failed")
+
+        underlying = SQLiteSession("settled-pop", tmp_path / "settled-pop.db")
+        history: list[TResponseInputItem] = [
+            {"role": "user", "content": "keep me"},
+            {"role": "assistant", "content": "remove me"},
+        ]
+        await underlying.add_items(history)
+        connection = sqlite3.connect(
+            str(tmp_path / "settled-pop.db"),
+            check_same_thread=False,
+            factory=PausingCommitConnection,
+        )
+        with underlying._connections_lock:
+            underlying._connections.add(connection)
+        monkeypatch.setattr(underlying, "_get_connection", lambda: connection)
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock()
+        session = OpenAIResponsesCompactionSession(
+            session_id="settled-pop",
+            underlying_session=underlying,
+            client=mock_client,
+            compaction_mode="previous_response_id",
+            should_trigger_compaction=lambda ctx: False,
+        )
+        await session.run_compaction({"response_id": "resp-old", "store": False})
+        session.should_trigger_compaction = lambda ctx: True
+        await session._defer_compaction("resp-old")
+        mutation = asyncio.create_task(session.pop_item())
+        try:
+            assert await asyncio.to_thread(committed.wait, 10)
+            if outcome == "cancelled":
+                mutation.cancel()
+            allow_return.set()
+            if outcome == "cancelled":
+                with pytest.raises(asyncio.CancelledError):
+                    await mutation
+            else:
+                with pytest.raises(RuntimeError, match="commit acknowledgement failed"):
+                    await mutation
+
+            assert await session.get_items() == history[:1]
+            assert not session._mutation_lock.locked()
+            with pytest.raises(ValueError, match="requires a response_id"):
+                await session.run_compaction({"force": True})
+            mock_client.responses.compact.assert_not_awaited()
+            assert session._get_deferred_compaction_response_id() is None
+            assert session._last_unstored_response_id is None
+            assert await underlying.get_items() == history[:1]
+        finally:
+            allow_return.set()
+            if not mutation.done():
+                mutation.cancel()
+            await asyncio.gather(mutation, return_exceptions=True)
+            underlying.close()
 
     @pytest.mark.asyncio
     async def test_get_items_delegates(self) -> None:

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -159,6 +159,76 @@ class TestOpenAIResponsesCompactionSession:
         mock_session.add_items.assert_called_once_with(items)
 
     @pytest.mark.asyncio
+    async def test_pop_item_invalidates_response_chain(self) -> None:
+        item: TResponseInputItem = {"role": "assistant", "content": "remove me"}
+        underlying = SimpleListSession(history=[item])
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(
+            return_value=SimpleNamespace(output=[], usage=None)
+        )
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=underlying,
+            client=mock_client,
+            compaction_mode="previous_response_id",
+            should_trigger_compaction=lambda ctx: False,
+        )
+        await session.run_compaction({"response_id": "resp-old", "store": False})
+        # Seed deferred work through the runner's compaction hook.
+        session.should_trigger_compaction = lambda ctx: True
+        await session._defer_compaction("resp-old")
+
+        assert await session.pop_item() == item
+        assert await session.get_items() == []
+        with pytest.raises(ValueError, match="requires a response_id"):
+            await session.run_compaction({"force": True})
+        mock_client.responses.compact.assert_not_awaited()
+        assert session._get_deferred_compaction_response_id() is None
+        assert session._last_unstored_response_id is None
+
+        await session.run_compaction({"response_id": "resp-new", "force": True})
+        assert mock_client.responses.compact.await_args is not None
+        assert mock_client.responses.compact.await_args.kwargs["previous_response_id"] == "resp-new"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("outcome", ["empty", "error", "cancelled"])
+    async def test_pop_item_preserves_response_chain_without_removal(self, outcome: str) -> None:
+        underlying = self.create_mock_session()
+        if outcome == "error":
+            underlying.pop_item.side_effect = RuntimeError("pop failed")
+        elif outcome == "cancelled":
+            underlying.pop_item.side_effect = asyncio.CancelledError()
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(
+            return_value=SimpleNamespace(output=[], usage=None)
+        )
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=underlying,
+            client=mock_client,
+            compaction_mode="previous_response_id",
+            should_trigger_compaction=lambda ctx: False,
+        )
+        await session.run_compaction({"response_id": "resp-old", "store": False})
+        session.should_trigger_compaction = lambda ctx: True
+        await session._defer_compaction("resp-old")
+
+        if outcome == "empty":
+            assert await session.pop_item() is None
+        elif outcome == "error":
+            with pytest.raises(RuntimeError, match="pop failed"):
+                await session.pop_item()
+        else:
+            with pytest.raises(asyncio.CancelledError):
+                await session.pop_item()
+
+        assert session._get_deferred_compaction_response_id() == "resp-old"
+        assert session._last_unstored_response_id == "resp-old"
+        await session.run_compaction({"force": True})
+        assert mock_client.responses.compact.await_args is not None
+        assert mock_client.responses.compact.await_args.kwargs["previous_response_id"] == "resp-old"
+
+    @pytest.mark.asyncio
     async def test_get_items_delegates(self) -> None:
         mock_session = self.create_mock_session()
         mock_session.get_items.return_value = [{"type": "message", "content": "test"}]


### PR DESCRIPTION
### Summary

This pull request fixes stale response-chain reuse after `OpenAIResponsesCompactionSession.pop_item()` removes an item from local history. A successful removal clears the retained response ID, deferred compaction ID, and unstored-response marker inside the existing mutation lock. Backend exceptions and cancellation also clear those identifiers because the deletion may already have committed. An acknowledged empty pop preserves the chain state.

After a removal or an uncertain backend outcome, `previous_response_id` compaction requires an explicitly supplied response ID; input-based compaction remains available for the remaining local history. Public signatures and stored history formats are unchanged. This covers the pop-specific behavior in #4867; the separate clear-session fix in #4865 remains independent.

### Test plan

- The successful-pop regression fails on the original implementation. The settled cancellation and error regressions fail before adding the exception-path resets.
- Four pop cases cover removal, empty history, a SQLite deletion that commits before cancellation is raised, and a committed deletion whose acknowledgement fails. Controlled thread events exercise the real backend mutation drain, verify surviving history, and assert that stale response compaction is rejected before an API call. The successful case also verifies that a fresh response ID enables subsequent compaction.
- `uv run pytest -q tests/memory/test_openai_responses_compaction_session.py tests/memory/test_session.py`: 117 passed.
- Full `.agents/skills/code-change-verification/scripts/run.sh` passes: formatting, lint, mypy (312 source files), Pyright (zero errors), 9,573 parallel tests, and 77 serial tests. The test suites reported 60 skips under the repository's Codex test settings.
- Verification used `OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1` with `OPENAI_API_KEY` unset. A temporary `UV_PROJECT_ENVIRONMENT` without spaces was needed because the verification-runner tests generate Python shebangs from the interpreter path; all 18 applicable runner tests pass with that environment.
- Two independent Codex reviews covered session persistence and cancellation/lifecycle behavior, with no findings. The reviewed patch remained unchanged after full verification.

### Issue number

Fixes #4867.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] I've completed Codex independent final review before submitting this PR
