### PR TITLE
fix(sessions): reject SQLite JSON scalar items

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -391,8 +391,10 @@ class AdvancedSQLiteSession(SQLiteSession):
             for (message_data,) in rows:
                 try:
                     item = json.loads(message_data)
-                    items.append(item)
-                except json.JSONDecodeError:
+                    if not isinstance(item, dict):
+                        raise TypeError("Session item must be a JSON object")
+                    items.append(cast(TResponseInputItem, item))
+                except (json.JSONDecodeError, TypeError):
                     continue
             return items
 
@@ -545,7 +547,10 @@ class AdvancedSQLiteSession(SQLiteSession):
                             continue
 
                         try:
-                            return json.loads(message_row[0])
+                            item = json.loads(message_row[0])
+                            if not isinstance(item, dict):
+                                raise TypeError("Session item must be a JSON object")
+                            return cast(TResponseInputItem, item)
                         except (json.JSONDecodeError, TypeError):
                             # Drop corrupted JSON entries and keep looking for a valid item.
                             continue

--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -243,8 +243,10 @@ class AsyncSQLiteSession(SessionABC):
             for (message_data,) in rows:
                 try:
                     item = json.loads(message_data)
-                    items.append(item)
-                except json.JSONDecodeError:
+                    if not isinstance(item, dict):
+                        raise TypeError("Session item must be a JSON object")
+                    items.append(cast(TResponseInputItem, item))
+                except (json.JSONDecodeError, TypeError):
                     continue
             return items
 
@@ -366,7 +368,10 @@ class AsyncSQLiteSession(SessionABC):
             while result:
                 message_data = result[0]
                 try:
