### PR TITLE
fix(sessions): do not forward session limit as Conversations page size

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -98,7 +98,7 @@ class OpenAIConversationsSession(SessionABC):
                 # calling model_dump() to make this serializable
                 all_items.append(item.model_dump(exclude_unset=True))
         else:
-            # Omit provider page size. The OpenAI client paginates; apply the session cutoff locally.
+            # Omit provider page size. Apply the session cutoff locally after pagination.
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
                 order="desc",

--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -98,9 +98,9 @@ class OpenAIConversationsSession(SessionABC):
                 # calling model_dump() to make this serializable
                 all_items.append(item.model_dump(exclude_unset=True))
         else:
+            # Omit provider page size. The OpenAI client paginates; apply the session cutoff locally.
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
-                limit=session_limit,
                 order="desc",
             ):
                 # calling model_dump() to make this serializable

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -233,6 +233,41 @@ class TestOpenAIConversationsSessionBasicOperations:
         mock_openai_client.conversations.items.list.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_get_items_applies_large_limit_after_provider_pagination(
+        self, mock_openai_client
+    ):
+        """A session limit must not be forwarded as the Conversations API page size."""
+
+        class ConversationItem:
+            def __init__(self, item_id: int) -> None:
+                self.item_id = item_id
+
+            def model_dump(self, *, exclude_unset: bool) -> dict[str, int]:
+                assert exclude_unset is True
+                return {"item_id": self.item_id}
+
+        yielded_item_ids: list[int] = []
+
+        async def descending_items():
+            # Yield one extra newest-first item so the local cutoff can prove it stops at N.
+            for item_id in range(101, -1, -1):
+                yielded_item_ids.append(item_id)
+                yield ConversationItem(item_id)
+
+        mock_openai_client.conversations.items.list = MagicMock(return_value=descending_items())
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        items = await session.get_items(limit=101)
+
+        assert [cast(dict[str, int], item)["item_id"] for item in items] == list(range(1, 102))
+        assert yielded_item_ids == list(range(101, 0, -1))
+        mock_openai_client.conversations.items.list.assert_called_once_with(
+            conversation_id="test_id", order="desc"
+        )
+
+    @pytest.mark.asyncio
     async def test_add_items_simple(self, mock_openai_client):
         """Test adding items to the conversation."""
         session = OpenAIConversationsSession(


### PR DESCRIPTION
### Summary

This pull request fixes `OpenAIConversationsSession.get_items(limit=N)` forwarding the SDK history cutoff as `conversations.items.list(limit=N)`.

For a large finite session limit that exceeds the Conversations API page-size constraint, an otherwise valid `Session.get_items(limit=N)` call could fail before the OpenAI Python client paginated. Maintainer guidance on #4721 was to omit `limit` from the provider list call, let the client own pagination, and keep the SDK cutoff local.

The finite-history path now requests items in descending order without a provider page-size argument, stops locally once N items are collected, and reverses them into chronological order. Unlimited and zero-limit paths are unchanged.

### Test plan

- Added a regression that requests 101 newest-first items and asserts:
  - `conversations.items.list()` is called without `limit`
  - collection stops after exactly 101 items
  - the returned list is the newest 101 items in chronological order
- `uv run pytest -q tests/memory/test_openai_conversations_session.py tests/memory/test_session_limit.py` — 56 passed
- Independent ordinary review of the complete merge-base diff — clean; no findings
- `.agents/skills/code-change-verification/scripts/run.sh`:
  - `make format` — passed
  - `make lint` — passed
  - `make typecheck` — passed (mypy + pyright, 0 errors)
  - `make tests` — 9611 passed, 29 skipped (parallel); 77 passed, 4 skipped, 55 deselected (serial)

### Issue number

Fixes #4757

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR