### PR TITLE
fix: preserve exact IDs in AdvancedSQLiteSession.delete_branch

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -1140,8 +1140,6 @@ class AdvancedSQLiteSession(SQLiteSession):
         if not branch_id or not branch_id.strip():
             raise ValueError("Branch ID cannot be empty")
 
-        branch_id = branch_id.strip()
-
         # Protect main branch
         if branch_id == "main":
             raise ValueError("Cannot delete the 'main' branch")

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1955,6 +1955,45 @@ async def test_branch_error_handling():
     session.close()
 
 
+@pytest.mark.parametrize("force", [False, True])
+async def test_delete_branch_preserves_exact_branch_id(force: bool):
+    """Deleting a returned branch ID must leave a distinct whitespace-free ID intact."""
+    session = AdvancedSQLiteSession(session_id="exact_branch_deletion", create_tables=True)
+    main_items: list[TResponseInputItem] = [
+        {"role": "user", "content": "First question"},
+        {"role": "assistant", "content": "First answer"},
+        {"role": "user", "content": "Second question"},
+    ]
+    survivor_items: list[TResponseInputItem] = [
+        {"role": "user", "content": "Keep this branch's history"},
+    ]
+    target_items: list[TResponseInputItem] = [
+        {"role": "user", "content": "Delete this branch's history"},
+    ]
+
+    try:
+        await session.add_items(main_items)
+        await session.create_branch_from_turn(2, "draft")
+        await session.add_items(survivor_items)
+        await session.switch_to_branch("main")
+        target_id = await session.create_branch_from_turn(2, " draft ")
+        await session.add_items(target_items)
+        if not force:
+            await session.switch_to_branch("main")
+
+        await session.delete_branch(target_id, force=force)
+
+        assert await session.get_items(branch_id="draft") == main_items[:2] + survivor_items
+        assert await session.get_items(branch_id=target_id) == []
+        assert await session.get_items() == main_items
+        assert {branch["branch_id"] for branch in await session.list_branches()} == {
+            "main",
+            "draft",
+        }
+    finally:
+        session.close()
+
+
 async def test_branch_deletion_with_force():
     """Test branch deletion with force parameter."""
     session_id = "force_delete_test"


### PR DESCRIPTION
### Summary

This pull request fixes deletion of the wrong branch in `AdvancedSQLiteSession`.

Branch creation treats `"draft"` and `" draft "` as distinct IDs. However, `delete_branch()` stripped spaces from the ID, so a request to delete `" draft "` could delete `"draft"` instead.

Keep the exact ID after the blank-input check. Add two regression cases for normal deletion and forced deletion of the active branch. Both check that the main branch and the other branch retain their histories.

### Test plan

- All 131 tests in `test_advanced_sqlite_session.py` pass. Both new cases fail against the base implementation.
- Format, lint, mypy, and pyright checks pass.
- Full verification: 9,574 passed, 56 skipped, 11 failed. All failures are local test-server binds denied by the sandbox, outside the changed code. Full verification remains incomplete.
- A separate `make tests-serial` run passed: 77 passed, 4 skipped.
- `codex review` found no actionable issues in the commit.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR

AI tools assisted with the code, tests, and review.
