### PR TITLE
fix(core): fall back to type name when guardrail function has no __name__

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -106,7 +106,7 @@ class InputGuardrail(Generic[TContext]):
         if self.name:
             return self.name
 
-        return self.guardrail_function.__name__
+        return getattr(self.guardrail_function, "__name__", type(self.guardrail_function).__name__)
 
     async def run(
         self,
@@ -160,7 +160,7 @@ class OutputGuardrail(Generic[TContext]):
         if self.name:
             return self.name
 
-        return self.guardrail_function.__name__
+        return getattr(self.guardrail_function, "__name__", type(self.guardrail_function).__name__)
 
     async def run(
         self, context: RunContextWrapper[TContext], agent: Agent[Any], agent_output: Any
@@ -258,7 +258,7 @@ def input_guardrail(
         return InputGuardrail(
             guardrail_function=f,
             # If not set, guardrail name uses the function’s name by default.
-            name=name if name else f.__name__,
+            name=name if name else getattr(f, "__name__", type(f).__name__),
             run_in_parallel=run_in_parallel,
         )
 
@@ -332,7 +332,7 @@ def output_guardrail(
         return OutputGuardrail(
             guardrail_function=f,
             # Guardrail name defaults to function's name when not specified (None).
-            name=name if name else f.__name__,
+            name=name if name else getattr(f, "__name__", type(f).__name__),
         )
 
     if func is not None:

--- a/src/agents/tool_guardrails.py
+++ b/src/agents/tool_guardrails.py
@@ -165,7 +165,9 @@ class ToolInputGuardrail(Generic[TContext_co]):
     """
 
     def get_name(self) -> str:
-        return self.name or self.guardrail_function.__name__
+        if self.name:
+            return self.name
+        return getattr(self.guardrail_function, "__name__", type(self.guardrail_function).__name__)
 
     async def run(self, data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
         if not callable(self.guardrail_function):
@@ -194,7 +196,9 @@ class ToolOutputGuardrail(Generic[TContext_co]):
     """
 
     def get_name(self) -> str:
-        return self.name or self.guardrail_function.__name__
+        if self.name:
+            return self.name
+        return getattr(self.guardrail_function, "__name__", type(self.guardrail_function).__name__)
 
     async def run(self, data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
         if not callable(self.guardrail_function):
@@ -236,7 +240,9 @@ def tool_input_guardrail(
     """Decorator to create a ToolInputGuardrail from a function."""
 
     def decorator(f: _ToolInputFuncSync | _ToolInputFuncAsync) -> ToolInputGuardrail[Any]:
-        return ToolInputGuardrail(guardrail_function=f, name=name or f.__name__)
+        return ToolInputGuardrail(
+            guardrail_function=f, name=name or getattr(f, "__name__", type(f).__name__)
+        )
 
     if func is not None:
         return decorator(func)
@@ -272,7 +278,9 @@ def tool_output_guardrail(
     """Decorator to create a ToolOutputGuardrail from a function."""
 
     def decorator(f: _ToolOutputFuncSync | _ToolOutputFuncAsync) -> ToolOutputGuardrail[Any]:
-        return ToolOutputGuardrail(guardrail_function=f, name=name or f.__name__)
+        return ToolOutputGuardrail(
+            guardrail_function=f, name=name or getattr(f, "__name__", type(f).__name__)
+        )
 
     if func is not None:
         return decorator(func)

--- a/tests/realtime/test_session_guardrails.py
+++ b/tests/realtime/test_session_guardrails.py
@@ -158,7 +158,10 @@ class TestGuardrailFunctionality:
         ]
         assert len(records) == 1
         context = records[0].__dict__["openai_agents_diagnostic_context"]
-        assert context["guardrail_type"].endswith("._FailingGuardrailCallable")
+        # get_name() now falls back to the callable's type name instead of raising, so the
+        # diagnostic context carries a guardrail_name and never reaches the guardrail_type
+        # fallback branch.
+        assert context["guardrail_name"] == "_FailingGuardrailCallable"
         assert records[0].exc_info is not None
 
     @pytest.mark.asyncio

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import time
 from typing import Any
 from unittest.mock import patch
@@ -44,6 +45,96 @@ def get_sync_guardrail(triggers: bool, output_info: Any | None = None):
         )
 
     return sync_guardrail
+
+
+def _partial_input_guardrail_target(
+    context: RunContextWrapper[Any],
+    agent: Agent[Any],
+    input: str | list[TResponseInputItem],
+    threshold: int | None = None,
+) -> GuardrailFunctionOutput:
+    return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+
+def _partial_output_guardrail_target(
+    context: RunContextWrapper[Any],
+    agent: Agent[Any],
+    agent_output: Any,
+    threshold: int | None = None,
+) -> GuardrailFunctionOutput:
+    return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+
+class _CallableInputGuardrail:
+    def __call__(
+        self,
+        context: RunContextWrapper[Any],
+        agent: Agent[Any],
+        input: str | list[TResponseInputItem],
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+
+class _CallableOutputGuardrail:
+    def __call__(
+        self, context: RunContextWrapper[Any], agent: Agent[Any], agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+
+def test_input_guardrail_get_name_with_functools_partial() -> None:
+    guardrail = InputGuardrail(
+        guardrail_function=functools.partial(_partial_input_guardrail_target, threshold=1)
+    )
+    assert guardrail.get_name() == "partial"
+
+
+def test_input_guardrail_get_name_with_callable_instance() -> None:
+    guardrail = InputGuardrail(guardrail_function=_CallableInputGuardrail())
+    assert guardrail.get_name() == "_CallableInputGuardrail"
+
+
+def test_output_guardrail_get_name_with_functools_partial() -> None:
+    guardrail = OutputGuardrail(
+        guardrail_function=functools.partial(_partial_output_guardrail_target, threshold=1)
+    )
+    assert guardrail.get_name() == "partial"
+
+
+def test_output_guardrail_get_name_with_callable_instance() -> None:
+    guardrail = OutputGuardrail(guardrail_function=_CallableOutputGuardrail())
+    assert guardrail.get_name() == "_CallableOutputGuardrail"
+
+
+def test_input_guardrail_decorator_with_functools_partial() -> None:
+    guardrail = input_guardrail(functools.partial(_partial_input_guardrail_target, threshold=1))
+    assert guardrail.get_name() == "partial"
+
+
+def test_output_guardrail_decorator_with_functools_partial() -> None:
+    guardrail = output_guardrail(functools.partial(_partial_output_guardrail_target, threshold=1))
+    assert guardrail.get_name() == "partial"
+
+
+@pytest.mark.asyncio
+async def test_run_with_functools_partial_input_guardrail_does_not_crash() -> None:
+    model = ScriptedModel()
+    agent = Agent(
+        name="test_agent",
+        instructions="Reply with 'hello'",
+        input_guardrails=[
+            InputGuardrail(
+                guardrail_function=functools.partial(_partial_input_guardrail_target, threshold=1)
+            )
+        ],
+        model=model,
+    )
+    model.enqueue([get_text_message("hello")])
+
+    result = await Runner.run(agent, "test input")
+
+    assert result.final_output is not None
+    assert result.input_guardrail_results[0].guardrail.get_name() == "partial"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_guardrails.py
+++ b/tests/test_tool_guardrails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from typing import Any
 
 import pytest
@@ -58,6 +59,66 @@ def get_async_input_guardrail(triggers: bool, output_info: Any | None = None):
             return ToolGuardrailFunctionOutput.allow(output_info=output_info)
 
     return async_guardrail
+
+
+def _partial_tool_input_guardrail_target(
+    data: ToolInputGuardrailData, threshold: int | None = None
+) -> ToolGuardrailFunctionOutput:
+    return ToolGuardrailFunctionOutput.allow()
+
+
+def _partial_tool_output_guardrail_target(
+    data: ToolOutputGuardrailData, threshold: int | None = None
+) -> ToolGuardrailFunctionOutput:
+    return ToolGuardrailFunctionOutput.allow()
+
+
+class _CallableToolInputGuardrail:
+    def __call__(self, data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow()
+
+
+class _CallableToolOutputGuardrail:
+    def __call__(self, data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow()
+
+
+def test_tool_input_guardrail_get_name_with_functools_partial() -> None:
+    guardrail = ToolInputGuardrail(
+        guardrail_function=functools.partial(_partial_tool_input_guardrail_target, threshold=1)
+    )
+    assert guardrail.get_name() == "partial"
+
+
+def test_tool_input_guardrail_get_name_with_callable_instance() -> None:
+    guardrail = ToolInputGuardrail(guardrail_function=_CallableToolInputGuardrail())
+    assert guardrail.get_name() == "_CallableToolInputGuardrail"
+
+
+def test_tool_output_guardrail_get_name_with_functools_partial() -> None:
+    guardrail = ToolOutputGuardrail(
+        guardrail_function=functools.partial(_partial_tool_output_guardrail_target, threshold=1)
+    )
+    assert guardrail.get_name() == "partial"
+
+
+def test_tool_output_guardrail_get_name_with_callable_instance() -> None:
+    guardrail = ToolOutputGuardrail(guardrail_function=_CallableToolOutputGuardrail())
+    assert guardrail.get_name() == "_CallableToolOutputGuardrail"
+
+
+def test_tool_input_guardrail_decorator_with_functools_partial() -> None:
+    guardrail = tool_input_guardrail(
+        functools.partial(_partial_tool_input_guardrail_target, threshold=1)
+    )
+    assert guardrail.get_name() == "partial"
+
+
+def test_tool_output_guardrail_decorator_with_functools_partial() -> None:
+    guardrail = tool_output_guardrail(
+        functools.partial(_partial_tool_output_guardrail_target, threshold=1)
+    )
+    assert guardrail.get_name() == "partial"
 
 
 def get_sync_output_guardrail(triggers: bool, output_info: Any | None = None):


### PR DESCRIPTION
### Summary

Passing a `functools.partial` or a plain callable instance as a guardrail function crashes the run with `AttributeError: 'functools.partial' object has no attribute '__name__'`. `get_name()` is evaluated on the tracing span path before the guardrail runs (`with guardrail_span(guardrail.get_name())` in `src/agents/run_internal/guardrails.py:37` and `:49`), so the run dies before the guardrail is ever evaluated.

I verified all four surfaces the issue names, with different call sites for each:

- `InputGuardrail.get_name()` (`src/agents/guardrail.py:105-109`) and `OutputGuardrail.get_name()` (`:159-163`) had no fallback and are called before `guardrail.run()` at `src/agents/run_internal/guardrails.py:37` and `:49`. Reproduced end to end with `Runner.run()`.
- The `input_guardrail`/`output_guardrail` decorators (`src/agents/guardrail.py:261`, `:335`) accessed `f.__name__` directly, so calling them on a partial or callable instance crashed at construction time, not at run time.
- `ToolInputGuardrail.get_name()`/`ToolOutputGuardrail.get_name()` (`src/agents/tool_guardrails.py:168`, `:197` before this change) are not on the tool-call hot path, but they are called during run-state serialization (`src/agents/run_state.py:2891`, `_serialize_tool_guardrail_results`), which round-trips through `RunState` persistence, and its existing `hasattr(result.guardrail, "get_name")` guard doesn't help since the guardrail wrapper always has `get_name`.
- The `tool_input_guardrail`/`tool_output_guardrail` decorators (`src/agents/tool_guardrails.py:239`, `:275` before this change) had the identical construction-time crash.

### What changed

Applied the same `getattr(fn, "__name__", type(fn).__name__)` fallback used elsewhere in this codebase (`src/agents/tool.py:2521`, `fallback_name = type(func).__name__`, used by `function_tool()` for callable instances; also `src/agents/run_internal/tool_use_tracker.py` and `src/agents/agent_output.py`) to all six sites above: both `get_name()` methods on `InputGuardrail`/`OutputGuardrail`, both decorators in `src/agents/guardrail.py`, both `get_name()` methods on `ToolInputGuardrail`/`ToolOutputGuardrail`, and both decorators in `src/agents/tool_guardrails.py`.

One existing test, `tests/realtime/test_session_guardrails.py::test_output_guardrail_failure_tolerates_missing_callable_name`, asserted the old broken behavior (that `get_name()` raises for a nameless callable, forcing `_guardrail_diagnostic_extra`'s except-branch fallback). Updated its assertion to match the corrected behavior: `get_name()` now succeeds and returns the type name directly, so the diagnostic context carries `guardrail_name` instead of `guardrail_type`.

### Test plan

RED (against the unfixed code, on branch before the fix): added 13 new tests reproducing the crash and ran them, all failing with the exact reported `AttributeError`:

```
uv run pytest tests/test_guardrails.py tests/test_tool_guardrails.py -k "functools_partial or callable_instance" -v
```
7 failed in test_guardrails.py, 6 failed in test_tool_guardrails.py, all `AttributeError: '...' object has no attribute '__name__'`, including `test_run_with_functools_partial_input_guardrail_does_not_crash` failing inside `Runner.run()` at `run_internal/guardrails.py:37`, matching the issue's own repro.

GREEN (after the fix):
```
uv run pytest tests/test_guardrails.py tests/test_tool_guardrails.py -k "functools_partial or callable_instance" -v
```
`13 passed`

Full suite:
```
make tests
```
`9613 passed, 29 skipped` (parallel) and `77 passed, 4 skipped` (serial), including the one existing test I updated.

Lint and types:
```
make lint
make mypy
```
Both clean. Also ran the repo's own `.agents/skills/code-change-verification/scripts/run.sh`, which reported "all commands passed."

### Issue number

Fixes #4944

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
