### PR TITLE
release: 0.22.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-agents"
-version = "0.22.1"
+version = "0.22.2"
 description = "OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/fixtures/released_api_contract.json
+++ b/tests/fixtures/released_api_contract.json
@@ -1,6 +1,6 @@
 {
-  "baseline": "v0.22.1",
-  "baseline_commit": "ee375635d57c9f1f5dbe80c4184965df41cbfcad",
+  "baseline": "v0.22.2",
+  "baseline_commit": "25af629b3c877ba3d0e95189141bb636b21167a5",
   "callables": {
     "Agent": {
       "dataclass_fields": [
@@ -46618,6 +46618,72 @@
         }
       ],
       "module": "agents.voice"
+    },
+    {
+      "class_name": "ImageGenerationToolConfig",
+      "fields": [
+        {
+          "annotation": "Required[Literal['image_generation']]",
+          "name": "type",
+          "required": true
+        },
+        {
+          "annotation": "Literal['generate', 'edit', 'auto']",
+          "name": "action",
+          "required": false
+        },
+        {
+          "annotation": "Literal['transparent', 'opaque', 'auto']",
+          "name": "background",
+          "required": false
+        },
+        {
+          "annotation": "Literal['high', 'low'] | None",
+          "name": "input_fidelity",
+          "required": false
+        },
+        {
+          "annotation": "_ImageGenerationInputImageMask",
+          "name": "input_image_mask",
+          "required": false
+        },
+        {
+          "annotation": "str",
+          "name": "model",
+          "required": false
+        },
+        {
+          "annotation": "Literal['auto', 'low']",
+          "name": "moderation",
+          "required": false
+        },
+        {
+          "annotation": "int",
+          "name": "output_compression",
+          "required": false
+        },
+        {
+          "annotation": "Literal['png', 'webp', 'jpeg']",
+          "name": "output_format",
+          "required": false
+        },
+        {
+          "annotation": "int",
+          "name": "partial_images",
+          "required": false
+        },
+        {
+          "annotation": "Literal['low', 'medium', 'high', 'xhigh', 'max', 'auto']",
+          "name": "quality",
+          "required": false
+        },
+        {
+          "annotation": "str",
+          "name": "size",
+          "required": false
+        }
+      ],
+      "module": "agents"
     }
   ],
   "required_submodule_exports": {
@@ -47591,7 +47657,8 @@
     "ModelTimeoutError",
     "OutputGuardrailBlockedMessageArgs",
     "OutputGuardrailBlockedMessageFormatter",
-    "WebSearchToolImageSettings"
+    "WebSearchToolImageSettings",
+    "ImageGenerationToolConfig"
   ],
   "submodule_export_exclusions": [
     "agents.sandbox.sandboxes"

--- a/uv.lock
+++ b/uv.lock
@@ -2541,7 +2541,7 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "griffelib" },


### PR DESCRIPTION
### Release readiness review (v0.22.1 -> TARGET c8a35736e3fb6ba3e377044ba30afddcc8032f20)

This is a release readiness report done by `$final-release-review` skill.

### Diff

https://github.com/openai/openai-agents-python/compare/v0.22.1...c8a35736e3fb6ba3e377044ba30afddcc8032f20

### Release intent

- Review mode: final candidate
- Intended release: patch 0.22.2
- Minimum required release type: patch
- Versioning verdict: compatible

### Release call

**🟢 GREEN LIGHT TO SHIP** Candidate metadata is consistent, no concrete release-blocking regression was established, and the branch contains exactly one release commit above refreshed origin/main.

### Scope summary

- 94 files changed (+5632/-3563): UnixLocal file-operation hardening, compaction response-chain invalidation after pop, image-generation configuration typing, tests, and documentation with translations.
- The release commit changes only `pyproject.toml`, `uv.lock`, and `tests/fixtures/released_api_contract.json`.

### Risk assessment (ordered by impact)

1. **UnixLocal file operations resist symlink replacement**
   - Risk: **🟢 LOW**. Stable authorized paths and grants remain supported. User-scoped listing and writing now require sudo access to system python3 and its standard library.
   - Evidence: #4931 introduces descriptor-relative O_NOFOLLOW traversal, pins root and grant aliases, and retains worker ownership through cancellation. Coverage includes stable symlinks, grant permissions, replacement races, and cleanup.
   - Files: `src/agents/sandbox/sandboxes/unix_local.py`, `src/agents/sandbox/sandboxes/_unix_local_files.py`, `src/agents/sandbox/sandboxes/_unix_local_file_ops.py`.
   - Action: Document the system-Python prerequisite after release and preserve the beta backend's existing host-isolation qualifications.

2. **Compaction invalidates retained response IDs after history is popped**
   - Risk: **🟢 LOW**. Manual previous-response compaction needs a new valid response ID after a successful or uncertain pop; auto/input compaction can use current local history.
   - Evidence: #4934 clears cached, deferred, and unstored response IDs under the existing mutation lock after a nonempty pop or an exception/cancellation. A pop returning None preserves them. Coverage includes committed SQLite deletion followed by failed or cancelled acknowledgement. The normal Runner supplies the next response ID through its existing persistence path.
   - Files: `src/agents/memory/openai_responses_compaction_session.py`, `tests/memory/test_openai_responses_compaction_session.py`.
   - Action: Explain that manual previous_response_id compaction must receive a new valid response ID matching corrected history, or callers can use auto/input mode. No public signature or durable schema changes are required.

3. **Image-generation typing expands without changing forwarding**
   - Risk: **🟢 LOW**. Existing upstream typed configurations, positional construction, mutable field behavior, and runtime dataclass layout remain supported.
   - Evidence: #4932 adds `ImageGenerationToolConfig` with wider model, size, and quality annotations. Responses conversion still forwards the original mapping. The frozen contract adds the new export and TypedDict fields without removing existing entries.
   - Files: `src/agents/tool.py`, `src/agents/__init__.py`, `src/agents/models/openai_responses.py`, `examples/tools/image_generator.py`.
   - Action: Explain the configuration type and unchanged API validation boundary. Existing callers require no migration.

### Documentation coverage (non-blocking)

- Coverage source: Current read-only inspection of all 22 open PR file lists found no `docs/` changes. The target includes merged #4577 and its translation refresh.
- Status: partially covered
- Covered obligations: The image example and API field docstring describe expanded options. The UnixLocal class docstring states the system-Python prerequisite. Existing session docs explain the three compaction modes.
- Gaps or post-release suggestions:
  - In `docs/tools.md`, under Hosted tools, show `ImageGenerationToolConfig`, required `type`, expanded model/size/quality options, unchanged forwarding, and provider validation.
  - In `docs/sandbox/clients.md`, under Unix-local, explain symlink-race protection and the sudo/system-python3 prerequisite for `ls(..., user=...)` and `write(..., user=...)`, independently of the application virtual environment.
  - In `docs/sessions/index.md`, under OpenAI Responses compaction, explain response-ID invalidation after successful or uncertain failed/cancelled pops, preservation after an empty pop, and the new-response-ID or auto/input alternatives.
- Publication timing: Publish new 0.22.2 behavior guidance after package release.

### Notes

- The checked-out branch, project version, editable lock entry, and contract baseline agree on 0.22.2.
- The contract baseline_commit and release commit parent are `25af629b3c877ba3d0e95189141bb636b21167a5`.
- No live model request was made during release preparation.