-                    return cast(TResponseInputItem, json.loads(message_data))
+                    item = json.loads(message_data)
+                    if not isinstance(item, dict):
+                        raise TypeError("Session item must be a JSON object")
+                    return cast(TResponseInputItem, item)
                 except (json.JSONDecodeError, TypeError):
                     cursor = await conn.execute(
                         f"""

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import Iterator
 from contextlib import closing, contextmanager
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from ..items import TResponseInputItem
 from .session import SessionABC, _await_mutation as _await_mutation
@@ -278,7 +278,9 @@ class SQLiteSession(SessionABC):
             for (message_data,) in rows:
                 try:
                     item = json.loads(message_data)
-                    items.append(item)
+                    if not isinstance(item, dict):
+                        raise TypeError("Session item must be a JSON object")
+                    items.append(cast(TResponseInputItem, item))
                 except (json.JSONDecodeError, TypeError):
                     # Skip invalid JSON entries
                     continue
@@ -385,7 +387,9 @@ class SQLiteSession(SessionABC):
                     message_data = result[0]
                     try:
                         item = json.loads(message_data)
-                        return item
+                        if not isinstance(item, dict):
+                            raise TypeError("Session item must be a JSON object")
+                        return cast(TResponseInputItem, item)
                     except (json.JSONDecodeError, TypeError):
                         # Drop corrupted JSON entries and keep looking for a valid item.
                         cursor = conn.execute(

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -2700,7 +2700,8 @@ async def test_get_items_explicit_limit_overrides_session_settings():
     session.close()
 
 
-async def test_get_items_limit_skips_corrupt_newest_rows():
+@pytest.mark.parametrize("corrupt_data", ["not valid json {{{", "null"])
+async def test_get_items_limit_skips_corrupt_newest_rows(corrupt_data: str):
     """limit counts valid items, expanding past corrupt newest rows."""
     session = AdvancedSQLiteSession(session_id="limit_corrupt_test", create_tables=True)
 
@@ -2716,7 +2717,7 @@ async def test_get_items_limit_skips_corrupt_newest_rows():
     conn = session._get_connection()
     cursor = conn.execute(
         f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
-        (session.session_id, "not valid json {{{"),
+        (session.session_id, corrupt_data),
     )
     next_sequence = conn.execute(
         "SELECT COALESCE(MAX(sequence_number), 0) + 1 FROM message_structure "
@@ -2737,6 +2738,8 @@ async def test_get_items_limit_skips_corrupt_newest_rows():
     # The explicit-branch call resolves to the same rows.
     limited_explicit = await session.get_items(limit=2, branch_id="main")
     assert [item.get("content") for item in limited_explicit] == ["valid 1", "valid 2"]
+
+    assert await session.pop_item() == {"role": "user", "content": "valid 2"}
 
     session.close()
 

--- a/tests/extensions/memory/test_async_sqlite_session.py
+++ b/tests/extensions/memory/test_async_sqlite_session.py
@@ -87,7 +87,8 @@ async def test_async_sqlite_session_pop_item():
         await session.close()
 
 
-async def test_async_sqlite_session_pop_item_skips_corrupt_most_recent():
+@pytest.mark.parametrize("corrupt_data", ["not valid json {{{", "null"])
+async def test_async_sqlite_session_pop_item_skips_corrupt_most_recent(corrupt_data: str):
     """pop_item skips corrupt newest rows and returns the next valid item."""
     with tempfile.TemporaryDirectory() as temp_dir:
         db_path = Path(temp_dir) / "async_pop_corrupt.db"
@@ -99,7 +100,7 @@ async def test_async_sqlite_session_pop_item_skips_corrupt_most_recent():
         conn = await session._get_connection()
         await conn.execute(
             f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
-            (session.session_id, "not valid json {{{"),
+            (session.session_id, corrupt_data),
         )
         await conn.commit()
 
@@ -150,7 +151,10 @@ async def test_async_sqlite_session_get_items_limit():
         await session.close()
 
 
-async def test_async_sqlite_session_get_items_limit_skips_corrupt_newest_rows():
+@pytest.mark.parametrize("corrupt_data", ["not valid json {{{", "null"])
+async def test_async_sqlite_session_get_items_limit_skips_corrupt_newest_rows(
+    corrupt_data: str,
+):
     """limit counts valid items, expanding past corrupt newest rows."""
     with tempfile.TemporaryDirectory() as temp_dir:
         db_path = Path(temp_dir) / "async_limit_corrupt.db"
@@ -167,7 +171,7 @@ async def test_async_sqlite_session_get_items_limit_skips_corrupt_newest_rows():
         conn = await session._get_connection()
         await conn.execute(
             f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
-            (session.session_id, "not valid json {{{"),
+            (session.session_id, corrupt_data),
         )
         await conn.commit()
 

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -383,7 +383,8 @@ async def test_session_memory_pop_different_sessions():
 
 
 @pytest.mark.asyncio
-async def test_sqlite_session_pop_item_skips_corrupt_most_recent():
+@pytest.mark.parametrize("corrupt_data", ["not valid json {{{", "null"])
+async def test_sqlite_session_pop_item_skips_corrupt_most_recent(corrupt_data: str):
     """pop_item skips corrupt newest rows and returns the next valid item."""
     with tempfile.TemporaryDirectory() as temp_dir:
         db_path = Path(temp_dir) / "test_pop_corrupt.db"
@@ -395,7 +396,7 @@ async def test_sqlite_session_pop_item_skips_corrupt_most_recent():
         with session._locked_connection() as conn:
             conn.execute(
                 f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
-                (session.session_id, "not valid json {{{"),
+                (session.session_id, corrupt_data),
             )
             conn.commit()
 
@@ -479,7 +480,8 @@ async def test_sqlite_session_get_items_with_limit():
 
 
 @pytest.mark.asyncio
-async def test_sqlite_session_get_items_limit_skips_corrupt_newest_rows():
+@pytest.mark.parametrize("corrupt_data", ["not valid json {{{", "null"])
+async def test_sqlite_session_get_items_limit_skips_corrupt_newest_rows(corrupt_data: str):
     """limit counts valid items, expanding past corrupt newest rows."""
     with tempfile.TemporaryDirectory() as temp_dir:
         db_path = Path(temp_dir) / "test_limit_corrupt.db"
@@ -496,7 +498,7 @@ async def test_sqlite_session_get_items_limit_skips_corrupt_newest_rows():
         with session._locked_connection() as conn:
             conn.execute(
                 f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
-                (session.session_id, "not valid json {{{"),
+                (session.session_id, corrupt_data),
             )
             conn.commit()
 


### PR DESCRIPTION
This pull request fixes SQLite-backed sessions that accepted JSON scalars and arrays as model-facing history items. It resolves #4939.

## Root cause

The SQLite deserialization paths checked only whether `json.loads()` succeeded. Valid JSON values such as `null`, strings, numbers, booleans, and arrays therefore passed through as `TResponseInputItem` even though that public type is object-shaped.

For `null`, `get_items(limit=1)` returned `[None]`. `pop_item()` deleted the scalar tail and returned `None`, incorrectly signaling an empty session instead of continuing to the next valid object.

## Solution

After JSON decoding, require the result to be a dictionary in all `get_items()` and `pop_item()` paths for:

- `SQLiteSession`
- `AsyncSQLiteSession`
- `AdvancedSQLiteSession`

Non-object JSON now uses each backend's existing corrupt-row handling. Storage schemas, serialization, transaction boundaries, limits, ordering, and AdvancedSQLiteSession branch cleanup are unchanged.

## Regression coverage

Existing corrupt-row tests now run against both malformed JSON and valid JSON `null`. They cover limited backfill and pop recovery in the synchronous and asynchronous implementations, plus implicit/explicit branch reads and pop cleanup in `AdvancedSQLiteSession`.

The five `null` cases fail on `upstream/main` and pass with this patch.

## Validation

- SQLite-family test files: 226 passed
- changed-file Ruff format and lint: passed
- repository formatting and lint: passed
- mypy: passed (312 source files)
- pyright: passed (0 errors, 0 warnings)
- full parallel tests: 9,564 passed, 56 skipped; 14 unrelated `tests/test_code_change_verification_runner.py` process-harness cases timed out under xdist, matching the same baseline failure seen on the independent preceding branch
- `git diff --check`: passed

## Risk assessment

Low. Valid persisted JSON objects are returned exactly as before. Only values outside the public response-input-item shape are reclassified as corrupt, using the existing skip and cleanup paths. No database migration or persisted format change is required.
