### PR TITLE
fix(sessions): skip malformed encrypted envelopes

### DIFF
--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -208,11 +208,15 @@ class EncryptedSession(SessionABC):
         if not _is_encrypted_envelope(item):
             return cast(TResponseInputItem, item)
 
+        payload = item["payload"]
+        if not isinstance(payload, str):
+            return None
+
         try:
-            token = item["payload"].encode("utf-8")
+            token = payload.encode("utf-8")
             plaintext = self.cipher.decrypt(token, ttl=self.ttl)
             return cast(TResponseInputItem, _from_json_bytes(plaintext))
-        except (InvalidToken, KeyError):
+        except (InvalidToken, UnicodeError, json.JSONDecodeError):
             return None
 
     def _unwrap_valid_items(

--- a/tests/extensions/memory/test_encrypt_session.py
+++ b/tests/extensions/memory/test_encrypt_session.py
@@ -42,6 +42,13 @@ def _invalid_encrypted_envelope() -> TResponseInputItem:
     )
 
 
+def _malformed_encrypted_envelope(payload: Any = 7) -> TResponseInputItem:
+    return cast(
+        TResponseInputItem,
+        {"__enc__": 1, "v": 1, "kid": "hkdf-v1", "payload": payload},
+    )
+
+
 @pytest.fixture
 def agent() -> Agent:
     """Fixture for a basic agent with a scripted model."""
@@ -938,6 +945,24 @@ async def test_encrypted_session_pop_mixed_expired_valid(
     underlying_session.close()
 
 
+@pytest.mark.parametrize("payload", [7, "\ud800"])
+async def test_encrypted_session_pop_skips_malformed_envelope(
+    payload: Any, encryption_key: str, underlying_session: SQLiteSession
+):
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    await session.add_items([{"role": "user", "content": "valid"}])
+    await underlying_session.add_items([_malformed_encrypted_envelope(payload)])
+
+    assert await session.pop_item() == {"role": "user", "content": "valid"}
+
+    underlying_session.close()
+
+
 async def test_encrypted_session_raw_string_key(underlying_session: SQLiteSession):
     """Test using raw string as encryption key (not base64)."""
     session = EncryptedSession(
@@ -995,6 +1020,43 @@ async def test_encrypted_session_get_items_limit_skips_invalid_latest_envelope(
 
     limited = await session.get_items(limit=1)
     assert [item.get("content") for item in limited] == ["older valid"]
+
+    underlying_session.close()
+
+
+@pytest.mark.parametrize("payload", [7, "\ud800"])
+async def test_encrypted_session_get_items_skips_malformed_envelope(
+    payload: Any, encryption_key: str, underlying_session: SQLiteSession
+):
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    await underlying_session.add_items([_malformed_encrypted_envelope(payload)])
+    await session.add_items([{"role": "user", "content": "valid"}])
+
+    assert await session.get_items(limit=1) == [{"role": "user", "content": "valid"}]
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_get_items_propagates_configuration_error(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+        ttl=cast(Any, "invalid"),
+    )
+    await session.add_items([{"role": "user", "content": "valid"}])
+
+    with pytest.raises(TypeError):
+        await session.get_items()
+
+    assert await underlying_session.get_items()
 
     underlying_session.close()
 


### PR DESCRIPTION
This pull request fixes encrypted session reads when a persisted envelope has a malformed payload. It resolves #4936.

## Root cause

`EncryptedSession._unwrap()` recognized an envelope by its marker and keys, then called `.encode()` on `payload` without validating its stored type. Non-string values raised `AttributeError`, and strings containing invalid Unicode scalar data raised `UnicodeEncodeError`. Either exception aborted `get_items()` and hid valid history; `pop_item()` removed the corrupt tail but stopped before returning the next valid item.

## Solution

Validate that the envelope payload is a string before decryption, and treat Unicode encoding/decoding failures as record corruption alongside invalid Fernet tokens and invalid decrypted JSON. The exception boundary stays narrow so configuration errors such as an invalid TTL still propagate.

## Regression coverage

The new tests exercise both integer and unpaired-surrogate payloads through:

- `get_items(limit=1)`, including backfill to a later valid record
- `pop_item()`, including continuation to the preceding valid record
- invalid TTL propagation, proving configuration `TypeError` is not mistaken for corrupt data

The tests fail on `upstream/main` and pass with this patch.

## Validation

- `ruff format --check` on changed files: passed
- `ruff check` on changed files: passed
- `pytest -q tests/extensions/memory/test_encrypt_session.py`: 43 passed
- repository formatting and lint: passed
- mypy: passed (312 source files)
- pyright: passed (0 errors, 0 warnings)
- full parallel tests: 9,564 passed, 56 skipped; 14 unrelated `tests/test_code_change_verification_runner.py` process-harness cases timed out under xdist. The affected test file passes independently.
- `git diff --check`: passed

## Risk assessment

Low. Valid encrypted envelopes, plaintext passthrough items, TTL handling, and the persisted envelope format are unchanged. The behavior change is limited to malformed marked envelopes, which are now skipped consistently with invalid or expired encrypted tokens.
