### PR TITLE
fix(models): treat blank OPENAI_DEFAULT_MODEL as unconfigured

### DIFF
--- a/src/agents/models/default_models.py
+++ b/src/agents/models/default_models.py
@@ -97,10 +97,14 @@ def is_gpt_5_default() -> bool:
 
 
 def get_default_model() -> str:
+    """Return the default model name.
+
+    ``OPENAI_DEFAULT_MODEL`` overrides the built-in default only when it is set to a
+    non-empty value. Blank or whitespace-only values are treated as unconfigured.
     """
-    Returns the default model name.
-    """
-    return os.getenv(OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME, "gpt-5.6-luna").lower()
+    configured = os.getenv(OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME)
+    stripped = configured.strip() if configured is not None else ""
+    return stripped.lower() if stripped else "gpt-5.6-luna"
 
 
 def get_default_model_settings(model: str | None = None) -> ModelSettings:

--- a/tests/models/test_default_models.py
+++ b/tests/models/test_default_models.py
@@ -30,6 +30,30 @@ def test_default_model_is_gpt_5_6_luna():
     assert get_default_model_settings() == _gpt_5_default_settings("none")
 
 
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_get_default_model_treats_blank_env_as_unconfigured(
+    blank: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_DEFAULT_MODEL", blank)
+
+    assert get_default_model() == "gpt-5.6-luna"
+    assert is_gpt_5_default() is True
+    assert get_default_model_settings() == _gpt_5_default_settings("none")
+
+    agent = Agent(name="test")
+    assert agent.model is None
+    assert agent.model_settings == _gpt_5_default_settings("none")
+
+
+def test_get_default_model_strips_whitespace_around_configured_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_DEFAULT_MODEL", "  GPT-4.1  ")
+
+    assert get_default_model() == "gpt-4.1"
+    assert is_gpt_5_default() is False
+
+
 @patch.dict(os.environ, {"OPENAI_DEFAULT_MODEL": "gpt-5.4"})
 def test_is_gpt_5_default_with_real_model_name():
     assert get_default_model() == "gpt-5.4"


### PR DESCRIPTION
### Summary

`get_default_model()` used `os.getenv("OPENAI_DEFAULT_MODEL", "gpt-5.6-luna")`. When the variable is **set but blank or whitespace-only** (common in dotenv / CI), getenv does not fall back. The empty string then:

- becomes the model name sent to Responses / Chat Completions
- makes `is_gpt_5_default()` false
- drops the GPT-5 default `ModelSettings` (`reasoning.effort="none"`, `verbosity="low"`)

Docs say: if you do not set a custom model, you get `gpt-5.6-luna`. Same package already treats blank strings as unset in `_resolve_str`.

### Test plan

- New tests for `""` and `"   "` → `gpt-5.6-luna` and GPT-5 default settings.
- `uv run pytest tests/models/test_default_models.py tests/test_run_config.py -q` → 82 passed.
- `uv run ruff check` / `ruff format --check` on the touched files → passed.

Full `make tests` was not run (large suite). Focused model/default lanes cover this contract.

### Issue number

None. Existing-behavior bug; no `CONTRIBUTING.md`, `AGENTS.md` allows a focused fix + test.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
