### PR TITLE
fix: honor zero history limits in the FileSession example

### DIFF
--- a/examples/memory/file_session.py
+++ b/examples/memory/file_session.py
@@ -47,7 +47,7 @@ class FileSession(Session):
         session_id = await self._ensure_session_id()
         items = await self._read_items(session_id)
         if limit is not None and limit >= 0:
-            return items[-limit:]
+            return items[-limit:] if limit > 0 else []
         return items
 
     async def add_items(self, items: list[Any]) -> None:

--- a/tests/memory/test_file_session.py
+++ b/tests/memory/test_file_session.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+from examples.memory.file_session import FileSession
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "limit, expected_contents",
+    [
+        pytest.param(0, [], id="zero"),
+        pytest.param(1, ["third"], id="one"),
+        pytest.param(2, ["second", "third"], id="latest-in-order"),
+        pytest.param(5, ["first", "second", "third"], id="larger-than-history"),
+        pytest.param(None, ["first", "second", "third"], id="unlimited"),
+    ],
+)
+async def test_get_items_respects_limit_without_changing_stored_history(
+    tmp_path: Path, limit: int | None, expected_contents: list[str]
+) -> None:
+    session = FileSession(dir=tmp_path, session_id="history")
+    items = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "third"},
+    ]
+    await session.add_items(items)
+
+    resumed = FileSession(dir=tmp_path, session_id="history")
+    retrieved = await resumed.get_items(limit=limit)
+
+    assert [item["content"] for item in retrieved] == expected_contents
+    assert await resumed.get_items() == items


### PR DESCRIPTION
### Summary

`FileSession.get_items(limit=0)` returns all saved messages instead of an empty list. The cause is `items[-limit:]`: when the limit is zero, Python treats it as `items[0:]`.

Return an empty list for zero. Positive limits still return the most recent messages in their original order. The saved history stays intact.

happy to discuss this fix!
### Test plan

- Add five cases for `0`, `1`, `2`, `5`, and `None`. Each test opens a saved session, checks the result, and confirms that the full history is still intact.
- The zero-limit case fails before the fix. All 20 focused tests pass after it.
- Format, lint, and type checks passed in the prior verification run.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

A separate Codex agent reviewed the diff. The `/review` command was not run.
