### PR TITLE
test: cover config coercion, custom-data, and provider cleanup lifecycle paths

### DIFF
--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2142,6 +2142,42 @@ class _RevokedReasoningIdModel(ScriptedModel):
 
 
 @pytest.mark.asyncio
+async def test_session_settings_dictionary_merge_overrides_runner_session_limit() -> None:
+    """A `SessionSettings` dictionary passed to `Runner.run` overlays the per-session
+    default instead of silently replacing it: fields the dictionary omits keep the
+    session's configured value, and omitted fields do not reset the base to None.
+    """
+    session = SQLiteSession("session-settings-merge", ":memory:")
+    await session.add_items(
+        [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "second answer"},
+        ]
+    )
+    session.session_settings = SessionSettings(limit=1)
+    model = ScriptedModel()
+    model.extend([[get_text_message("done")]])
+
+    result = await Runner.run(
+        Agent(name="test", model=model),
+        "third",
+        session=session,
+        run_config=RunConfig(session_settings={}),
+    )
+
+    assert result.final_output is not None
+    last_call = model.last_call
+    assert last_call is not None
+    replayed = [item for item in last_call.input if isinstance(item, dict)]
+    assert replayed == [
+        {"role": "assistant", "content": "second answer"},
+        {"role": "user", "content": "third"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_omit_policy_strips_reasoning_ids_already_stored_in_the_session() -> None:
     """Adopting `omit` must also cover reasoning IDs a session recorded before it was set.
 

--- a/tests/test_httpx_compat.py
+++ b/tests/test_httpx_compat.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agents._httpx_compat import (
+    _load_legacy_httpx,
+    is_legacy_httpx_instance,
+    legacy_httpx_types,
+    require_legacy_httpx,
+)
+
+
+def test_is_legacy_httpx_instance_is_false_before_httpx_import() -> None:
+    import sys
+
+    with patch.dict(sys.modules):
+        sys.modules.pop("httpx", None)
+        assert is_legacy_httpx_instance(object(), "Client") is False
+        assert "httpx" not in sys.modules
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (ModuleNotFoundError("No module named 'httpx'", name="httpx"), None),
+        (ModuleNotFoundError("No module named 'other'", name="other"), "other"),
+        (ImportError("httpx is broken"), "httpx is broken"),
+    ],
+    ids=["httpx-missing", "other-module-missing", "httpx-import-broken"],
+)
+def test_load_legacy_httpx_degrades_only_for_missing_httpx(
+    error: Exception, expected: str | None
+) -> None:
+    _load_legacy_httpx.cache_clear()
+    try:
+        if expected is None:
+            with patch("agents._httpx_compat.import_module", side_effect=error):
+                assert _load_legacy_httpx() is None
+            assert legacy_httpx_types("Client") == ()
+        else:
+            with (
+                patch("agents._httpx_compat.import_module", side_effect=error),
+                pytest.raises(Exception, match=expected),
+            ):
+                _load_legacy_httpx()
+    finally:
+        _load_legacy_httpx.cache_clear()
+
+
+def test_require_legacy_httpx_raises_when_httpx_is_missing() -> None:
+    _load_legacy_httpx.cache_clear()
+    try:
+        with patch(
+            "agents._httpx_compat.import_module",
+            side_effect=ModuleNotFoundError("No module named 'httpx'", name="httpx"),
+        ):
+            with pytest.raises(
+                ImportError, match="installed integration requires the legacy httpx"
+            ):
+                require_legacy_httpx()
+    finally:
+        _load_legacy_httpx.cache_clear()
+
+
+def test_require_legacy_httpx_returns_httpx_module() -> None:
+    _load_legacy_httpx.cache_clear()
+    try:
+        httpx = require_legacy_httpx()
+        assert httpx.__name__ == "httpx"
+        client_types = legacy_httpx_types("Client")
+        assert len(client_types) == 1
+        assert client_types[0].__name__ == "Client"
+        assert is_legacy_httpx_instance(httpx.Client(), "Client") is True
+        assert is_legacy_httpx_instance(object(), "Client") is False
+    finally:
+        _load_legacy_httpx.cache_clear()

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -20,6 +20,7 @@ from agents.models.interface import Model, ModelProvider
 from agents.run import __all__ as run_exports
 from agents.run_config import SandboxConcurrencyLimits, SandboxRunConfig
 from agents.sandbox.manifest import Manifest
+from agents.sandbox.sandboxes import UnixLocalSandboxClient
 from agents.sandbox.snapshot import NoopSnapshotSpec
 from agents.testing import ScriptedModel
 
@@ -170,6 +171,10 @@ def test_run_config_accepts_serialized_manifest_without_path_grants(
             {"tool_execution": {"max_function_tool_concurrenc": 2}},
             "Unknown run_config.tool_execution settings: max_function_tool_concurrenc",
         ),
+        (
+            {"sandbox": {"manifest_path": "/tmp/manifest.json"}},
+            "Unknown run_config.sandbox settings: manifest_path",
+        ),
     ],
 )
 def test_run_config_rejects_unknown_first_party_dictionary_fields(
@@ -177,6 +182,44 @@ def test_run_config_rejects_unknown_first_party_dictionary_fields(
 ) -> None:
     with pytest.raises(TypeError, match=message):
         RunConfig(**settings)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("settings", "message"),
+    [
+        (
+            {"model_settings": "hot"},
+            "model_settings must be a ModelSettings instance or a dict, got str",
+        ),
+        (
+            {"sandbox": "docker"},
+            "run_config.sandbox must be a SandboxRunConfig instance or a dict, got str",
+        ),
+    ],
+)
+def test_run_config_rejects_non_dictionary_typed_settings(
+    settings: dict[str, object], message: str
+) -> None:
+    with pytest.raises(TypeError, match=message):
+        RunConfig(**settings)  # type: ignore[arg-type]
+
+
+def test_run_config_rejects_unknown_sandbox_options_settings() -> None:
+    client = UnixLocalSandboxClient()
+
+    with pytest.raises(TypeError, match="Unknown sandbox.options settings: nope"):
+        RunConfig(sandbox={"client": client, "options": {"nope": 1}})  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_runner_rejects_non_dictionary_run_config() -> None:
+    model = ScriptedModel(steps=[[get_text_message("done")]])
+    agent = Agent(name="test", model=model)
+
+    with pytest.raises(
+        TypeError, match="run_config must be a RunConfig instance or a dict, got int"
+    ):
+        await Runner.run(agent, "hello", run_config=42)  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/test_runner_model_provider_lifecycle.py
+++ b/tests/test_runner_model_provider_lifecycle.py
@@ -270,6 +270,72 @@ async def test_run_streamed_cancel_before_start_propagates_through_cleanup_wrapp
     assert sandbox_cleanup_completed.is_set()
 
 
+@pytest.mark.asyncio
+async def test_run_cancellation_waits_for_provider_cleanup_then_reraises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A blocking Model double is used instead of ScriptedModel because this test needs
+    # a run suspended at a controlled await point so cancellation can be delivered once
+    # before and once during provider cleanup, which scripted steps cannot express.
+    model_started = asyncio.Event()
+    blocked = asyncio.Event()
+    close_started = asyncio.Event()
+    close_release = asyncio.Event()
+    close_completed = asyncio.Event()
+
+    class BlockingModel(Model):
+        async def get_response(
+            self,
+            system_instructions: Any,
+            input: Any,
+            model_settings: Any,
+            tools: Any,
+            output_schema: Any,
+            handoffs: Any,
+            tracing: Any,
+            *,
+            previous_response_id: Any,
+            conversation_id: Any,
+            prompt: Any,
+        ) -> Any:
+            model_started.set()
+            await blocked.wait()
+            raise AssertionError("unreachable: the run is cancelled while blocked")
+
+        async def stream_response(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+            raise AssertionError("streaming is not exercised by this test")
+            yield
+
+    async def slow_close(_provider: MultiProvider) -> None:
+        close_started.set()
+        await close_release.wait()
+        close_completed.set()
+
+    monkeypatch.setattr(MultiProvider, "aclose", slow_close)
+    agent = Agent(name="test", model=BlockingModel())
+    run_task = asyncio.create_task(Runner.run(agent, "hello"))
+    try:
+        await asyncio.wait_for(model_started.wait(), timeout=1)
+
+        run_task.cancel()
+        await asyncio.wait_for(close_started.wait(), timeout=1)
+        for _ in range(2):
+            run_task.cancel()
+            await asyncio.sleep(0)
+
+        close_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await run_task
+    finally:
+        blocked.set()
+        close_release.set()
+        if not run_task.done():
+            run_task.cancel()
+        await asyncio.gather(run_task, return_exceptions=True)
+
+    assert close_completed.is_set()
+
+
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 async def test_run_streamed_closes_implicit_responses_websocket_connection() -> None:

--- a/tests/test_tool_custom_data.py
+++ b/tests/test_tool_custom_data.py
@@ -111,6 +111,77 @@ async def test_function_tool_custom_data_rejects_non_finite_floats(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("bad_extractor", "message"),
+    [
+        (lambda _ctx: "not a mapping", "custom_data_extractor must return a mapping or None"),
+        (
+            lambda _ctx: {42: "value"},
+            "custom_data_extractor must return a mapping with string keys",
+        ),
+    ],
+)
+async def test_function_tool_custom_data_rejects_invalid_extractor_results(
+    bad_extractor: Any, message: str
+) -> None:
+    @function_tool(custom_data_extractor=bad_extractor)
+    def get_data() -> str:
+        return "tool_result"
+
+    model = ScriptedModel()
+    model.extend([[get_text_message("call tool"), get_function_tool_call("get_data", "{}")]])
+    agent = Agent(name="test", model=model, tools=[get_data])
+
+    with pytest.raises(UserError, match=message):
+        await Runner.run(agent, input="user")
+
+
+@pytest.mark.asyncio
+async def test_function_tool_custom_data_empty_mapping_normalizes_to_none() -> None:
+    @function_tool(custom_data_extractor=lambda _ctx: {})
+    def get_data() -> str:
+        return "tool_result"
+
+    model = ScriptedModel()
+    model.extend(
+        [
+            [get_text_message("call tool"), get_function_tool_call("get_data", "{}")],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="test", model=model, tools=[get_data])
+
+    result = await Runner.run(agent, input="user")
+
+    tool_output = _tool_output_items(result.new_items)[0]
+    assert tool_output.custom_data is None
+
+
+@pytest.mark.asyncio
+async def test_function_tool_custom_data_awaits_async_extractor() -> None:
+    async def extract_custom_data(_ctx: Any) -> dict[str, Any]:
+        return {"source": "async"}
+
+    @function_tool(custom_data_extractor=extract_custom_data)
+    def get_data() -> str:
+        return "tool_result"
+
+    model = ScriptedModel()
+    model.extend(
+        [
+            [get_text_message("call tool"), get_function_tool_call("get_data", "{}")],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(name="test", model=model, tools=[get_data])
+
+    result = await Runner.run(agent, input="user")
+
+    tool_output = _tool_output_items(result.new_items)[0]
+    assert tool_output.custom_data == {"source": "async"}
+
+
+@pytest.mark.asyncio
 async def test_mcp_custom_data_extractor_maps_result_meta_to_tool_output_item() -> None:
     def extract_custom_data(ctx: Any) -> dict[str, Any]:
         return {"mcp_response_meta": dict(ctx.result_meta or {})}


### PR DESCRIPTION
### Summary

Adds regression tests for caller-visible error and lifecycle paths in core modules that had no coverage: `src/agents/_config_coercion.py`, `src/agents/util/_custom_data.py`, `src/agents/run_internal/model_provider_lifecycle.py`, and `src/agents/_httpx_compat.py` (85% / 89% / 86% / 71% before; three of the four now at 100%). All tests exercise public boundaries (`RunConfig`, `Runner.run`, `@function_tool`) and use `ScriptedModel` where possible; the provider-cancellation test uses a minimal blocking `Model` double because scripted steps cannot suspend a non-streamed run at a controlled await point, with that boundary documented in the test.

Covered behaviors:

- Unknown and non-dictionary typed settings are rejected with actionable `TypeError` messages across `RunConfig`, `Runner.run`, and sandbox options.
- Custom-data extractor results that are non-mappings or have non-string keys are rejected, empty mappings normalize to `None`, and async extractors are awaited.
- A non-streamed run cancelled twice while the runner-owned model provider close is in flight still completes the close and re-raises `CancelledError`.
- The legacy-httpx compat helpers degrade gracefully when httpx is missing, without importing it as a side effect.
- `SessionSettings` dictionary merge semantics: an empty dictionary passed through `RunConfig(session_settings={})` overlays rather than replaces the session's configured limit.

### Test plan

- `make format`, `make lint`, and `make pyright` pass with the change.
- `make tests-parallel`: 9583 passed, 63 skipped.
- `make tests-serial`: 77 passed, 4 skipped.
- `make coverage`: total coverage stays at 92% while the four target modules reach 100% / 100% / 100% / 89%.
- `make mypy` reports 5 pre-existing errors in `src/agents/sandbox/session/archive_ops.py` and `src/agents/run_internal/run_loop.py`; the same errors reproduce on a clean checkout of `main` with this change stashed, so they are unrelated to this PR.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR