### PR TITLE
fix(sandbox): keep UnixLocal workspace-root removal off the event loop

### DIFF
--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -1223,7 +1223,7 @@ class UnixLocalSandboxClient(BaseSandboxClient[UnixLocalSandboxClientOptions | N
         if unmount_failed:
             return session
         try:
-            shutil.rmtree(Path(inner.state.manifest.root), ignore_errors=False)
+            await run_blocking_workspace_io(shutil.rmtree, Path(inner.state.manifest.root))
         except FileNotFoundError:
             pass
         except Exception:

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import io
+import shutil
 import signal
 import tarfile
 import threading
@@ -610,3 +612,65 @@ async def test_hydrate_workspace_cancellation_waits_for_the_extracting_worker(
     # the workspace root are only released once nothing is still writing to them.
     assert events == ["extract-start", "extract-end"]
     assert not buf.closed
+
+
+@pytest.mark.asyncio
+async def test_client_delete_keeps_workspace_removal_off_the_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The event loop must keep running while `delete()` removes the workspace root.
+
+    The removal walks the whole workspace tree, so running it inline starves every other
+    task on the loop for its full duration. `rm(recursive=True)`, `persist_workspace`, and
+    `hydrate_workspace` already hand that work to `run_blocking_workspace_io`.
+
+    The handshake below measures the removal itself rather than the whole `delete()` call,
+    so an `await` elsewhere in the method, such as the ephemeral unmount loop, cannot
+    satisfy it.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "payload.txt").write_text("payload", encoding="utf-8")
+
+    client = UnixLocalSandboxClient()
+    session = await client.resume(
+        UnixLocalSandboxSessionState(
+            manifest=Manifest(root=str(workspace)),
+            snapshot=NoopSnapshot(id="noop"),
+            workspace_root_owned=True,
+        )
+    )
+
+    real_rmtree = shutil.rmtree
+    removal_started = threading.Event()
+    loop_advanced = threading.Event()
+    loop_advanced_during_removal: list[bool] = []
+
+    def _slow_rmtree(path: object, *args: object, **kwargs: object) -> None:
+        removal_started.set()
+        # The observer can only answer while the removal is in flight if the loop is
+        # still free. An inline removal holds the loop here until this call returns.
+        loop_advanced_during_removal.append(loop_advanced.wait(timeout=5.0))
+        real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(unix_local_module.shutil, "rmtree", _slow_rmtree)
+
+    async def _observe_loop() -> None:
+        while not removal_started.is_set():
+            await asyncio.sleep(0)
+        loop_advanced.set()
+
+    observer = asyncio.create_task(_observe_loop())
+    try:
+        returned = await client.delete(session)
+    finally:
+        observer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await observer
+
+    assert removal_started.is_set()
+    assert loop_advanced_during_removal == [True]
+    # The removal still targets the manifest root, and `delete()` still hands the same
+    # session back to the caller.
+    assert not workspace.exists()
+    assert returned is session


### PR DESCRIPTION
### Summary

This pull request moves the UnixLocal workspace-root removal off the event loop, completing the set of operations #4700 converted.

`UnixLocalSandboxClient.delete()` removed the workspace root with a direct `shutil.rmtree` call inside an `async def`:

```python
try:
    shutil.rmtree(Path(inner.state.manifest.root), ignore_errors=False)
except FileNotFoundError:
    pass
except Exception:
    pass
```

Removing the root walks the whole workspace tree, so the loop was held for the full removal and no other task could advance. `rm(recursive=True)`, `persist_workspace`, and `hydrate_workspace` already hand that class of work to `run_blocking_workspace_io`, whose docstring states the contract: it runs the function in a worker thread and keeps ownership until that worker finishes. Its module docstring explains why that matters over plain `asyncio.to_thread`, which does not stop its worker when the awaiting task is cancelled. #4700 introduced the helper and converted those three sites. `git blame` puts this line at `2d665c9a6` (2026-04-15) and `git log -L` returns only that commit for it, so #4700 did not touch it. The rationale for preferring the helper over bare `to_thread` is in the #4700 description, which also records that it is why #4678 was closed.

Scope note, since this is a `rmtree`/archive-class fix rather than a sweep: other inline synchronous filesystem calls remain in this module, notably the `shutil.copyfileobj` in `write` and the `os.scandir` in `ls`. Those are bounded by a caller-supplied payload and a single directory rather than by a recursive tree walk, and I have left them alone here.

`shutil.rmtree` relies on its stdlib default `ignore_errors=False`, because the helper forwards positional arguments only. Errors are therefore still raised and still swallowed by the unchanged `except` clauses. When no cancellation is observed, `task.result()` re-raises the worker's original exception object, so the types reaching those clauses are the same; when a cancellation is observed the helper raises that `CancelledError` instead. This matches how the sibling `rm(recursive=True)` call site invokes it.

Present in `v0.22.1`, not only on `main`.

#### Released-behavior delta, disclosed

`delete()` can now raise `CancelledError`. Scoped precisely, because it depends on the manifest:

| Session shape | v0.22.1 | This change |
| --- | --- | --- |
| No ephemeral mount targets | No suspension point in `delete()`, so it returned the session | Can raise `CancelledError`; under `asyncio.wait_for` the caller still waits for the full removal and then receives `TimeoutError` |
| Has ephemeral mount targets | Already awaited `mount_entry.unmount(...)`, so cancellation could already be delivered before the removal was reached | Unchanged in kind; one further cancellation point |

The removal always runs to completion, because the helper keeps the worker owned, so nothing leaks and the workspace is still removed. Delivering cancellation is impossible without a suspension point, so this is inherent to the fix. It is the same trade-off #4700 accepted for the three sibling sites. Note that `CancelledError` derives from `BaseException`, so neither the method's own `except Exception` nor a caller's `contextlib.suppress(Exception)` absorbs it.

Worth flagging for the in-SDK path: the sole caller, `_SandboxSessionResources.cleanup`, wraps the call in `except BaseException`, records it as `cleanup_error` if no earlier error was recorded, and still runs `_aclose_dependencies()` in a `finally`, so dependency teardown stays complete. It then re-raises, and at `SandboxRuntimeSessionManager.cleanup` a non-`None` `cleanup_error` skips `serialize_resume_state()`. That skip is pre-existing for any cleanup error; what is new is that cancellation can now reach it from here, so a cancelled cleanup loses the serialized sandbox resume state. Happy to guard that separately if you would rather it were absorbed.

Otherwise unchanged: the `workspace_root_owned` and `unmount_failed` early returns and the unmount ordering are byte-identical to `v0.22.1`, and the same session is returned on every path that returns at all. The pre-existing `TypeError` guard for a foreign session type is untouched.

### Test plan

Added `test_client_delete_keeps_workspace_removal_off_the_event_loop` in `tests/sandbox/test_unix_local.py`. It builds the session through the public `client.resume(state)`, replaces `shutil.rmtree` with a wrapper that still performs the real removal, and uses an event handshake rather than wall-clock timing: the worker signals that the removal has begun and then waits for a loop-side observer to answer, so the assertion covers the removal itself rather than the whole `delete()` call.

That scoping matters. An earlier draft counted loop progress across the whole call, which an `await` elsewhere in `delete()`, such as the ephemeral unmount loop, could satisfy on its own. Verified against both regressions:

| Source under test | Result |
| --- | --- |
| This change | passes |
| Inline `shutil.rmtree` | `assert [False] == [True]` |
| Inline `shutil.rmtree` plus an unrelated `await asyncio.sleep(0.01)` in `delete()` | `assert [False] == [True]` |

The test also asserts the workspace root is really gone and that the same session is returned, so it pins the removal target, not just the dispatch mechanism.

Ownership-on-cancellation is not separately pinned here; it is a property of `run_blocking_workspace_io` and is already covered for `hydrate_workspace` by the test #4700 added.

`.agents/skills/code-change-verification/scripts/run.sh` completes with exit 0: `make format`, `make lint` (`All checks passed!`), `make typecheck` (mypy `0 errors`, pyright `no issues found in 310 source files`), and `make tests` (`9539 passed, 29 skipped`). The pre-existing `tests/sandbox/test_runtime.py -k delete` tests also pass unchanged.

### Issue number

No existing issue. Found while auditing the module for remaining instances of the pattern #4700 addressed. Happy to open one first if you would prefer the discussion to start there.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

Not using Codex, so the last item does not apply.
