### PR TITLE
fix(extensions): keep SQLite usage capture off the event loop

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -72,6 +72,11 @@ class AdvancedSQLiteSession(SQLiteSession):
             logger: The logger to use. Defaults to the module logger
             **kwargs: Additional keyword arguments to pass to the superclass
         """  # noqa: E501
+        self._current_branch_id = "main"
+        # Synchronized with durable history during initialization and whenever a
+        # branch pointer is established or a write begins. A mismatch means
+        # another instance cleared the session, so the local pointer resets to main.
+        self._generation = 0
         self._create_structure_tables_on_init = create_tables
         try:
             super().__init__(
@@ -86,11 +91,6 @@ class AdvancedSQLiteSession(SQLiteSession):
             except BaseException:
                 pass
             raise
-        self._current_branch_id = "main"
-        # Synchronized with the durable session_clear_generations row whenever a
-        # branch pointer is established or a write begins. A mismatch means
-        # another instance cleared the session, so the local pointer resets to main.
-        self._generation = 0
         self._logger = logger if logger is not None else logging.getLogger(__name__)
 
     def _init_db_for_connection(self, conn: sqlite3.Connection) -> None:
@@ -103,6 +103,7 @@ class AdvancedSQLiteSession(SQLiteSession):
             self._claim_structure_tables(conn)
             self._create_schema_for_connection(conn)
         conn.commit()
+        self._refresh_branch_after_external_clear(conn, initialize=False)
 
     def _commit_branch_pointer(self, branch_id: str, generation: int) -> bool:
         """Set the current-branch pointer unless a clear has committed meanwhile.
@@ -634,16 +635,24 @@ class AdvancedSQLiteSession(SQLiteSession):
                 # write is skipped. The anchor is scoped to this branch/turn, so
                 # unrelated removals (e.g. delete_branch on another branch) do
                 # not drop this write.
-                current_turn, branch_id, turn_anchor = await asyncio.to_thread(
-                    self._capture_current_turn
-                )
-                # Only update turn-level usage - session usage is aggregated on demand
-                await self._update_turn_usage_internal(
-                    current_turn,
-                    result.context_wrapper.usage,
-                    branch_id=branch_id,
-                    turn_anchor=turn_anchor,
-                )
+                branch_id = self._current_branch_id
+                generation = self._generation
+                usage = result.context_wrapper.usage
+
+                async def _store_usage() -> None:
+                    current_turn, captured_branch, turn_anchor = await asyncio.to_thread(
+                        self._capture_current_turn, branch_id, generation
+                    )
+                    # Only update turn-level usage; session usage is aggregated on demand.
+                    await self._update_turn_usage_internal(
+                        current_turn,
+                        usage,
+                        branch_id=captured_branch,
+                        turn_anchor=turn_anchor,
+                    )
+
+                # Capture and write must both settle before caller cancellation propagates.
+                await _await_mutation(_store_usage())
         except Exception as e:
 
             def diagnostic_extra() -> dict[str, object]:
@@ -656,17 +665,20 @@ class AdvancedSQLiteSession(SQLiteSession):
                 diagnostic_extra=diagnostic_extra,
             )
 
-    def _capture_current_turn(self) -> tuple[int, str, int | None]:
+    def _capture_current_turn(self, branch_id: str, generation: int) -> tuple[int, str, int | None]:
         """Return (current_turn, branch_id, turn_anchor) in one locked read.
 
         ``turn_anchor`` is the smallest ``message_structure.id`` of the current
-        turn on the current branch (``None`` if the turn has no rows). Because
+        turn on the captured branch (``None`` if the turn has no rows). Because
         ids are monotonic and never reused, it uniquely identifies this turn
         incarnation, so a later pop+recreate that reuses the numeric turn id
         yields a different anchor.
         """
         with self._locked_connection() as conn:
