### PR TITLE
chore: enable Python Dependabot coverage with release-age cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,45 @@
 version: 2
+# Ordinary updates wait seven days after release, matching uv's exclude-newer.
+# Dependabot security updates bypass this cooldown and the version-update schedule;
+# an administrator must enable security updates in the repository settings.
+# uv's own exclude-newer policy still applies when resolving a security fix.
+# If it blocks an urgent fix, a maintainer must obtain a package-specific exception
+# under CONTRIBUTING.md, recording the advisory, fixed version, owner, mitigation,
+# approval, and expiry. Temporarily add that package to exclude-newer-package in
+# the applicable [tool.uv] / [tool.uv.pip] table using a fixed timestamp just after
+# the approved release. Update only the affected dependency and necessary transitives,
+# review the diff, and run the required checks. Remove the exception and revalidate
+# once the release is seven days old; never disable the global policy for this.
 updates:
+  # The root pyproject.toml and uv.lock cover runtime, extras, and development tools.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+  # These independent requirements files are outside the root lockfile.
+  # Unpinned requirements do not provide a locked transitive dependency inventory.
+  - package-ecosystem: "pip"
+    directories:
+      - "/examples/realtime/twilio"
+      - "/examples/realtime/twilio_sip"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
### Summary

Dependabot currently checks only GitHub Actions. Add weekly updates for the root uv project and both standalone Twilio requirements manifests, with seven-day cooldowns for ordinary Python and Actions updates. Retain the monthly Actions schedule and bound ordinary update PR volume.

Document the administrator security-update toggle and an approved, package-specific uv timestamp exception for urgent fixes. GitHub's security-update cooldown exemption does not disable uv's separate resolver policy. No dependency versions or lockfiles change; unpinned example requirements do not provide a locked transitive inventory.

### Test plan

- Validated YAML against the current Dependabot schema and checked manifest ownership, schedules, cooldowns and security-related options.
- Ran synthetic `uv lock` and `uv pip compile` scenarios: the approved package-specific timestamp admits a fresh fix while another fresh package remains excluded; removal restores the cooldown.
- `git diff --check` passes.
- Two consecutive clean adversarial-review rounds, each with two independent fresh-context reviewers, including security review.
- Full SDK checks are not applicable to this repository-meta-only configuration change. The existing baseline `uv lock --check --offline` fails under local uv 0.12.8; dependency remediation remains separate from this PR.

After merge, an administrator must enable Dependabot security updates, currently disabled, and verify hosted jobs discover all configured manifests and eligible security updates run promptly. This PR does not change repository settings.

### Issue number

None.

### Checks

- [x] Focused configuration and synthetic security-exception checks pass.
- [x] Two clean independent review rounds completed.
- [x] Diff is limited to Dependabot configuration.
- [ ] Post-merge: enable security updates and verify hosted rollout.

<!-- codex-thread: 01a092b5-6bcd-7240-8596-75592e8f7a0a -->
