### PR TITLE
fix(sessions): paginate OpenAI conversations session reads

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -100,7 +100,6 @@ class OpenAIConversationsSession(SessionABC):
         else:
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
-                limit=session_limit,
                 order="desc",
             ):
                 # calling model_dump() to make this serializable

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -233,6 +233,32 @@ class TestOpenAIConversationsSessionBasicOperations:
         mock_openai_client.conversations.items.list.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_get_items_limit_is_applied_after_provider_pagination(self, mock_openai_client):
+        """A session limit must not be used as the Conversations API page size."""
+
+        async def conversation_items():
+            for index in range(4, 0, -1):
+                if index == 1:
+                    raise AssertionError("get_items should stop after collecting the limit")
+                item = MagicMock()
+                item.model_dump.return_value = {"id": str(index), "role": "user"}
+                yield item
+
+        mock_openai_client.conversations.items.list = MagicMock(return_value=conversation_items())
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        assert await session.get_items(limit=3) == [
+            {"id": "2", "role": "user"},
+            {"id": "3", "role": "user"},
+            {"id": "4", "role": "user"},
+        ]
+        mock_openai_client.conversations.items.list.assert_called_once_with(
+            conversation_id="test_id", order="desc"
+        )
+
+    @pytest.mark.asyncio
     async def test_add_items_simple(self, mock_openai_client):
         """Test adding items to the conversation."""
         session = OpenAIConversationsSession(


### PR DESCRIPTION
### Summary

`OpenAIConversationsSession.get_items(limit=N)` was forwarding the local session limit as the Conversations API page size. Provider page-size limits could therefore reject otherwise valid session reads before pagination ran. This change lets the existing async iterator own provider pagination, applies the session cutoff locally, and preserves chronological ordering.

### Test plan

- `uv run pytest tests/memory/test_openai_conversations_session.py tests/memory/test_session_limit.py -q` — 56 passed (16 existing asyncio deprecation warnings).
- `uv run ruff check src/agents/memory/openai_conversations_session.py tests/memory/test_openai_conversations_session.py` — passed.
- `git diff --check` — passed.
- Targeted `mypy` and `pyright` checks for the changed runtime file — passed.
- The repository verification wrapper completed formatting and linting, then stopped at pre-existing repository-wide type errors in sandbox/voice/optional-extension modules. The full test target also hit unrelated optional-environment and restricted-temp-directory failures; the changed session tests pass independently.

### Issue number

Closes #4757

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
