### PR TITLE
fix(core): select built-in shell and apply_patch tools by their own type

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1968,8 +1968,7 @@ class Converter:
         if any(handoff.tool_name == tool_choice for handoff in handoffs or ()):
             return False
         return not any(
-            isinstance(tool, FunctionTool | CustomTool) and tool.name == tool_choice
-            for tool in tools or ()
+            isinstance(tool, FunctionTool) and tool.name == tool_choice for tool in tools or ()
         )
 
     @classmethod

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1829,6 +1829,14 @@ class Converter:
             return {
                 "type": "code_interpreter",
             }
+        elif tool_choice == "shell" and cls._has_shell_tool(tools):
+            return {
+                "type": "shell",
+            }
+        elif tool_choice == "apply_patch" and cls._has_apply_patch_tool(tools):
+            return {
+                "type": "apply_patch",
+            }
         elif tool_choice == "mcp":
             # Note that this is still here for backwards compatibility,
             # but migrating to MCPToolChoice is recommended.
@@ -1940,6 +1948,14 @@ class Converter:
                 "tools on the OpenAI Responses API. Use `auto`, `required`, `none`, or load "
                 "the tool via ToolSearchTool() first."
             )
+
+    @classmethod
+    def _has_shell_tool(cls, tools: Sequence[Tool] | None) -> bool:
+        return any(isinstance(tool, ShellTool) for tool in tools or ())
+
+    @classmethod
+    def _has_apply_patch_tool(cls, tools: Sequence[Tool] | None) -> bool:
+        return any(isinstance(tool, ApplyPatchTool) for tool in tools or ())
 
     @classmethod
     def _has_computer_tool(cls, tools: Sequence[Tool] | None) -> bool:

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1829,11 +1829,15 @@ class Converter:
             return {
                 "type": "code_interpreter",
             }
-        elif tool_choice == "shell" and cls._has_shell_tool(tools):
+        elif tool_choice == "shell" and cls._prefers_builtin_tool_selector(
+            tool_choice, ShellTool, tools=tools, handoffs=handoffs
+        ):
             return {
                 "type": "shell",
             }
-        elif tool_choice == "apply_patch" and cls._has_apply_patch_tool(tools):
+        elif tool_choice == "apply_patch" and cls._prefers_builtin_tool_selector(
+            tool_choice, ApplyPatchTool, tools=tools, handoffs=handoffs
+        ):
             return {
                 "type": "apply_patch",
             }
@@ -1950,12 +1954,23 @@ class Converter:
             )
 
     @classmethod
