### PR TITLE
fix(core): fall back to type name for nameless guardrail callables

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -10,7 +10,7 @@ from typing_extensions import TypeVar
 from .exceptions import UserError
 from .items import TResponseInputItem
 from .run_context import RunContextWrapper, TContext
-from .util._types import MaybeAwaitable
+from .util._types import MaybeAwaitable, _callable_name
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -106,7 +106,7 @@ class InputGuardrail(Generic[TContext]):
         if self.name:
             return self.name
 
-        return self.guardrail_function.__name__
+        return _callable_name(self.guardrail_function)
 
     async def run(
         self,
@@ -160,7 +160,7 @@ class OutputGuardrail(Generic[TContext]):
         if self.name:
             return self.name
 
-        return self.guardrail_function.__name__
+        return _callable_name(self.guardrail_function)
 
     async def run(
         self, context: RunContextWrapper[TContext], agent: Agent[Any], agent_output: Any
@@ -258,7 +258,7 @@ def input_guardrail(
         return InputGuardrail(
             guardrail_function=f,
             # If not set, guardrail name uses the function’s name by default.
-            name=name if name else f.__name__,
+            name=name if name else _callable_name(f),
             run_in_parallel=run_in_parallel,
         )
 
@@ -332,7 +332,7 @@ def output_guardrail(
         return OutputGuardrail(
             guardrail_function=f,
             # Guardrail name defaults to function's name when not specified (None).
-            name=name if name else f.__name__,
+            name=name if name else _callable_name(f),
         )
 
     if func is not None:

--- a/src/agents/tool_guardrails.py
+++ b/src/agents/tool_guardrails.py
@@ -9,7 +9,7 @@ from typing_extensions import TypedDict, TypeVar
 
 from .exceptions import UserError
 from .tool_context import ToolContext
-from .util._types import MaybeAwaitable
+from .util._types import MaybeAwaitable, _callable_name
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -165,7 +165,7 @@ class ToolInputGuardrail(Generic[TContext_co]):
     """
 
     def get_name(self) -> str:
-        return self.name or self.guardrail_function.__name__
+        return self.name or _callable_name(self.guardrail_function)
 
     async def run(self, data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
         if not callable(self.guardrail_function):
@@ -194,7 +194,7 @@ class ToolOutputGuardrail(Generic[TContext_co]):
     """
 
     def get_name(self) -> str:
-        return self.name or self.guardrail_function.__name__
+        return self.name or _callable_name(self.guardrail_function)
 
     async def run(self, data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
         if not callable(self.guardrail_function):
@@ -236,7 +236,7 @@ def tool_input_guardrail(
     """Decorator to create a ToolInputGuardrail from a function."""
 
     def decorator(f: _ToolInputFuncSync | _ToolInputFuncAsync) -> ToolInputGuardrail[Any]:
-        return ToolInputGuardrail(guardrail_function=f, name=name or f.__name__)
+        return ToolInputGuardrail(guardrail_function=f, name=name or _callable_name(f))
 
     if func is not None:
         return decorator(func)
@@ -272,7 +272,7 @@ def tool_output_guardrail(
     """Decorator to create a ToolOutputGuardrail from a function."""
 
     def decorator(f: _ToolOutputFuncSync | _ToolOutputFuncAsync) -> ToolOutputGuardrail[Any]:
-        return ToolOutputGuardrail(guardrail_function=f, name=name or f.__name__)
+        return ToolOutputGuardrail(guardrail_function=f, name=name or _callable_name(f))
 
     if func is not None:
         return decorator(func)

--- a/src/agents/util/_types.py
+++ b/src/agents/util/_types.py
@@ -1,7 +1,15 @@
-from collections.abc import Awaitable
-from typing import TypeAlias
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeAlias
 
 from typing_extensions import TypeVar
 
 T = TypeVar("T")
 MaybeAwaitable: TypeAlias = Awaitable[T] | T
+
+
+def _callable_name(func: Callable[..., Any]) -> str:
+    """Return a display name for any callable, including ones without __name__."""
+    name = getattr(func, "__name__", None)
+    if isinstance(name, str) and name:
+        return name
+    return type(func).__name__

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import time
 from typing import Any
 from unittest.mock import patch
@@ -2268,3 +2269,93 @@ async def test_output_guardrail_exception_reports_completed_results_streamed():
             pass
 
     assert _result_names(result.output_guardrail_results) == ["passes"]
+
+
+@pytest.mark.asyncio
+async def test_input_guardrail_name_falls_back_for_nameless_callables() -> None:
+    """Guardrails built from partials or callable instances still resolve a span name."""
+
+    def check(
+        context: RunContextWrapper[Any],
+        agent: Agent[Any],
+        input: str | list[TResponseInputItem],
+        threshold: int | None = None,
+    ) -> GuardrailFunctionOutput:
+        del context, agent, input, threshold
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    class Checker:
+        def __call__(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            input: str | list[TResponseInputItem],
+        ) -> GuardrailFunctionOutput:
+            del context, agent, input
+            return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    assert InputGuardrail(guardrail_function=check).get_name() == "check"
+    assert isinstance(
+        InputGuardrail(guardrail_function=functools.partial(check, threshold=1)).get_name(), str
+    )
+    assert isinstance(InputGuardrail(guardrail_function=Checker()).get_name(), str)
+    assert InputGuardrail(guardrail_function=Checker(), name="explicit").get_name() == "explicit"
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_name_falls_back_for_nameless_callables() -> None:
+    """Output guardrails built from nameless callables still resolve a span name."""
+
+    async def check(
+        context: RunContextWrapper[Any], agent: Agent[Any], output: Any
+    ) -> GuardrailFunctionOutput:
+        del context, agent, output
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    assert OutputGuardrail(guardrail_function=check).get_name() == "check"
+    assert isinstance(OutputGuardrail(guardrail_function=functools.partial(check)).get_name(), str)
+
+
+@pytest.mark.asyncio
+async def test_guardrail_decorators_accept_nameless_callables() -> None:
+    """The guardrail decorators fall back to a type-based name instead of raising."""
+
+    def check(
+        context: RunContextWrapper[Any],
+        agent: Agent[Any],
+        input: str | list[TResponseInputItem],
+        threshold: int | None = None,
+    ) -> GuardrailFunctionOutput:
+        del context, agent, input, threshold
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    assert isinstance(input_guardrail(functools.partial(check, threshold=1)).get_name(), str)
+    assert isinstance(output_guardrail(functools.partial(check)).get_name(), str)
+
+
+@pytest.mark.asyncio
+async def test_run_with_partial_input_guardrail_succeeds() -> None:
+    """A run using a partial guardrail function completes instead of raising AttributeError."""
+
+    def check(
+        context: RunContextWrapper[Any],
+        agent: Agent[Any],
+        input: str | list[TResponseInputItem],
+        threshold: int | None = None,
+    ) -> GuardrailFunctionOutput:
+        del context, agent, input, threshold
+        return GuardrailFunctionOutput(output_info="partial_ok", tripwire_triggered=False)
+
+    model = ScriptedModel()
+    agent = Agent(
+        name="partial_guardrail_agent",
+        instructions="Reply with 'hello'",
+        input_guardrails=[InputGuardrail(guardrail_function=functools.partial(check, threshold=1))],
+        model=model,
+    )
+    model.enqueue([get_text_message("hello")])
+
+    result = await Runner.run(agent, "test input")
+
+    assert result.final_output == "hello"
+    assert result.input_guardrail_results[0].output.output_info == "partial_ok"

--- a/tests/test_tool_guardrails.py
+++ b/tests/test_tool_guardrails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from typing import Any
 
 import pytest
@@ -656,3 +657,25 @@ if __name__ == "__main__":
         print("✅ All basic tests passed!")
 
     asyncio.run(main())
+
+
+def test_tool_guardrail_names_fall_back_for_nameless_callables() -> None:
+    """Tool guardrails built from nameless callables still resolve a span name."""
+
+    def check_input(data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        del data
+        return ToolGuardrailFunctionOutput.allow(output_info=None)
+
+    def check_output(data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+        del data
+        return ToolGuardrailFunctionOutput.allow(output_info=None)
+
+    assert ToolInputGuardrail(guardrail_function=check_input).get_name() == "check_input"
+    assert isinstance(
+        ToolInputGuardrail(guardrail_function=functools.partial(check_input)).get_name(), str
+    )
+    assert isinstance(
+        ToolOutputGuardrail(guardrail_function=functools.partial(check_output)).get_name(), str
+    )
+    assert isinstance(tool_input_guardrail(functools.partial(check_input)).get_name(), str)
+    assert isinstance(tool_output_guardrail(functools.partial(check_output)).get_name(), str)


### PR DESCRIPTION
Fixes #4944.

Guardrail span naming assumed every guardrail function has `__name__`, so a `functools.partial` or callable instance crashed the run with `AttributeError` before the guardrail even ran. This adds a small shared helper that falls back to the callable type name (same approach function tools already use) and applies it to all four guardrail classes plus the four guardrail decorators. Plain functions and explicit names behave exactly as before.

Test plan:
- Added 5 tests (4 in `tests/test_guardrails.py`, 1 in `tests/test_tool_guardrails.py`) covering `get_name`, the decorators, and an end-to-end `Runner.run` with a partial guardrail. All fail on the parent commit with `AttributeError` and pass with this change.
- `tests/test_guardrails.py` + `tests/test_tool_guardrails.py`: 87 passed.
- Neighbors `test_output_guardrail_cancellation.py`, `test_runner_guardrail_resume.py`, `test_stream_input_guardrail_timing.py`: 16 passed.
- `ruff check` and `ruff format --check` clean on all touched files.