### PR TITLE
fix(sandbox): reject archives needing unavailable symlink privilege

### DIFF
--- a/src/agents/sandbox/util/tar_utils.py
+++ b/src/agents/sandbox/util/tar_utils.py
@@ -365,6 +365,70 @@ def validate_tar_bytes(
         raise UnsafeTarMemberError(member="<tar>", reason="invalid tar stream") from e
 
 
+def _reject_symlink_leaves_over_existing_dirs(
+    members: list[tarfile.TarInfo], *, root: Path
+) -> None:
+    """Reject symlink members whose destination is an existing directory.
+
+    ``_prepare_replaceable_leaf`` already raises this, but only once the symlink
+    pass reaches that member - after :func:`_raise_if_symlinks_unsupported` has
+    run. This read-only pre-scan keeps the archive-level diagnostic ahead of the
+    host-capability one, so a host that cannot create symlinks still reports why
+    the archive is unsafe rather than masking it. It writes nothing.
+    """
+
+    for member in members:
+        if not member.issym():
+            continue
+        rel_path = safe_tar_member_rel_path(member, allow_symlinks=True)
+        if rel_path is None:
+            continue
+        dest = root / rel_path
+        if dest.is_dir() and not dest.is_symlink():
+            raise UnsafeTarMemberError(
+                member=member.name,
+                reason=f"destination directory already exists: {rel_path.as_posix()}",
+            )
+
+
+def _raise_if_symlinks_unsupported(members: list[tarfile.TarInfo], *, root: Path) -> None:
+    """Fail before anything is written when the archive needs symlinks this process
+    cannot create.
+
+    A non-elevated Windows process without Developer Mode enabled cannot call
+    ``os.symlink``: it raises ``OSError`` with ``winerror == 1314`` ("A required
+    privilege is not held by the client"). Symlink members are deliberately the last
+    thing ``safe_extract_tarfile`` writes, so probing for this once up front - before
+    any directory or file has been restored - means a host that cannot satisfy the
+    archive rejects it outright instead of aborting partway through extraction.
+    """
+
+    if os.name != "nt":
+        # The privilege this guards against is Windows-only, and the probe costs a
+        # temp directory plus a symlink on every extraction of a symlink-bearing
+        # archive (venv-style symlinks are the common case here).
+        return
+    if not any(member.issym() for member in members):
+        return
+
+    # Probe inside *root* rather than the system temp directory: the privilege is
+    # process-wide, but a probe on a different filesystem could pass while the real
+    # extraction target rejects symlinks, reintroducing the partial state this
+    # guards against.
+    with tempfile.TemporaryDirectory(dir=root, prefix=".agents-symlink-probe-") as probe_dir:
+        try:
+            os.symlink("probe-target", Path(probe_dir) / "probe-link")
+        except OSError as exc:
+            if getattr(exc, "winerror", None) != 1314:
+                raise
+            raise OSError(
+                "cannot extract archive: it contains a symlink, and this process "
+                "cannot create filesystem symlinks. On Windows, enable Developer "
+                "Mode (Settings > Privacy & security > For developers) or run "
+                "with an elevated (Administrator) process. No files were extracted."
+            ) from exc
+
+
 def safe_extract_tarfile(
     tar: tarfile.TarFile,
     *,
@@ -382,7 +446,11 @@ def safe_extract_tarfile(
     - archive members nested underneath archive symlink members
 
     It also ensures extraction doesn't traverse through existing symlink parents
-    and creates archive symlinks only after directories and regular files.
+    and creates archive symlinks only after directories and regular files. If the
+    archive contains symlink members that this process cannot create (for example,
+    a non-elevated Windows host without Developer Mode), extraction is rejected
+    up front, before any directory or file is written, rather than aborting after
+    partially extracting the archive.
     """
 
     root.mkdir(parents=True, exist_ok=True)
@@ -393,6 +461,11 @@ def safe_extract_tarfile(
         tar,
         allow_external_symlink_targets=allow_external_symlink_targets,
     )
+    # An error about the ARCHIVE outranks one about the HOST: without this, a
+    # symlink-incapable host reports "cannot create filesystem symlinks" for an
+    # archive that is itself unsafe, hiding the more specific diagnostic.
+    _reject_symlink_leaves_over_existing_dirs(members, root=root_resolved)
+    _raise_if_symlinks_unsupported(members, root=root)
 
     def _prepare_replaceable_leaf(*, dest: Path, rel_path: Path, name: str) -> None:
         _ensure_no_symlink_parents(root=root_resolved, dest=dest, check_leaf=False)

--- a/tests/sandbox/test_tar_utils.py
+++ b/tests/sandbox/test_tar_utils.py
@@ -285,6 +285,86 @@ def test_safe_extract_tarfile_rejects_existing_leaf_directory_for_symlink(
         _safe_extract(raw, tmp_path)
 
 
+def _raise_symlink_privilege_error(*_args: object, **_kwargs: object) -> None:
+    exc = OSError(22, "A required privilege is not held by the client")
+    exc.winerror = 1314  # type: ignore[attr-defined]
+    raise exc
+
+
+def test_unsafe_archive_error_outranks_symlink_privilege_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unsafe *archive* must be reported as unsafe even on a host that cannot
+    create symlinks, rather than being masked by the capability probe."""
+
+    monkeypatch.setattr(os, "symlink", _raise_symlink_privilege_error)
+    (tmp_path / "link.txt").mkdir()
+    raw = _tar_bytes(_symlink("link.txt", "target.txt"))
+
+    with pytest.raises(UnsafeTarMemberError, match="destination directory already exists"):
+        _safe_extract(raw, tmp_path)
+
+
+def test_safe_extract_tarfile_rejects_archive_up_front_when_symlinks_unsupported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulates a non-elevated Windows host: extraction is rejected before any
+    directory or file is written, rather than aborting after partial extraction."""
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(os, "symlink", _raise_symlink_privilege_error)
+
+    raw = _tar_bytes(
+        _dir("."),
+        _dir("./pkg"),
+        _file("./pkg/main.py", b"print('hi')\n"),
+        _symlink("./pkg/link.txt", "main.py"),
+    )
+
+    with pytest.raises(OSError, match="cannot extract archive: it contains a symlink"):
+        _safe_extract(raw, tmp_path)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_safe_extract_tarfile_ignores_symlink_incapability_without_symlink_members(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An archive with no symlink members never probes symlink support, so it
+    extracts normally even on a host that cannot create symlinks."""
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(os, "symlink", _raise_symlink_privilege_error)
+
+    raw = _tar_bytes(_dir("."), _file("./main.py", b"print('hi')\n"))
+
+    _safe_extract(raw, tmp_path)
+
+    assert (tmp_path / "main.py").read_bytes() == b"print('hi')\n"
+
+
+def test_safe_extract_tarfile_reraises_unrelated_symlink_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the specific non-elevated-Windows privilege error is translated into
+    the actionable message; any other OSError from os.symlink propagates as-is."""
+
+    def _raise_other_error(*_args: object, **_kwargs: object) -> None:
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(os, "symlink", _raise_other_error)
+
+    raw = _tar_bytes(_symlink("link.txt", "target.txt"))
+
+    with pytest.raises(OSError, match="No space left on device"):
+        _safe_extract(raw, tmp_path)
+
+
 def test_validate_tar_bytes_rejects_members_under_archive_symlink() -> None:
     raw = _tar_bytes(
         _symlink("escape", "/tmp/outside"),


### PR DESCRIPTION
**Summary**

`safe_extract_tarfile()` creates symlink members last, but `os.symlink()` was unguarded: on a non-elevated Windows host without Developer Mode it raises `OSError: [WinError 1314]` after files are already written. This adds a Windows-only capability probe before any member is written, so an archive whose symlinks this process cannot create is rejected with nothing written. An unsafe-archive error still outranks it, so such a host reports why the archive is unsafe instead of masking it. Archives without symlinks are unaffected; symlink creation still runs last and every containment check is untouched.

**Test plan**

Non-elevated Windows 11, Developer Mode off. Before: `WinError 1314` mid-extraction, files already on disk. After: rejected up front, nothing written.

- `pytest tests/sandbox/test_tar_utils.py`: 4 new tests pass. Failing set identical to base by node id, not count: 7 before, 7 after, none added or fixed. Those 7 create real symlinks, which this host cannot.
- `ruff format --check`, `ruff check`, `mypy src`, `mypy --platform win32 src`: pass

**Issue number**

Fixes #4852 (product half only). The test-harness half landed in #4853.

**Checks**

- [ ] `run.sh` not run: it is POSIX-only (`os.setsid`). Ran its ruff, mypy and pytest steps directly; `make tests` not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
