### PR TITLE
fix(sessions): expand tilde in SQLite db paths

### DIFF
--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -54,7 +54,7 @@ class AsyncSQLiteSession(SessionABC):
             if session_settings is not None
             else SessionSettings()
         )
-        self.db_path = db_path
+        self.db_path = db_path if str(db_path) == ":memory:" else Path(db_path).expanduser()
         self.sessions_table = sessions_table
         self.messages_table = messages_table
         self._connection: aiosqlite.Connection | None = None

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -53,7 +53,7 @@ class SQLiteSession(SessionABC):
             if session_settings is not None
             else SessionSettings()
         )
-        self.db_path = db_path
+        self.db_path = db_path if str(db_path) == ":memory:" else Path(db_path).expanduser()
         self.sessions_table = sessions_table
         self.messages_table = messages_table
         self._local = threading.local()

--- a/tests/memory/test_sqlite_db_path.py
+++ b/tests/memory/test_sqlite_db_path.py
@@ -1,0 +1,52 @@
+"""SQLite file sessions accept ~/... paths by expanding the user directory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from agents.extensions.memory import AsyncSQLiteSession
+from agents.memory import SQLiteSession
+
+
+@pytest.mark.asyncio
+async def test_sqlite_session_expands_tilde_db_path(tmp_path, monkeypatch) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    db_path = "~/hermes_tilde_sync.db"
+    expanded = Path(db_path).expanduser()
+    assert str(expanded).startswith(str(fake_home))
+
+    session = SQLiteSession("tilde-sync", db_path=db_path)
+    try:
+        await session.add_items([{"role": "user", "content": "hello"}])
+        items = await session.get_items()
+        assert len(items) == 1
+        assert expanded.exists()
+    finally:
+        session.close()
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_session_expands_tilde_db_path(tmp_path, monkeypatch) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    db_path = "~/hermes_tilde_async.db"
+    expanded = Path(db_path).expanduser()
+    assert str(expanded).startswith(str(fake_home))
+
+    session = AsyncSQLiteSession("tilde-async", db_path=db_path)
+    try:
+        await session.add_items([{"role": "user", "content": "hello"}])
+        items = await session.get_items()
+        assert len(items) == 1
+        assert expanded.exists()
+    finally:
+        await session.close()


### PR DESCRIPTION
### Summary

`SQLiteSession` and `AsyncSQLiteSession` crashed on `~/...` db paths with `OperationalError`, because only the file-lock path was expanded. This normalizes `db_path` with `expanduser()` (except `:memory:`) so the lock and the connection agree.

### Test plan

- New `tests/memory/test_sqlite_db_path.py` covers both sessions with a fake `HOME` (failed before, passes now).
- Neighbors pass: `test_session.py`, `test_async_sqlite_session.py`, `test_advanced_sqlite_session.py` (223 passed).
- `ruff check` clean, `ruff format` applied.

### Issue number

Fixes #4942

### Checks

- [x] I've added new tests, if relevant
- [x] I've confirmed all verification steps pass
