### PR TITLE
fix guardrails: support partial callables

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -106,7 +106,7 @@ class InputGuardrail(Generic[TContext]):
         if self.name:
             return self.name
 
-        return self.guardrail_function.__name__
+        return getattr(self.guardrail_function, "__name__", type(self.guardrail_function).__name__)
 
     async def run(
         self,
@@ -160,7 +160,7 @@ class OutputGuardrail(Generic[TContext]):
         if self.name:
             return self.name
 
-        return self.guardrail_function.__name__
+        return getattr(self.guardrail_function, "__name__", type(self.guardrail_function).__name__)
 
     async def run(
         self, context: RunContextWrapper[TContext], agent: Agent[Any], agent_output: Any
@@ -258,7 +258,7 @@ def input_guardrail(
         return InputGuardrail(
             guardrail_function=f,
             # If not set, guardrail name uses the function’s name by default.
-            name=name if name else f.__name__,
+            name=name if name else getattr(f, "__name__", type(f).__name__),
             run_in_parallel=run_in_parallel,
         )
 
@@ -332,7 +332,7 @@ def output_guardrail(
         return OutputGuardrail(
             guardrail_function=f,
             # Guardrail name defaults to function's name when not specified (None).
-            name=name if name else f.__name__,
+            name=name if name else getattr(f, "__name__", type(f).__name__),
         )
 
     if func is not None:

--- a/src/agents/tool_guardrails.py
+++ b/src/agents/tool_guardrails.py
@@ -165,7 +165,9 @@ class ToolInputGuardrail(Generic[TContext_co]):
     """
 
     def get_name(self) -> str:
-        return self.name or self.guardrail_function.__name__
+        return self.name or getattr(
+            self.guardrail_function, "__name__", type(self.guardrail_function).__name__
+        )
 
     async def run(self, data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
         if not callable(self.guardrail_function):
@@ -194,7 +196,9 @@ class ToolOutputGuardrail(Generic[TContext_co]):
     """
 
     def get_name(self) -> str:
-        return self.name or self.guardrail_function.__name__
+        return self.name or getattr(
+            self.guardrail_function, "__name__", type(self.guardrail_function).__name__
+        )
 
     async def run(self, data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
         if not callable(self.guardrail_function):
@@ -236,7 +240,9 @@ def tool_input_guardrail(
     """Decorator to create a ToolInputGuardrail from a function."""
 
     def decorator(f: _ToolInputFuncSync | _ToolInputFuncAsync) -> ToolInputGuardrail[Any]:
-        return ToolInputGuardrail(guardrail_function=f, name=name or f.__name__)
+        return ToolInputGuardrail(
+            guardrail_function=f, name=name or getattr(f, "__name__", type(f).__name__)
+        )
 
     if func is not None:
         return decorator(func)
@@ -272,7 +278,9 @@ def tool_output_guardrail(
     """Decorator to create a ToolOutputGuardrail from a function."""
 
     def decorator(f: _ToolOutputFuncSync | _ToolOutputFuncAsync) -> ToolOutputGuardrail[Any]:
-        return ToolOutputGuardrail(guardrail_function=f, name=name or f.__name__)
+        return ToolOutputGuardrail(
+            guardrail_function=f, name=name or getattr(f, "__name__", type(f).__name__)
+        )
 
     if func is not None:
         return decorator(func)

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import time
 from typing import Any
 from unittest.mock import patch
@@ -347,6 +348,54 @@ async def test_input_guardrail_decorator_with_name_and_run_in_parallel():
 
     assert named_blocking_guardrail.get_name() == "custom_name"
     assert named_blocking_guardrail.run_in_parallel is False
+
+
+@pytest.mark.asyncio
+async def test_guardrail_names_fall_back_for_partials():
+    def check(
+        context: RunContextWrapper[Any],
+        agent: Agent[Any],
+        input: str | list[TResponseInputItem],
+        threshold: int,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    def check_output(
+        context: RunContextWrapper[Any], agent: Agent[Any], agent_output: Any, threshold: int
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    input_guardrail = InputGuardrail(guardrail_function=functools.partial(check, threshold=1))
+    output_guardrail = OutputGuardrail(
+        guardrail_function=functools.partial(check_output, threshold=1)
+    )
+
+    assert input_guardrail.get_name() == "partial"
+    assert output_guardrail.get_name() == "partial"
+
+
+@pytest.mark.asyncio
+async def test_runner_accepts_partial_input_guardrail():
+    def check(
+        context: RunContextWrapper[Any],
+        agent: Agent[Any],
+        input: str | list[TResponseInputItem],
+        threshold: int,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    model = ScriptedModel()
+    agent = Agent(
+        name="partial_guardrail_agent",
+        instructions="Reply with 'hello'",
+        input_guardrails=[InputGuardrail(guardrail_function=functools.partial(check, threshold=1))],
+        model=model,
+    )
+    model.enqueue([get_text_message("hello")])
+
+    result = await Runner.run(agent, "hi")
+
+    assert result.final_output == "hello"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_guardrails.py
+++ b/tests/test_tool_guardrails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from typing import Any
 
 import pytest
@@ -82,6 +83,18 @@ def get_async_output_guardrail(triggers: bool, output_info: Any | None = None):
             return ToolGuardrailFunctionOutput.allow(output_info=output_info)
 
     return async_guardrail
+
+
+def test_guardrail_names_fall_back_for_partials():
+    input_guardrail = ToolInputGuardrail(
+        guardrail_function=functools.partial(get_sync_input_guardrail, triggers=False)
+    )
+    output_guardrail = ToolOutputGuardrail(
+        guardrail_function=functools.partial(get_sync_output_guardrail, triggers=False)
+    )
+
+    assert input_guardrail.get_name() == "partial"
+    assert output_guardrail.get_name() == "partial"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #4944.

`InputGuardrail`, `OutputGuardrail`, `ToolInputGuardrail`, and `ToolOutputGuardrail` assumed their callable always had `__name__`. That made `functools.partial` and callable instances crash before the guardrail could run.

Guardrail names now fall back to the callable type name, matching the existing function-tool behavior. Tests cover both direct name lookup and a real `Runner.run()` call with a partial input guardrail.