### PR TITLE
fix(extensions): include shell and apply_patch calls in AdvancedSQLiteSession's tool usage

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -958,6 +958,8 @@ class AdvancedSQLiteSession(SQLiteSession):
                 "file_search_call",
                 "web_search_call",
                 "code_interpreter_call",
+                "shell_call",
+                "apply_patch_call",
                 "tool_search_call",
                 "tool_search_output",
             }:
@@ -1678,12 +1680,17 @@ class AdvancedSQLiteSession(SQLiteSession):
                         """
                         SELECT tool_name, SUM(usage_count), user_turn_number
                         FROM (
-                            SELECT tool_name, 1 AS usage_count, user_turn_number
+                            SELECT COALESCE(
+                                tool_name,
+                                CASE WHEN message_type IN ('shell_call', 'apply_patch_call')
+                                    THEN message_type END
+                            ) AS tool_name, 1 AS usage_count, user_turn_number
                             FROM message_structure
                             WHERE session_id = ? AND branch_id = ? AND message_type IN (
                                 'tool_call', 'function_call', 'computer_call', 'file_search_call',
                                 'web_search_call', 'code_interpreter_call', 'tool_search_call',
-                                'custom_tool_call', 'mcp_call', 'mcp_approval_request'
+                                'custom_tool_call', 'mcp_call', 'mcp_approval_request',
+                                'shell_call', 'apply_patch_call'
                             )
 
                             UNION ALL

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -21,13 +21,14 @@ pytest.importorskip("sqlalchemy")  # Skip tests if SQLAlchemy is not installed
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 import agents._debug as _debug
-from agents import Agent, Runner, TResponseInputItem, function_tool
+from agents import Agent, ApplyPatchTool, Runner, ShellTool, TResponseInputItem, function_tool
 from agents.extensions.memory import AdvancedSQLiteSession
 from agents.result import RunResult
 from agents.run_context import RunContextWrapper
 from agents.testing import ScriptedModel
 from agents.usage import Usage
 from tests.test_responses import get_text_message
+from tests.utils.hitl import RecordingEditor, make_apply_patch_dict, make_shell_call
 
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
@@ -835,6 +836,148 @@ async def test_tool_usage_tracking(agent: Agent):
     assert "calculator" in tool_names
 
     session.close()
+
+
+@pytest.mark.parametrize(
+    "call,output,tool_name",
+    [
+        pytest.param(
+            make_shell_call("shell-1", status="completed"),
+            {
+                "type": "shell_call_output",
+                "call_id": "shell-1",
+                "output": [
+                    {"stdout": "test", "stderr": "", "outcome": {"type": "exit", "exit_code": 0}}
+                ],
+            },
+            "shell_call",
+            id="shell",
+        ),
+        pytest.param(
+            make_apply_patch_dict("patch-1"),
+            {
+                "type": "apply_patch_call_output",
+                "call_id": "patch-1",
+                "status": "completed",
+                "output": "Updated test.md",
+            },
+            "apply_patch_call",
+            id="apply-patch",
+        ),
+    ],
+)
+async def test_tool_usage_tracks_shell_and_patch_calls(
+    call: TResponseInputItem, output: TResponseInputItem, tool_name: str
+) -> None:
+    """Store unnamed built-in calls with names and count calls, not their outputs."""
+    session = AdvancedSQLiteSession(session_id="builtin-tools", create_tables=True)
+    items: list[TResponseInputItem] = [
+        {"role": "user", "content": "Update the file."},
+        call,
+        output,
+    ]
+    try:
+        await session.add_items(items)
+        assert await session.get_items() == items
+        assert await session.get_tool_usage() == [(tool_name, 1, 1)]
+        turns = await session.get_conversation_by_turns()
+        assert turns[1][1]["tool_name"] == tool_name
+    finally:
+        session.close()
+
+
+async def test_tool_usage_reads_legacy_shell_and_patch_names(tmp_path: Path) -> None:
+    """Read old NULL names without rewriting the stored metadata or mixing tools."""
+    db_path = tmp_path / "legacy-tools.db"
+    session = AdvancedSQLiteSession(session_id="legacy-tools", db_path=db_path, create_tables=True)
+    items: list[TResponseInputItem] = [
+        {"role": "user", "content": "Update the file."},
+        cast(TResponseInputItem, make_shell_call("shell-1", status="completed")),
+        cast(TResponseInputItem, make_apply_patch_dict("patch-1")),
+    ]
+    try:
+        await session.add_items(items)
+    finally:
+        session.close()
+
+    # Earlier SDK versions stored these calls with NULL tool names.
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        conn.execute(
+            "UPDATE message_structure SET tool_name = NULL "
+            "WHERE message_type IN ('shell_call', 'apply_patch_call')"
+        )
+        conn.commit()
+
+    reopened = AdvancedSQLiteSession(session_id="legacy-tools", db_path=db_path)
+    try:
+        assert sorted(await reopened.get_tool_usage()) == [
+            ("apply_patch_call", 1, 1),
+            ("shell_call", 1, 1),
+        ]
+        assert await reopened.get_items() == items
+        turns = await reopened.get_conversation_by_turns()
+        assert [item["tool_name"] for item in turns[1][1:]] == [None, None]
+        await reopened.add_items(
+            [
+                cast(TResponseInputItem, make_shell_call("shell-2", status="completed")),
+                cast(TResponseInputItem, make_apply_patch_dict("patch-2")),
+            ]
+        )
+        assert sorted(await reopened.get_tool_usage()) == [
+            ("apply_patch_call", 2, 1),
+            ("shell_call", 2, 1),
+        ]
+    finally:
+        reopened.close()
+
+
+async def test_tool_usage_tracks_runner_shell_and_patch_calls_by_branch() -> None:
+    """Count real Runner-persisted call/output pairs without crossing branches or turns."""
+    model = ScriptedModel(
+        steps=[
+            [make_shell_call("shell-1"), make_apply_patch_dict("patch-1")],
+            [get_text_message("Updated.")],
+            [make_shell_call("shell-2")],
+            [get_text_message("Checked.")],
+        ]
+    )
+    editor = RecordingEditor()
+    shell_executor = Mock(return_value="test")
+    agent = Agent(
+        name="coding",
+        model=model,
+        tools=[ShellTool(executor=shell_executor), ApplyPatchTool(editor=editor)],
+    )
+    session = AdvancedSQLiteSession(session_id="runner-tools", create_tables=True)
+    try:
+        result = await Runner.run(agent, "Update the file.", session=session)
+        assert result.final_output == "Updated."
+        assert shell_executor.call_count == 1
+        assert len(editor.operations) == 1
+        items = await session.get_items()
+        assert {item.get("type") for item in items} >= {
+            "shell_call",
+            "shell_call_output",
+            "apply_patch_call",
+            "apply_patch_call_output",
+        }
+        expected_main = [("apply_patch_call", 1, 1), ("shell_call", 1, 1)]
+        assert sorted(await session.get_tool_usage()) == expected_main
+
+        branch = await session.create_branch_from_turn(1, "alternative")
+        await Runner.run(agent, "Check the file.", session=session)
+        assert await session.get_tool_usage() == [("shell_call", 1, 1)]
+        assert await session.get_tool_usage(branch) == [("shell_call", 1, 1)]
+        await session.add_items(
+            [
+                {"role": "user", "content": "Check again."},
+                cast(TResponseInputItem, make_shell_call("shell-3", status="completed")),
+            ]
+        )
+        assert await session.get_tool_usage() == [("shell_call", 1, 1), ("shell_call", 1, 2)]
+        assert sorted(await session.get_tool_usage("main")) == expected_main
+    finally:
+        session.close()
 
 
 async def test_tool_usage_tracking_preserves_namespaces_and_tool_search(agent: Agent):


### PR DESCRIPTION
### Summary

This pull request fixes missing shell and apply_patch calls in `AdvancedSQLiteSession.get_tool_usage()`.

These calls are already stored in session history but were omitted from tool usage statistics. The change includes both call types and records their derived tool names for new entries.

For existing shell and apply_patch records whose tool name is `NULL`, the usage query derives the corresponding name at read time. Stored rows are not rewritten and no migration is required.

Tool outputs are not counted as additional calls. Existing branch isolation, per-turn grouping, other tool statistics, stored message payloads, and public APIs are unchanged.

### Test plan

- Added four regression cases covering shell and apply_patch usage statistics; all four fail on the unchanged production source because tool usage is empty.
- Covered calls with their outputs, mixed existing and newly written records, and an offline Runner path.
- Windows: 133 AdvancedSQLiteSession tests passed.
- Linux: full verification passed, including formatting, lint, Mypy, Pyright, and 9,691 tests; 33 skipped.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