-    def _has_shell_tool(cls, tools: Sequence[Tool] | None) -> bool:
-        return any(isinstance(tool, ShellTool) for tool in tools or ())
-
-    @classmethod
-    def _has_apply_patch_tool(cls, tools: Sequence[Tool] | None) -> bool:
-        return any(isinstance(tool, ApplyPatchTool) for tool in tools or ())
+    def _prefers_builtin_tool_selector(
+        cls,
+        tool_choice: str,
+        builtin_type: type[Any],
+        *,
+        tools: Sequence[Tool] | None,
+        handoffs: Sequence[Handoff[Any, Any]] | None,
+    ) -> bool:
+        """Select a built-in tool only when no callable target claims the same name."""
+        if not any(isinstance(tool, builtin_type) for tool in tools or ()):
+            return False
+        if any(handoff.tool_name == tool_choice for handoff in handoffs or ()):
+            return False
+        return not any(
+            isinstance(tool, FunctionTool | CustomTool) and tool.name == tool_choice
+            for tool in tools or ()
+        )
 
     @classmethod
     def _has_computer_tool(cls, tools: Sequence[Tool] | None) -> bool:

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -2257,30 +2257,44 @@ async def _capture_tool_choice_request(
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
-@pytest.mark.parametrize("target_kind", ["function", "custom"])
 @pytest.mark.parametrize("tool_choice", ["shell", "apply_patch"])
-async def test_builtin_tool_choice_prefers_coexisting_callable_tool(
-    tool_choice: str, target_kind: str
-) -> None:
+async def test_builtin_tool_choice_prefers_coexisting_function_tool(tool_choice: str) -> None:
     builtin_tool = _builtin_tool_choice_tool(tool_choice)
-    callable_target: Tool = (
-        function_tool(lambda: "ok", name_override=tool_choice)
-        if target_kind == "function"
-        else CustomTool(
-            name=tool_choice,
-            description="A callable target sharing the built-in name.",
-            on_invoke_tool=cast(Any, lambda *args, **kwargs: "ok"),
-        )
-    )
+    function_target = function_tool(lambda: "ok", name_override=tool_choice)
 
     called_kwargs = await _capture_tool_choice_request(
         tool_choice=tool_choice,
-        tools=[builtin_tool, callable_target],
+        tools=[builtin_tool, function_target],
         handoffs=[],
     )
 
     assert called_kwargs["tool_choice"] == {"type": "function", "name": tool_choice}
-    assert tool_choice in [dict(tool).get("type") for tool in called_kwargs["tools"]]
+    assert ("function", tool_choice) in [
+        (dict(tool).get("type"), dict(tool).get("name")) for tool in called_kwargs["tools"]
+    ]
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_choice", ["shell", "apply_patch"])
+async def test_builtin_tool_choice_ignores_coexisting_custom_tool(tool_choice: str) -> None:
+    builtin_tool = _builtin_tool_choice_tool(tool_choice)
+    custom_target = CustomTool(
+        name=tool_choice,
+        description="A custom tool sharing the built-in name.",
+        on_invoke_tool=cast(Any, lambda *args, **kwargs: "ok"),
+    )
+
+    called_kwargs = await _capture_tool_choice_request(
+        tool_choice=tool_choice,
+        tools=[builtin_tool, custom_target],
+        handoffs=[],
+    )
+
+    sent = [(dict(tool).get("type"), dict(tool).get("name")) for tool in called_kwargs["tools"]]
+    assert ("custom", tool_choice) in sent
+    assert not any(entry == ("function", tool_choice) for entry in sent)
+    assert called_kwargs["tool_choice"] == {"type": tool_choice}
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -20,13 +20,16 @@ from openai.types.shared.reasoning import Reasoning
 
 from agents import (
     Agent,
+    ApplyPatchTool,
     AsyncComputer,
     Computer,
     ComputerTool,
+    CustomTool,
     ImageGenerationTool,
     ModelSettings,
     ModelTracing,
     Runner,
+    ShellTool,
     Tool,
     ToolSearchTool,
     WebSearchTool,
@@ -2210,6 +2213,110 @@ async def test_preview_model_forced_computer_tool_choice_uses_preview_selector(
             "display_height": 600,
         }
     ]
+
+
+def _builtin_tool_choice_tool(tool_choice: str) -> Tool:
+    if tool_choice == "shell":
+        return ShellTool(executor=lambda request: "ok")
+    return ApplyPatchTool(editor=cast(Any, object()))
+
+
+async def _capture_tool_choice_request(
+    *,
+    tool_choice: str,
+    tools: list[Tool],
+    handoffs: list[Any],
+) -> dict[str, Any]:
+    called_kwargs: dict[str, Any] = {}
+
+    class DummyResponses:
+        async def create(self, **kwargs):
+            nonlocal called_kwargs
+            called_kwargs = kwargs
+            return get_response_obj([])
+
+    class DummyResponsesClient:
+        def __init__(self):
+            self.responses = DummyResponses()
+
+    model = OpenAIResponsesModel(
+        model="gpt-5.4",
+        openai_client=cast(Any, DummyResponsesClient()),
+    )
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(tool_choice=tool_choice),
+        tools=tools,
+        output_schema=None,
+        handoffs=handoffs,
+        tracing=ModelTracing.DISABLED,
+    )
+    return called_kwargs
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_kind", ["function", "custom"])
+@pytest.mark.parametrize("tool_choice", ["shell", "apply_patch"])
+async def test_builtin_tool_choice_prefers_coexisting_callable_tool(
+    tool_choice: str, target_kind: str
+) -> None:
+    builtin_tool = _builtin_tool_choice_tool(tool_choice)
+    callable_target: Tool = (
+        function_tool(lambda: "ok", name_override=tool_choice)
+        if target_kind == "function"
+        else CustomTool(
+            name=tool_choice,
+            description="A callable target sharing the built-in name.",
+            on_invoke_tool=cast(Any, lambda *args, **kwargs: "ok"),
+        )
+    )
+
+    called_kwargs = await _capture_tool_choice_request(
+        tool_choice=tool_choice,
+        tools=[builtin_tool, callable_target],
+        handoffs=[],
+    )
+
+    assert called_kwargs["tool_choice"] == {"type": "function", "name": tool_choice}
+    assert tool_choice in [dict(tool).get("type") for tool in called_kwargs["tools"]]
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_choice", ["shell", "apply_patch"])
+async def test_builtin_tool_choice_prefers_coexisting_handoff(tool_choice: str) -> None:
+    builtin_tool = _builtin_tool_choice_tool(tool_choice)
+    handoff_target = handoff(Agent(name="Target"), tool_name_override=tool_choice)
+
+    called_kwargs = await _capture_tool_choice_request(
+        tool_choice=tool_choice,
+        tools=[builtin_tool],
+        handoffs=[handoff_target],
+    )
+
+    assert called_kwargs["tool_choice"] == {"type": "function", "name": tool_choice}
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_choice", ["shell", "apply_patch"])
+async def test_builtin_tool_choice_selects_builtin_among_multiple_tools(tool_choice: str) -> None:
+    builtin_tool = _builtin_tool_choice_tool(tool_choice)
+    other_tools = [
+        function_tool(lambda: "ok", name_override="lookup_account"),
+        function_tool(lambda: "ok", name_override="summarize"),
+    ]
+
+    called_kwargs = await _capture_tool_choice_request(
+        tool_choice=tool_choice,
+        tools=[other_tools[0], builtin_tool, other_tools[1]],
+        handoffs=[handoff(Agent(name="Target"))],
+    )
+
+    assert called_kwargs["tool_choice"] == {"type": tool_choice}
+    assert tool_choice in [dict(tool).get("type") for tool in called_kwargs["tools"]]
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_responses_converter.py
+++ b/tests/models/test_openai_responses_converter.py
@@ -34,6 +34,7 @@ import agents
 from agents import (
     Agent,
     AgentOutputSchema,
+    ApplyPatchTool,
     Computer,
     ComputerTool,
     FileSearchTool,
@@ -166,6 +167,30 @@ def test_convert_tool_choice_allows_function_named_computer_without_computer_too
     assert Converter.convert_tool_choice("computer_use", tools=[computer_use_function]) == {
         "type": "function",
         "name": "computer_use",
+    }
+
+
+def test_convert_tool_choice_builtin_shell_and_apply_patch() -> None:
+    shell_tool = ShellTool(executor=lambda request: "ok")
+    apply_patch_tool = ApplyPatchTool(editor=cast(Any, object()))
+
+    assert Converter.convert_tool_choice("shell", tools=[shell_tool]) == {"type": "shell"}
+    assert Converter.convert_tool_choice("apply_patch", tools=[apply_patch_tool]) == {
+        "type": "apply_patch"
+    }
+
+
+def test_convert_tool_choice_allows_function_named_shell_without_builtin_tool() -> None:
+    shell_function = function_tool(lambda: "ok", name_override="shell")
+    apply_patch_function = function_tool(lambda: "ok", name_override="apply_patch")
+
+    assert Converter.convert_tool_choice("shell", tools=[shell_function]) == {
+        "type": "function",
+        "name": "shell",
+    }
+    assert Converter.convert_tool_choice("apply_patch", tools=[apply_patch_function]) == {
+        "type": "function",
+        "name": "apply_patch",
     }
 
 


### PR DESCRIPTION
### Summary

This pull request fixes `tool_choice="shell"` and `tool_choice="apply_patch"` selecting a function tool the request never defines.

An agent configured with `ShellTool` or `ApplyPatchTool` sends the tool as `{"type": "shell"}` or `{"type": "apply_patch"}`. Setting `tool_choice` to the matching string falls through to the named-function branch, so the same request also carries `{"type": "function", "name": "shell"}` while no function tool by that name is present in it. The Responses API defines `ToolChoiceShellParam` and `ToolChoiceApplyPatchParam` for these tools and `ModelSettings.tool_choice` accepts the strings, but neither selector is reachable today: `required` cannot target one specific tool when others are configured, and passing the selector dict directly raises `TypeError`.

Both strings now map to their own selector when the matching built-in tool is configured. Gating on tool presence follows `ComputerTool`, where the built-in selector applies only when that tool is present and the string otherwise stays an ordinary function name; without the gate a function tool named `shell` or `apply_patch` would silently stop being targetable. `LocalShellTool` is deliberately unchanged, since the Responses API defines no `local_shell` selector.

### Test plan

- `test_convert_tool_choice_builtin_shell_and_apply_patch` asserts each string maps to its own selector when the matching tool is configured. It fails on `main`, which returns the named-function form.
- `test_convert_tool_choice_allows_function_named_shell_without_builtin_tool` pins that a function tool of either name still resolves to the named-function form, mirroring the existing `ComputerTool` test.
- `make format`, `make lint`, `make typecheck` and `uv run mypy --platform win32 src` are clean.
- `.agents/skills/code-change-verification/scripts/run.sh` does not complete in my environment: 14 tests in `tests/test_code_change_verification_runner.py` fail with `Timed out waiting for a controlled process transition`. They reproduce identically on unmodified `main` here and are unrelated to this change. Excluding that file, the suite reports 9671 passed, 32 skipped.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
