### PR TITLE
chore: add code ownership and required release review guidance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default ownership includes source, workflows, release/build tooling,
+# dependency manifests and locks, security policy, and this file.
+* @seratch @rm-openai

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -2,6 +2,22 @@
 
 Release tags are created manually by authorized maintainers. Merging a release pull request does not create a tag.
 
+## Required release review
+
+Before merging a release pull request, obtain at least one approving review from a code owner listed in `.github/CODEOWNERS`, resolve review conversations, and wait for all required checks to pass. The author cannot approve their own pull request. Changes after approval require a fresh code-owner review; the most recent reviewable push must also be approved by someone other than its pusher.
+
+CODEOWNERS must be present on the pull request's base branch, and repository settings must enforce the review requirement. For the pull request that first adds CODEOWNERS, request approval from one of the listed maintainers explicitly.
+
+### Administrator setup
+
+For the existing `main` branch protection rule, require a pull request before merging, set required approvals to at least **1**, enable **Require review from Code Owners**, **Dismiss stale pull request approvals when new commits are pushed**, **Require approval of the most recent reviewable push**, and **Require conversation resolution before merging**. Apply these requirements to administrators and roles that can bypass branch protection; any emergency bypass exception requires separate approval and documentation.
+
+Preserve every existing required check and its expected source, force-push and deletion restrictions, release-tag rules, environment deployment filters and reviewers, and trusted-publisher configuration. After CODEOWNERS merges and the settings are applied, verify that GitHub recognizes both owners and blocks an unapproved release pull request. Adding CODEOWNERS alone does not enforce approval.
+
+The shared release policy requires code-owner approval before merging the release pull request; it does not require an additional environment approval gate. This repository's existing `pypi` deployment approval remains part of the publishing procedure below.
+
+## Publish the reviewed release
+
 1. Merge the reviewed release pull request and record its actual merged commit SHA.
 2. As an authorized maintainer, check that commit and its version before creating the tag. Replace the placeholders below:
 


### PR DESCRIPTION
### Summary

Release pull requests currently have no CODEOWNERS coverage. Assign all repository paths to two existing release maintainers, `@seratch` and `@rm-openai`, whose repository admin permissions were verified. This includes source, workflows, build and publishing configuration, the release validator, dependency manifests and locks, security policy, and CODEOWNERS itself.

Document required approving code-owner review before release PR merge and the separate administrator settings needed to enforce it: at least one approval, code-owner review, stale-approval dismissal, latest-push approval, conversation resolution, and administrator enforcement. Preserve all existing required checks, tag protections, and the current PyPI publishing procedure and deployment approval.

**Administrator follow-up:** after CODEOWNERS lands on `main`, apply the documented branch-protection settings and verify GitHub recognizes the owners and blocks unapproved release PRs. This PR does not change remote settings. The initial PR needs explicit maintainer review because CODEOWNERS is read from the base branch.

### Test plan

- Verified both owners have repository admin access and are existing release reviewers.
- Validated the sole wildcard rule covers all 1,591 tracked/new paths, including sensitive release paths.
- `git diff --check` passed.
- `UV_FROZEN=1 make build-docs` passed, with warnings in unchanged reference documentation. The existing lockfile failed `uv sync --locked`; frozen installation succeeded without dependency changes.
- Two consecutive clean adversarial-review rounds with two fresh independent reviewers per round; included focused security, release-approval scenarios, and translation-perspective review.
- The full SDK verification stack and new runtime tests are not applicable to this two-file repository metadata change.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant (not applicable: ownership and guidance only)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (not applicable: no SDK build/test or runtime changes)
- [x] I've confirmed all applicable verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR (two clean independent adversarial rounds)

<!-- codex-thread: 01a092b5-792c-7db3-a889-2dbb5a5db80d -->
