### PR TITLE
fix(core): preserve Field descriptions on variadic tool parameters

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -436,9 +436,12 @@ def function_schema(
         value_ann = ann
         if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
             field_info = _extract_field_info_from_metadata(param_metadata.get(name, ()))
-            if field_info is not None and field_info.metadata:
-                # Constraints apply to each value, not the collected container or its defaults.
-                value_ann = Annotated[(ann, *cast(Any, field_info).metadata)]
+            if field_info is not None:
+                if field_info.metadata:
+                    # Constraints apply to each value, not the collected container or its defaults.
+                    value_ann = Annotated[(ann, *cast(Any, field_info).metadata)]
+                if field_description is None:
+                    field_description = field_info.description
 
         # Handle different parameter kinds
         if param.kind == param.VAR_POSITIONAL:

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -636,6 +636,58 @@ def test_variadic_field_constraints_do_not_bypass_fixed_tuple_rejection():
         function_schema(func)
 
 
+def _var_positional_field_description(
+    *scores: Annotated[int, Field(description="A score to record.", ge=0, le=10)],
+) -> int:
+    return sum(scores)
+
+
+def _var_keyword_field_description(
+    **scores: Annotated[int, Field(description="A score to record.", ge=0, le=10)],
+) -> int:
+    return sum(scores.values())
+
+
+@pytest.mark.parametrize(
+    "func, strict, container_type, value_key",
+    [
+        (_var_positional_field_description, True, "array", "items"),
+        (_var_keyword_field_description, False, "object", "additionalProperties"),
+    ],
+)
+def test_variadic_field_description_in_schema(func, strict, container_type, value_key):
+    fs = function_schema(func, strict_json_schema=strict)
+    scores = fs.params_json_schema["properties"]["scores"]
+
+    assert scores["description"] == "A score to record."
+    assert scores["type"] == container_type
+    assert scores[value_key] == {"type": "integer", "minimum": 0, "maximum": 10}
+    assert "description" not in scores[value_key]
+
+
+def test_variadic_field_description_yields_to_docstring():
+    def func(*scores: Annotated[int, Field(description="From the field.")]) -> int:
+        """Sum the scores.
+
+        Args:
+            scores: From the docstring.
+        """
+        return sum(scores)
+
+    fs = function_schema(func, strict_json_schema=False)
+    assert fs.params_json_schema["properties"]["scores"]["description"] == "From the docstring."
+
+
+def test_variadic_field_description_yields_to_annotated_string():
+    def func(
+        *scores: Annotated[int, Field(description="From the field."), "From the string."],
+    ) -> int:
+        return sum(scores)
+
+    fs = function_schema(func, strict_json_schema=False)
+    assert fs.params_json_schema["properties"]["scores"]["description"] == "From the string."
+
+
 def test_schema_with_mapping_raises_strict_mode_error():
     """A mapping type is not allowed in strict mode. Same for dicts. Ensure we raise a UserError."""
 


### PR DESCRIPTION
### Summary

This pull request fixes lost Pydantic `Field` descriptions on variadic tool parameters.

`*scores: Annotated[int, Field(description="Exam scores", ge=0, le=100)]` advertises the constraints on each collected value but drops the description, so the model is shown an undocumented array argument. The same applies to values collected through `**kwargs`. Descriptions already reach variadic parameters through docstrings (#3956) and through an annotated string, leaving `Field(description=...)` as the one documented spelling that still loses them.

A `Field()` inside `Annotated` splits into attributes such as `description` and constraints collected as metadata. #4739 routed the metadata half to each collected value; this carries the description half to the parameter the schema advertises. It applies only when neither a docstring nor an annotated string supplies a description, so the existing precedence is unchanged, and reading only the description keeps the container's `default_factory` and the value-level constraint placement #4739 established. Extending the shared `_extract_description_from_metadata` helper would be broader than the need: it feeds every parameter kind and would also reorder precedence between a `Field(description=...)` and a sibling string for ordinary parameters.

### Test plan

- `test_variadic_field_description_in_schema` covers `*args` and `**kwargs` under strict and non-strict schemas, asserting the description lands on the parameter while the constraints from the same `Field(...)` stay on each collected value. Both cases fail on `main` with `KeyError: 'description'`.
- Two precedence tests pin that a docstring and an annotated string still take priority.
- `make format`, `make lint`, `make typecheck` and `uv run mypy --platform win32 src` are clean.
- `.agents/skills/code-change-verification/scripts/run.sh` does not complete in my environment: 14 tests in `tests/test_code_change_verification_runner.py` fail with `Timed out waiting for a controlled process transition`. They reproduce identically on unmodified `main` here and are unrelated to this change. Excluding that file, the suite reports 9673 passed, 32 skipped.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