-            branch_id = self._resolve_read_branch(conn, None)
+            self._refresh_branch_after_external_clear(conn, initialize=False)
+            if self._generation != generation:
+                # A clear invalidates usage belonging to the previous session history.
+                return 0, branch_id, None
             with closing(conn.cursor()) as cursor:
                 cursor.execute(
                     """
@@ -1903,15 +1915,15 @@ class AdvancedSQLiteSession(SQLiteSession):
                 turn reused the same numeric id. Because the check is scoped to
                 this branch/turn, unrelated removals (e.g. delete_branch on
                 another branch) do not drop this write. ``None`` means the branch
-                had no turn when it was read, so there is nothing to attribute
-                the usage to and the write is skipped.
+                had no turn when it was read or a session clear invalidated the
+                pending capture, so the write is skipped.
         """
 
         target_branch = branch_id if branch_id is not None else self._current_branch_id
 
         if turn_anchor is None:
-            # ``_capture_current_turn`` returns no anchor only when the branch has no
-            # turn rows; recording usage would invent a phantom turn 0.
+            # A missing anchor means there is no captured turn or a session clear
+            # invalidated the capture; neither case can safely receive usage.
             self._logger.debug("Skipping usage store: no current turn on branch %r", target_branch)
             return
 

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -634,7 +634,9 @@ class AdvancedSQLiteSession(SQLiteSession):
                 # write is skipped. The anchor is scoped to this branch/turn, so
                 # unrelated removals (e.g. delete_branch on another branch) do
                 # not drop this write.
-                current_turn, branch_id, turn_anchor = self._capture_current_turn()
+                current_turn, branch_id, turn_anchor = await asyncio.to_thread(
+                    self._capture_current_turn
+                )
                 # Only update turn-level usage - session usage is aggregated on demand
                 await self._update_turn_usage_internal(
                     current_turn,

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -3384,6 +3384,113 @@ async def test_store_run_usage_waits_for_database_lock_off_event_loop(
         session.close()
 
 
+@pytest.mark.parametrize("create_tables", [False, True])
+async def test_store_run_usage_after_reopening_cleared_session(
+    tmp_path: Path, usage_data: Usage, create_tables: bool
+):
+    """Reopening existing history must not discard its first usage update."""
+    db_path = tmp_path / "reopened_usage.db"
+    original = AdvancedSQLiteSession(
+        session_id="reopened_usage", db_path=db_path, create_tables=True
+    )
+    items: list[TResponseInputItem] = [{"role": "user", "content": "current turn"}]
+    try:
+        await original.add_items([{"role": "user", "content": "old turn"}])
+        await original.clear_session()
+        await original.add_items(items)
+    finally:
+        original.close()
+
+    reopened = AdvancedSQLiteSession(
+        session_id="reopened_usage", db_path=db_path, create_tables=create_tables
+    )
+    try:
+        # Store before any read can refresh the reopened session's local state.
+        await reopened.store_run_usage(create_mock_run_result(usage_data))
+        recorded_usage = await reopened.get_turn_usage(1)
+        assert isinstance(recorded_usage, dict)
+        assert recorded_usage["total_tokens"] == usage_data.total_tokens
+        assert await reopened.get_items() == items
+    finally:
+        reopened.close()
+
+
+async def test_store_run_usage_cancellation_during_capture_waits_for_commit(usage_data: Usage):
+    """Cancellation during capture must settle the complete usage mutation."""
+    session = AdvancedSQLiteSession(session_id="usage_capture_cancel", create_tables=True)
+    task: asyncio.Task[None] | None = None
+    try:
+        await session.add_items([{"role": "user", "content": "usage turn"}])
+        with _gate_worker("_capture_current_turn") as (started, real_to_thread, release):
+            try:
+                task = asyncio.create_task(
+                    session.store_run_usage(create_mock_run_result(usage_data))
+                )
+                assert await real_to_thread(started.wait, 5)
+                task.cancel("capture-cancel")
+                await asyncio.sleep(0)
+                cancelled_before_release = task.done()
+                release.set()
+                with pytest.raises(asyncio.CancelledError) as exc_info:
+                    await task
+                _assert_cancel_message(exc_info.value, "capture-cancel")
+            finally:
+                release.set()
+                if task is not None:
+                    await asyncio.gather(task, return_exceptions=True)
+
+        recorded_usage = await session.get_turn_usage(1)
+        assert isinstance(recorded_usage, dict)
+        assert recorded_usage["total_tokens"] == usage_data.total_tokens
+        assert not cancelled_before_release
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("operation", ["switch", "clear"])
+async def test_store_run_usage_keeps_target_while_capture_is_waiting(
+    usage_data: Usage, operation: str
+):
+    """Usage must not move to another branch or replacement session history."""
+    session = AdvancedSQLiteSession(session_id=f"usage_capture_{operation}", create_tables=True)
+    task: asyncio.Task[None] | None = None
+    try:
+        await session.add_items([{"role": "user", "content": "main turn"}])
+        if operation == "switch":
+            await session.create_branch_from_turn(1, "branch_a")
+            await session.add_items([{"role": "user", "content": "branch turn"}])
+
+        with _gate_worker("_capture_current_turn") as (started, real_to_thread, release):
+            try:
+                task = asyncio.create_task(
+                    session.store_run_usage(create_mock_run_result(usage_data))
+                )
+                assert await real_to_thread(started.wait, 5)
+                if operation == "switch":
+                    await session.switch_to_branch("main")
+                else:
+                    await session.clear_session()
+                    await session.add_items([{"role": "user", "content": "replacement turn"}])
+                release.set()
+                await task
+            finally:
+                release.set()
+                if task is not None:
+                    await asyncio.gather(task, return_exceptions=True)
+
+        assert await session.get_turn_usage(branch_id="main") == []
+        if operation == "switch":
+            branch_usage = await session.get_turn_usage(branch_id="branch_a")
+            assert isinstance(branch_usage, list)
+            assert len(branch_usage) == 1
+            assert branch_usage[0]["total_tokens"] == usage_data.total_tokens
+            assert await session.get_items() == [{"role": "user", "content": "main turn"}]
+        else:
+            assert await session.get_items() == [{"role": "user", "content": "replacement turn"}]
+    finally:
+        session.close()
+
+
 async def test_stale_store_run_usage_skipped_when_turn_removed_by_pop(usage_data: Usage):
     """A store_run_usage that reads a turn and then races with pop_item removing
     that turn must not reinsert usage for the now-nonexistent turn.

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -3332,6 +3332,58 @@ async def test_clear_before_branch_transaction_prevents_stale_reservation():
         session.close()
 
 
+async def test_store_run_usage_waits_for_database_lock_off_event_loop(
+    tmp_path: Path,
+    usage_data: Usage,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A contended usage read must let the event loop release the database lock."""
+    session = AdvancedSQLiteSession(
+        session_id="responsive_usage",
+        db_path=tmp_path / "responsive_usage.db",
+        create_tables=True,
+    )
+    await session.add_items([{"role": "user", "content": "first turn"}])
+    loop = asyncio.get_running_loop()
+    database_lock = session._lock
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+    event_loop_progress: list[bool] = []
+
+    def hold_database_lock() -> None:
+        with database_lock:
+            lock_held.set()
+            # Bound a broken implementation so the test cannot deadlock its event loop.
+            event_loop_progress.append(release_lock.wait(timeout=2))
+
+    class ObservedLock:
+        # Instrument the existing lock acquisition without replacing SQLite or usage writes.
+        def __enter__(self):
+            loop.call_soon_threadsafe(release_lock.set)
+            return database_lock.__enter__()
+
+        def __exit__(self, *args: Any):
+            return database_lock.__exit__(*args)
+
+    holder = asyncio.create_task(asyncio.to_thread(hold_database_lock))
+    try:
+        assert await asyncio.to_thread(lock_held.wait, 2)
+        with monkeypatch.context() as patcher:
+            patcher.setattr(session, "_lock", ObservedLock())
+            await session.store_run_usage(create_mock_run_result(usage_data))
+        await holder
+
+        assert event_loop_progress == [True]
+        assert await session.get_items() == [{"role": "user", "content": "first turn"}]
+        recorded_usage = await session.get_turn_usage(1)
+        assert isinstance(recorded_usage, dict)
+        assert recorded_usage["total_tokens"] == usage_data.total_tokens
+    finally:
+        release_lock.set()
+        await holder
+        session.close()
+
+
 async def test_stale_store_run_usage_skipped_when_turn_removed_by_pop(usage_data: Usage):
     """A store_run_usage that reads a turn and then races with pop_item removing
     that turn must not reinsert usage for the now-nonexistent turn.


### PR DESCRIPTION
This pull request fixes an event-loop stall in `AdvancedSQLiteSession.store_run_usage()` while preserving branch and turn ownership when session operations overlap.

### Summary

Move SQLite turn capture into a worker and keep capture plus the guarded usage write within the existing cancellation handling, so caller cancellation waits for storage to settle. Order capture with appends and pops on the same session instance: later history changes cannot make an earlier run select a newer or replacement turn. Release that ordering barrier after capture; the existing row-anchor check protects the later write.

Keep each queued append on the branch selected when its call begins, even if a branch switch completes while it waits. Publish branch and clear generation together and capture them as one value, preventing a clear or refresh from combining an old branch with a new generation. Preserve the existing clear/reset behavior and initialize the stored generation when reopening a session.

Public APIs and the database schema are unchanged. Independent instances and processes retain the existing database-lock ordering; this change adds no cross-process call-entry ordering or SQLite read transaction.

### Test plan

- Added controlled regressions for lock contention, capture cancellation, branch switching, clear/replacement, reopening, and later append/pop operations; the relevant cases fail before their fixes.
- Covered queued append targeting on empty and populated branches, coherent clear/refresh publication, queued failure/cancellation, and contention across sequential event loops.
- All 146 AdvancedSQLiteSession tests passed.
- Two independent reviews of the complete final diff passed with no findings.
- The required formatting, lint, Mypy, Pyright, and full test stack passed: 9,659 passed and 78 skipped under the repository test configuration. Native macOS sandbox coverage remains for CI.

### Issue number

No existing issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] I've completed two independent reviews of the final diff
