### PR TITLE
fix(sandbox): keep command paths POSIX on a Windows host

### DIFF
--- a/src/agents/extensions/sandbox/e2b/sandbox.py
+++ b/src/agents/extensions/sandbox/e2b/sandbox.py
@@ -1202,10 +1202,10 @@ class E2BSandboxSession(BaseSandboxSession):
             path = await self._validate_path_access(path, for_write=True)
 
         if user is None and not parents:
-            parent = path.parent
-            test = await self.exec("test", "-d", str(parent), shell=False)
+            parent = sandbox_path_str(path.parent)
+            test = await self.exec("test", "-d", parent, shell=False)
             if not test.ok():
-                raise ExecNonZeroError(test, command=("test", "-d", str(parent)))
+                raise ExecNonZeroError(test, command=("test", "-d", parent))
         await self._ensure_dir(path, reason="mkdir_failed")
 
     async def _collect_pty_output(

--- a/src/agents/sandbox/entries/artifacts.py
+++ b/src/agents/sandbox/entries/artifacts.py
@@ -24,7 +24,7 @@ from ..errors import (
 )
 from ..materialization import MaterializedFile, gather_in_order
 from ..types import ExecResult, User
-from ..workspace_paths import SandboxPathGrant, sandbox_path_grant_host_path
+from ..workspace_paths import SandboxPathGrant, sandbox_path_grant_host_path, sandbox_path_str
 from .base import BaseEntry
 
 if TYPE_CHECKING:
@@ -794,7 +794,7 @@ class GitRepo(BaseEntry):
             # Copy into destination in the container.
             await session.mkdir(dest, parents=True)
             copy = await session.exec(
-                "cp", "-R", "--", f"{git_src_root}/.", f"{dest}/", shell=False
+                "cp", "-R", "--", f"{git_src_root}/.", f"{sandbox_path_str(dest)}/", shell=False
             )
             if not copy.ok():
                 raise GitCopyError(

--- a/src/agents/sandbox/memory/storage.py
+++ b/src/agents/sandbox/memory/storage.py
@@ -11,6 +11,7 @@ from typing import Any
 from ..config import MemoryLayoutConfig
 from ..errors import WorkspaceReadNotFoundError
 from ..session.base_sandbox_session import BaseSandboxSession
+from ..workspace_paths import sandbox_path_str
 
 
 def decode_payload(payload: object) -> str:
@@ -106,7 +107,7 @@ class SandboxMemoryStorage:
 
     async def ensure_text_file(self, path: Path) -> None:
         absolute = self._session.normalize_path(path)
-        exists = await self._session.exec("test", "-f", str(absolute), shell=False)
+        exists = await self._session.exec("test", "-f", sandbox_path_str(absolute), shell=False)
         if exists.ok():
             return
         await self._session.write(path, io.BytesIO(b""))

--- a/tests/extensions/sandbox/test_e2b.py
+++ b/tests/extensions/sandbox/test_e2b.py
@@ -977,6 +977,27 @@ async def test_e2b_mkdir_recreates_workspace_root_when_readiness_is_stale() -> N
 
 
 @pytest.mark.asyncio
+async def test_e2b_mkdir_probes_the_parent_with_a_posix_path() -> None:
+    """The parent probe must stay POSIX so `mkdir` works from a Windows host.
+
+    A Windows host resolves the sandbox path to a native one, so stringifying its parent sent
+    `test -d \\workspace` into the Linux sandbox. That probe always fails, and every `mkdir` without
+    `parents=True` then raised `ExecNonZeroError` even though the parent existed.
+    """
+    session, sandbox = _session(workspace_root_ready=False)
+    sandbox.commands.exec_root_ready = True
+    await session.start()
+
+    await session.mkdir("sub/dir")
+
+    probe_commands = [
+        str(call["command"]) for call in sandbox.commands.calls if "test -d" in str(call["command"])
+    ]
+    assert "test -d /workspace/sub" in probe_commands
+    assert not any("\\" in command for command in probe_commands)
+
+
+@pytest.mark.asyncio
 async def test_e2b_start_installs_runtime_helpers() -> None:
     session, sandbox = _session(workspace_root_ready=False)
 

--- a/tests/sandbox/test_entries.py
+++ b/tests/sandbox/test_entries.py
@@ -5,6 +5,7 @@ import io
 import os
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path, PureWindowsPath
+from typing import cast
 
 import pytest
 
@@ -982,7 +983,29 @@ async def test_git_repo_root_subpath_alias_copies_repo_root(subpath: str) -> Non
     assert copy_call[3].startswith("/tmp/sandbox-git-")
     assert copy_call[3].endswith("/.")
     assert not copy_call[3].endswith("//.")
-    assert copy_call[4].replace("\\", "/") == "/workspace/repo/"
+    assert copy_call[4] == "/workspace/repo/"
+
+
+@pytest.mark.asyncio
+async def test_git_repo_copies_to_a_posix_destination_from_a_windows_host() -> None:
+    """The copy destination must stay POSIX so the clone lands inside the sandbox.
+
+    A Windows host resolves a sandbox destination to a native path, and interpolating that into the
+    argument sends ``\\workspace\\repo/`` to a POSIX container. ``cp`` accepts it, creating a
+    directory with that literal name and leaving the real destination empty, so the misplacement is
+    silent. ``PureWindowsPath`` reproduces the host-native shape on every platform.
+
+    This reuses the file-local recording session rather than ``scripted_sandbox_session`` because
+    the assertion targets one argument inside the clone's fixed multi-command sequence.
+    """
+    session = _RecordingSession()
+    repo = GitRepo(repo="openai/example", ref="main")
+
+    await repo.apply(session, cast(Path, PureWindowsPath("/workspace/repo")), Path("/ignored"))
+
+    copy_call = next(call for call in session.exec_calls if call[:1] == ("cp",))
+    assert copy_call[4] == "/workspace/repo/"
+    assert not any("\\" in argument for argument in copy_call)
 
 
 @pytest.mark.asyncio
@@ -994,7 +1017,7 @@ async def test_git_repo_allows_relative_subpath_copy() -> None:
 
     copy_call = next(call for call in session.exec_calls if call[:1] == ("cp",))
     assert copy_call[3].endswith("/docs/reference/.")
-    assert copy_call[4].replace("\\", "/") == "/workspace/repo/"
+    assert copy_call[4] == "/workspace/repo/"
 
 
 def _git_temp_cleanup_calls(session: _RecordingSession) -> list[tuple[str, ...]]:

--- a/tests/sandbox/test_posix_tool_paths.py
+++ b/tests/sandbox/test_posix_tool_paths.py
@@ -10,6 +10,9 @@ import pytest
 from agents.sandbox import Manifest
 from agents.sandbox.capabilities.tools import ViewImageArgs, ViewImageTool
 from agents.sandbox.capabilities.tools.shell_tool import _resolve_workdir_command
+from agents.sandbox.config import MemoryLayoutConfig
+from agents.sandbox.memory.storage import SandboxMemoryStorage
+from agents.sandbox.types import ExecResult
 from agents.testing import scripted_sandbox_session
 from agents.tool import ToolOutputImage
 
@@ -70,4 +73,33 @@ async def test_view_image_normalizes_backslashes_as_sandbox_separators() -> None
 
     assert isinstance(output, ToolOutputImage)
     assert session.calls[0].args[0].as_posix() == "/workspace/images/plot.png"
+    session.assert_complete()
+
+
+@pytest.mark.asyncio
+async def test_memory_layout_probes_existing_files_with_posix_paths() -> None:
+    """The existence probe must be POSIX so an existing memory file is not replaced.
+
+    A Windows host normalizes the sandbox path to a native one, and stringifying it sends
+    ``test -f \\workspace\\memories\\MEMORY.md`` into a POSIX sandbox. That probe can never
+    succeed, so every layout check overwrites the file with an empty one. ``ensure_layout`` runs on
+    each rollout enqueue and on flush, so the loss repeats.
+    """
+    session = scripted_sandbox_session(
+        [
+            *({"method": "mkdir", "result": None} for _ in range(5)),
+            {"method": "exec", "result": ExecResult(stdout=b"", stderr=b"", exit_code=0)},
+            {"method": "exec", "result": ExecResult(stdout=b"", stderr=b"", exit_code=0)},
+        ],
+        manifest=Manifest(root="/workspace"),
+    )
+    storage = SandboxMemoryStorage(session=session, layout=MemoryLayoutConfig())
+
+    await storage.ensure_layout()
+
+    probes = [call for call in session.calls if call.method == "exec"]
+    assert [call.args[2] for call in probes] == [
+        "/workspace/memories/MEMORY.md",
+        "/workspace/memories/memory_summary.md",
+    ]
     session.assert_complete()


### PR DESCRIPTION
### Summary

Three sandbox commands built an argument with `str()` on a host-native `Path`. On a Windows host that
yields backslashes, and a Linux sandbox reads a backslash as an ordinary filename character rather
than a separator, so each command silently addressed the wrong path.

- `GitRepo.apply` sent `\workspace\repo/` as the `cp` destination. GNU `cp -R -- src/. '\workspace\repo/'`
  exits 0 and creates a directory with that literal name, so the clone was misplaced and the real
  destination stayed empty with no error to surface. I confirmed the exit status and the resulting
  layout against real coreutils 9.4 rather than inferring it.
- `SandboxMemoryStorage.ensure_text_file` probed `test -f \workspace\memories\MEMORY.md`, which can
  never match. `ensure_layout` therefore treated an existing file as absent and overwrote it with an
  empty one. It runs on every rollout enqueue and on flush, so a user's `MEMORY.md` was lost
  repeatedly.
- `E2BSandboxSession.mkdir` probed the parent the same way, so every `mkdir` without `parents=True`
  raised `ExecNonZeroError` even when the parent existed.

Each site now uses `sandbox_path_str`, which `entries/mounts/patterns.py`, `sandboxes/docker.py`,
`runtime.py` and the rest of `e2b/sandbox.py` already apply to sandbox command arguments.
`.agents/references/sandbox-runtime-boundary.md` states the rule these three sites broke.

**Scope.** The change is limited to values that become sandbox command arguments. I swept every
`exec`/`exec_stream` argument in `src/agents/sandbox` and `src/agents/extensions/sandbox` and these
three are the complete set; the remaining callers already normalize, and `util/github.py` correctly
uses `str()` because it runs `git` on the host through `subprocess`.

Two deliberate exclusions, happy to fold either in if you would prefer:

- Sites that only serialize a path for error context or instrumentation (`GitCopyError(dest=...)`,
  `memory/manager.py:189`, `sandboxes/docker.py:520`, `base_sandbox_session.py:795`). These produce
  backslashes in Windows error text but break no command, and including them would widen the rule
  from "command argument" to "command argument or serialized value" without covering every sibling.
- `_prepare_exec_command`, where `str(c)` stringifies a `Path` at the public `exec(*command: str | Path)`
  boundary. Normalizing there fixes none of the three bugs above, because each call site stringifies
  before reaching it, and no first-party caller passes a bare `Path`. It is worth doing as
  defense-in-depth, but as an untested behavior change at a public boundary it does not belong in a
  bug fix.

### Test plan

- `tests/sandbox/test_entries.py`: `test_git_repo_copies_to_a_posix_destination_from_a_windows_host`
  drives `GitRepo.apply` with a `PureWindowsPath` destination and asserts the `cp` argument and that no
  argument contains a backslash. `PureWindowsPath` is flavour-fixed, so this case reproduces the
  host-native shape and fails on every platform, not only Windows. I verified that on Linux directly.
- `tests/sandbox/test_posix_tool_paths.py`: `test_memory_layout_probes_existing_files_with_posix_paths`
  asserts the exact probe arguments `ensure_layout` issues. It lives here rather than in
  `sandbox/test_memory.py` because that file is in the Windows `collect_ignore` list, where the bug is
  the only place it reproduces.
- `tests/extensions/sandbox/test_e2b.py`: `test_e2b_mkdir_probes_the_parent_with_a_posix_path` asserts
  the parent probe. Before the fix the recorded command is `test -d '\workspace\sub'`.
- Reverting only `src/` fails 9 cases: the 3 new ones plus the 6 existing `cp` assertions, which now
  detect the bug on Windows as well.
- Two existing assertions in `test_entries.py` applied `.replace("\\", "/")` to the `cp` destination
  before comparing, which is exactly what hid this bug. They now compare the argument directly.
- All three test files are collected on Windows, so the `tests-windows` job exercises them. The memory
  and E2B cases detect the regression only on that leg, since a native `Path` already stringifies to
  POSIX on Linux; the `GitRepo` case guards every leg.
- `ruff format --check`, `ruff check`, `check_optional_truthiness.py src/agents`, `mypy src` (312 files)
  and `pyright` are clean.
- Parallel suite: 8570 passed, 178 skipped. Serial suite: 77 passed, 4 skipped. The 12 sandbox failures
  are the pre-existing symlink-privilege ones (#4852); I confirmed a pristine tree on this host
  produces the same 12.
- `make` is not installed here, so the `Makefile` targets were run directly in the script's order:
  format, lint, typecheck, then the parallel and serial suites.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
