### PR TITLE
ci: add Python and Actions CodeQL security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 6 * * 2'
+
+permissions: {}
+
+jobs:
+  analyze:
+    # Require both job names for analysis execution. Findings need the separate
+    # CodeQL code-scanning rule: Alerts = All, Security alerts = All on main.
+    # A successful analysis job does not mean that no alerts were found.
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
This pull request adds CodeQL security scanning for Python and GitHub Actions on main pushes, main-targeted pull requests, and a weekly schedule. The repository currently has no configured CodeQL security analysis; its separate Code Quality workflow does not establish security coverage.

### Summary

- Add stable `CodeQL (python)` and `CodeQL (actions)` jobs with immutable official action pins, separate result categories, and no-build analysis.
- Limit permissions to repository reads and security-results uploads; disable checkout credential persistence and avoid project installation or build steps.
- Preserve all existing workflows. Record that successful analysis execution does not imply an absence of findings.

### Deployment follow-up

Administrators must preserve existing required checks, require both new language jobs, and activate native CodeQL merge protection on main with **Alerts: All** and **Security alerts: All**. Verify real main/PR/fork/Dependabot/scheduled runs, processed results, initial-alert triage, and effective enforcement after deployment. These settings are not changed by this PR.

Native findings protection covers PR-diff findings and excludes merge groups. No merge queue is introduced.

### Test plan

- actionlint 1.7.12 and pinned action-input validation passed.
- Two consecutive independent adversarial review rounds, two fresh reviewers each; no blocking findings.
- Repository verification passed: formatting, linting, mypy, pyright, and 9,660 tests; 60 skipped.
- Nested native-macOS sandbox coverage remains with trusted GitHub-hosted CI, as prescribed by the repository's Codex verification mode.
- Final content matches the reviewed and verified state.

<!-- codex-thread: 01a092b5-5759-7522-9da5-90ed445962e4 -->
